### PR TITLE
vllm/qwen3.5: add 4b/9b/27b/35b/122b/397b

### DIFF
--- a/docs/model-deployment/vllm/qwen3.5.md
+++ b/docs/model-deployment/vllm/qwen3.5.md
@@ -6,56 +6,111 @@ Qwen3.5 是 Qwen3 系列的增强版本，在推理能力、代码生成、多�
 
 ## 模型列表
 
-| 模型 | 参数量 | 上下文 | 量化方式 | 推荐硬件 |
-|------|--------|--------|---------|---------|
-| Qwen3.5-4B | 4B | 128K | BF16 | 1x BW1000 64GB |
-| Qwen3.5-7B | 7B | 128K | BF16 | 1x BW1000 64GB |
-| Qwen3.5-14B | 14B | 128K | BF16 | 1x BW1000 64GB |
-| Qwen3.5-32B | 32B | 128K | BF16 | 1x BW1100 144GB / 2x DCU TP |
-| Qwen3.5-72B | 72B | 128K | BF16 | 2x BW1100 144GB TP / 4x BW1000 64GB TP |
+| 模型 | 参数量 | 上下文 | 推荐硬件 |
+|------|--------|--------|---------|
+| Qwen3.5-4B | 4B | 262K | 1x BW1000 64GB |
+| Qwen3.5-9B | 9B | 262K | 1x BW1000 64GB |
+| Qwen3.5-27B | 27B | 262K | 2x BW1000 64GB |
+| Qwen3.5-35B-A3B | 35B | 262K | 2x BW1000 64GB |
+| Qwen3.5-122B-A10B | 122B | 262K | 8x BW1000 64GB |
+| Qwen3.5-122B-A10B-W8A8-INT8 | 122B | 262K | 4x BW1000 64GB |
+| Qwen3.5-397B-A17B-W8A8-INT8 | 397B | 262K | 8x BW1000 64GB|
+
 
 ## 启动命令
-
-### Qwen3.5-4B（单卡）
-
+### 环境变量
 ```bash
 export VLLM_HCU_USE_FLASH_ATTN=1
 export VLLM_HCU_USE_FLASH_ATTN_UNIFIED=1
 export VLLM_HCU_USE_CUSTOM_TOPK_TOPP_SAMPLER=1
-python -m vllm.entrypoints.openai.api_server \
-    --model Qwen/Qwen3.5-4B \
-    --tensor-parallel-size 1 \
+```
+### Qwen3.5-4B
+```bash
+vllm serve Qwen/Qwen3.5-4B \
+    -tp 1 \
     --max-num-batched-tokens 10240 \
-    --gpu-memory-utilization 0.9 \
-    --speculative-config '{"method":"mtp","num_speculative_tokens":3}' \
+    --speculative-config.method mtp \
+    --speculative-config.num_speculative_tokens 3 \
     --trust-remote-code \
     --disable-cascade-attn \
-    --dtype bfloat16
 ```
 
-### Qwen3.5-7B（单卡）
-
+### Qwen3.5-9B
 ```bash
-python -m vllm.entrypoints.openai.api_server \
-    --model Qwen/Qwen3.5-7B \
-    --tensor-parallel-size 1 \
-    --max-model-len 32768 \
-    --gpu-memory-utilization 0.92 \
+vllm serve  Qwen/Qwen3.5-9B \
+    -tp 1 \
+    --max-num-batched-tokens 10240 \
     --trust-remote-code \
-    --dtype bfloat16
+    --disable-cascade-attn \
+    --speculative-config.method mtp \
+    --speculative-config.num_speculative_tokens 3 
 ```
 
-### Qwen3.5-72B（四卡）
 
+### Qwen3.5-27B
 ```bash
-python -m vllm.entrypoints.openai.api_server \
-    --model Qwen/Qwen3.5-72B \
-    --tensor-parallel-size 4 \
-    --max-model-len 8192 \
-    --gpu-memory-utilization 0.92 \
+vllm serve Qwen/Qwen3.5-27B \
+    -tp 2 \
     --trust-remote-code \
-    --dtype bfloat16
+    --disable-cascade-attn \
+    --max-num-batched-tokens 10240 \
+    --speculative-config.method mtp \
+    --speculative-config.num_speculative_tokens 3 
 ```
+
+### Qwen3.5-35B-A3B
+```bash
+vllm serve Qwen/Qwen3.5-35B-A3B \
+    -tp 2 \
+    --trust-remote-code \
+    --disable-cascade-attn \
+    --max-num-batched-tokens 10240 \
+    --speculative-config.method mtp \
+    --speculative-config.num_speculative_tokens 3 
+```
+
+### Qwen3.5-122B-A10B
+```bash
+vllm serve  Qwen/Qwen3.5-122B-A10B \
+    -tp 8 \
+    --trust-remote-code \
+    --disable-cascade-attn \
+    --max-num-batched-tokens 10240 \
+    --speculative-config.method mtp \
+    --speculative-config.num_speculative_tokens 3 
+```
+
+### Qwen3.5-122B-A10B-W8A8-INT8
+```bash
+vllm serve  Qwen/Qwen3.5-122B-A10B-W8A8-INT8 \
+    -tp 4 \
+    --disable-cascade-attn \
+    --max-num-batched-tokens 10240 \
+    --trust-remote-code \
+    --speculative-config.method mtp \
+    --speculative-config.num_speculative_tokens 3 \
+    --speculative-config.quantization "slimquant_marlin"
+```
+### Qwen3.5-397B-A17B-W8A8-INT8
+```bash
+vllm serve  Qwen/Qwen3.5-397B-A17B-W8A8-INT8 \
+    -tp 8 \
+    --disable-cascade-attn \
+    --max-num-batched-tokens 10240 \
+    --trust-remote-code \
+    --no-enable-prefix-caching \
+    --speculative-config.method mtp \
+    --speculative-config.num_speculative_tokens 3 \
+    --speculative-config.quantization "slimquant_marlin"
+```
+
+
+
+
+
+
+
+
 
 ## API 调用
 
@@ -76,8 +131,4 @@ response = client.chat.completions.create(
 print(response.choices[0].message.content)
 ```
 
-## DCU 适配注意
 
-- 与 Qwen3 共享相同的架构，DCU 兼容性一致
-- 72B 模型建议至少 4x BW1000 64GB 或 2x BW1100 144GB
-- 支持思考模式和工具调用，用法同 Qwen3


### PR DESCRIPTION
Add deployment documentation for Qwen3.5 models (4B, 9B, 27B, 35B, 122B, 397B) on vLLM.