### PR TITLE
docs: replace rocm-smi with hy-smi

### DIFF
--- a/docs/model-deployment/sglang/overview.md
+++ b/docs/model-deployment/sglang/overview.md
@@ -86,8 +86,8 @@ result = json.loads(response.text)
 ## 性能监控
 
 ```bash
-rocm-smi
-watch -n 2 rocm-smi
+hy-smi
+watch -n 2 hy-smi
 ```
 
 ## 参考链接

--- a/docs/model-deployment/vllm/overview.md
+++ b/docs/model-deployment/vllm/overview.md
@@ -109,10 +109,10 @@ python -m vllm.entrypoints.openai.api_server \
 
 ```bash
 # 查看 DCU 利用率
-rocm-smi
+hy-smi
 
 # 持续监控
-watch -n 2 rocm-smi
+watch -n 2 hy-smi
 ```
 
 ## 已知限制

--- a/docs/optimization/memory-optimization.md
+++ b/docs/optimization/memory-optimization.md
@@ -129,7 +129,7 @@ pipe.enable_sequential_cpu_offload()
 
 ```bash
 # 实时监控
-watch -n 1 rocm-smi --showmeminfo
+watch -n 1 hy-smi --showmeminfo
 
 # Python 中获取显存信息
 import torch

--- a/docs/troubleshooting/common-issues.md
+++ b/docs/troubleshooting/common-issues.md
@@ -23,7 +23,7 @@
 
 ```bash
 # 1. 检查 DCU 设备是否被识别
-rocm-smi
+hy-smi
 # 或
 hipconfig
 
@@ -68,7 +68,7 @@ export LD_LIBRARY_PATH=/opt/rocm/lib:$LD_LIBRARY_PATH
 # 应使用 bf16，而非 fp32
 
 # 2. 检查 DCU 利用率
-rocm-smi
+hy-smi
 
 # 3. 确认 tensor-parallel 配置合理
 

--- a/docs/troubleshooting/error-codes.md
+++ b/docs/troubleshooting/error-codes.md
@@ -6,7 +6,7 @@
 |--------|------|---------|---------|
 | `hipErrorOutOfMemory` | 显存不足 | 模型/批次过大 | 减小 batch size 或使用量化 |
 | `hipErrorInvalidValue` | 无效参数 | 参数配置错误 | 检查 API 参数 |
-| `hipErrorNoDevice` | 无可用设备 | 驱动问题 | 检查 rocm-smi |
+| `hipErrorNoDevice` | 无可用设备 | 驱动问题 | 检查 hy-smi |
 | `hipErrorPeerAccessUnsupported` | 不支持 P2P | 硬件/拓扑限制 | 检查 DCU 拓扑 |
 
 ## PyTorch 错误


### PR DESCRIPTION
Replace all occurrences of `rocm-smi` with `hy-smi` across docs (5 files, 8 occurrences).