### PR TITLE
chore: add .agent/skills symlink for Codex

### DIFF
--- a/.agent/skills
+++ b/.agent/skills
@@ -1,0 +1,1 @@
+../.claude/skills


### PR DESCRIPTION
Creates `.agent/skills` → `.claude/skills` symlink so Codex agents can discover the same skill definitions as Claude.