### PR TITLE
docs: reformat sglang/qwen3.5.md to match glm-5 template

### DIFF
--- a/docs/model-deployment/sglang/qwen3.5.md
+++ b/docs/model-deployment/sglang/qwen3.5.md
@@ -6,18 +6,16 @@ Qwen3.5 是 Qwen3 系列的增强版本，在推理能力、代码生成、多�
 
 ## 模型列表
 
-
-| 模型                               | 参数量  | 上下文  | 量化方式             | 推荐硬件                                    |
-| -------------------------------- | ---- | ---- | ---------------- | --------------------------------------- |
-| Qwen3.5-27B                      | 27B  | 128K | 未量化(BF16)        | 2x BW1100 144GB TP                      |
-| Qwen3.5-35B-A3B                  | 35B  | 128K | 未量化(BF16)        | 2x BW1100 144GB TP                      |
-| Qwen3.5-35B-A3B-Channel-FP8-w8a8 | 35B  | 128K | FP8-Channel-wise | 2x BW1100 144GB TP                      |
-| Qwen3.5-397B-A17B                | 397B | 128K | 未量化(BF16)        | 4x BW1100 144GB TP / 8x BW1100 144GB TP |
-
+| 模型权重 | 量化方式 | SGLang 版本 | 推荐硬件 | 卡数 | 部署方式 | 启动命令 |
+| -------- | -------- | ----------- | -------- | ---- | -------- | -------- |
+| [Qwen/Qwen3.5-27B](https://www.modelscope.cn/models/Qwen/Qwen3.5-27B) | BF16 | 0.5.10 | BW1100 | 2 | IFB | [**`>_`**](#qwen35-27b-ifb-bw1100-2x-sglang-0510) |
+| [Qwen/Qwen3.5-35B-A3B](https://www.modelscope.cn/models/Qwen/Qwen3.5-35B-A3B) | BF16 | 0.5.10 | BW1100 | 2 | IFB | [**`>_`**](#qwen35-35b-a3b-ifb-bw1100-2x-sglang-0510) |
+| [hygon/Qwen3.5-35B-A3B-Channel-FP8-w8a8](https://www.modelscope.cn/models/hygon/Qwen3.5-35B-A3B-Channel-FP8-w8a8) | FP8 W8A8 | 0.5.10 | BW1100 | 2 | IFB | [**`>_`**](#qwen35-35b-a3b-channel-fp8-w8a8-ifb-bw1100-2x-sglang-0510) |
+| [Qwen/Qwen3.5-397B-A17B](https://www.modelscope.cn/models/Qwen/Qwen3.5-397B-A17B) | BF16 | 0.5.10 | BW1100 | 4 | IFB | [**`>_`**](#qwen35-397b-a17b-ifb-bw1100-4x-sglang-0510) |
 
 ## 启动命令
 
-### Qwen3.5-27B（2卡）
+### Qwen3.5-27B IFB BW1100 2x SGLang 0.5.10
 
 ```bash
 export SGLANG_ENABLE_SPEC_V2=1
@@ -25,6 +23,8 @@ export SGLANG_USE_FUSED_TOPK_SOFTMAX=1
 export SGLANG_USE_LIGHTOP=1
 export SGLANG_USE_CAUSAL_CONV1D=1
 export SGLANG_USE_AITER_LINEAR_ATTN=1
+export SGLANG_USE_MODELSCOPE=1
+
 sglang serve --model-path Qwen/Qwen3.5-27B \
     --attention-backend fa3 \
     --mm-attention-backend fa3 \
@@ -37,10 +37,10 @@ sglang serve --model-path Qwen/Qwen3.5-27B \
     --mamba-scheduler-strategy extra_buffer \
     --kv-cache-dtype fp8_e4m3  \
     --trust-remote-code \
-    --chunked-prefill-size -1 
+    --chunked-prefill-size -1
 ```
 
-### Qwen3.5-35B-A3B（2卡）
+### Qwen3.5-35B-A3B IFB BW1100 2x SGLang 0.5.10
 
 ```bash
 export SGLANG_ENABLE_SPEC_V2=1
@@ -49,6 +49,8 @@ export SGLANG_USE_LIGHTOP=1
 export SGLANG_USE_CAUSAL_CONV1D=1
 export SGLANG_USE_AITER_LINEAR_ATTN=1
 export SGLANG_USE_CUDA_IPC_TRANSPORT=1
+export SGLANG_USE_MODELSCOPE=1
+
 sglang serve --model-path Qwen/Qwen3.5-35B-A3B \
     --attention-backend fa3 \
     --mm-attention-backend fa3 \
@@ -62,14 +64,12 @@ sglang serve --model-path Qwen/Qwen3.5-35B-A3B \
     --mamba-scheduler-strategy extra_buffer \
     --kv-cache-dtype fp8_e4m3  \
     --trust-remote-code \
-    --chunked-prefill-size -1 
+    --chunked-prefill-size -1
 ```
 
-> NMZ 卡使用 fp8_e4m3，非 NMZ 卡使用 fp8_e5m2，请按照使用硬件情况进行配置。
+> NMZ 卡使用 `fp8_e4m3`，非 NMZ 卡使用 `fp8_e5m2`，请按照使用硬件情况进行配置。
 
-### Qwen3.5-35B-A3B-Channel-FP8-w8a8（2卡）
-
-> 此模型为Channel-wise FP8量化模型。
+### Qwen3.5-35B-A3B-Channel-FP8-w8a8 IFB BW1100 2x SGLang 0.5.10
 
 ```bash
 export SGLANG_USE_LIGHTOP=1
@@ -80,7 +80,8 @@ export SGLANG_USE_CUDA_IPC_TRANSPORT=1
 export SGLANG_USE_AITER_LINEAR_ATTN=1
 export SGLANG_ENABLE_SPEC_V2=1
 export SGLANG_USE_MODELSCOPE=1
-sglang serve --model-path  hygon/Qwen3.5-35B-A3B-Channel-FP8-w8a8 \
+
+sglang serve --model-path hygon/Qwen3.5-35B-A3B-Channel-FP8-w8a8 \
     --attention-backend fa3 \
     --mm-attention-backend fa3 \
     --speculative-algorithm EAGLE \
@@ -96,22 +97,22 @@ sglang serve --model-path  hygon/Qwen3.5-35B-A3B-Channel-FP8-w8a8 \
     --mamba-scheduler-strategy extra_buffer
 ```
 
-### Qwen3.5-397B-A17B（四卡）
+### Qwen3.5-397B-A17B IFB BW1100 4x SGLang 0.5.10
 
 ```bash
 export SGLANG_ENABLE_SPEC_V2=1
 export USE_DCU_CUSTOM_ALLREDUCE=1
 export SGLANG_USE_LIGHTOP=1
-export SGLANG_USE_FP8_W8A8_MOE=1          # FP8模型开启
+export SGLANG_USE_FP8_W8A8_MOE=1
 export SGLANG_USE_FUSED_TOPK_SOFTMAX=1
 export SGLANG_USE_CAUSAL_CONV1D=1
 export SGLANG_KV_LAYOUT_DCU_FA=1
+export SGLANG_USE_MODELSCOPE=1
 
 sglang serve --model-path Qwen/Qwen3.5-397B-A17B \
     --tp-size 4 \
     --trust-remote-code \
     --dtype bfloat16 \
-    --port $port \
     --attention-backend fa3 \
     --page-size 64 \
     --kv-cache-dtype fp8_e4m3 \
@@ -122,13 +123,15 @@ sglang serve --model-path Qwen/Qwen3.5-397B-A17B \
 
 ## API 调用
 
+### IFB
+
 ```python
 from openai import OpenAI
 
 client = OpenAI(base_url="http://localhost:30000/v1", api_key="not-needed")
 
 response = client.chat.completions.create(
-    model="Qwen/Qwen3.5-35B-A3B",
+    model="Qwen/Qwen3.5-35B-A3B",  # 替换为实际使用的模型名
     messages=[
         {"role": "system", "content": "You are a helpful assistant."},
         {"role": "user", "content": "中国的首都是哪里？"},
@@ -138,26 +141,16 @@ response = client.chat.completions.create(
 print(response.choices[0].message.content)
 ```
 
-## curl 调用
-
-```
+```bash
 curl http://localhost:30000/v1/chat/completions \
   -H "Content-Type: application/json" \
   -d '{
     "model": "Qwen/Qwen3.5-35B-A3B",
-    "max_tokens": 2048,
     "messages": [
       {"role": "system", "content": "You are a helpful assistant."},
-      {"role": "user", "content": [
-        {"type": "text", "text": "中国的首都是哪里？"}
-      ]}
-    ]
+      {"role": "user", "content": "中国的首都是哪里？"}
+    ],
+    "max_tokens": 128
   }'
 ```
-
-## DCU 适配注意
-
-- Qwen3.5与 Qwen3 共享相同架构，DCU 兼容性一致
-- 72B 模型建议至少 4x BW1000 64GB 或 2x BW1100 144GB
-- SGLang 结构化生成对代码生成场景特别有用
 


### PR DESCRIPTION
Reformats `sglang/qwen3.5.md` to conform to the standard document structure used in `sglang/glm-5.md`:

- Standard 7-column model table with ModelScope links, SGLang version, card count, deployment mode, and anchor links
- Section titles follow `<MODEL> IFB <HW> <Nx> SGLang 0.5.10` convention
- Added `SGLANG_USE_MODELSCOPE=1` to all sections
- Removed `--port $port` (undefined variable) from 397B command
- Restructured `## API 调用` with `### IFB` subsection (curl merged in)
- Removed `## DCU 适配注意` (not in standard template)