### PR TITLE
docs: update support matrix for K100_AI and BW1000 coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 
 ## 📋 模型列表
 
-✅ 已验证 &nbsp;|&nbsp; 🚧 开发中 &nbsp;|&nbsp; `-` 暂不支持
+✅ 已验证 &nbsp;|&nbsp; 🚧 开发中 &nbsp;|&nbsp; `-` 暂未验证
 
 <table>
   <tr>

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@
     <tr>
       <td rowspan="2">Qwen3.5</td>
       <td>vLLM</td>
-      <td align="center">-</td><td align="center"><a href="docs/model-deployment/vllm/qwen3.5.md">✅</a></td><td align="center"><a href="docs/model-deployment/vllm/qwen3.5.md">✅</a></td>
+      <td align="center"><a href="docs/model-deployment/vllm/qwen3.5.md">✅</a></td><td align="center"><a href="docs/model-deployment/vllm/qwen3.5.md">✅</a></td><td align="center"><a href="docs/model-deployment/vllm/qwen3.5.md">✅</a></td>
     </tr>
     <tr>
       <td>SGLang</td>
@@ -89,7 +89,7 @@
     <tr>
       <td rowspan="2">Qwen3</td>
       <td>vLLM</td>
-      <td align="center">-</td><td align="center"><a href="docs/model-deployment/vllm/qwen3.md">✅</a></td><td align="center"><a href="docs/model-deployment/vllm/qwen3.md">✅</a></td>
+      <td align="center"><a href="docs/model-deployment/vllm/qwen3.md">✅</a></td><td align="center"><a href="docs/model-deployment/vllm/qwen3.md">✅</a></td><td align="center"><a href="docs/model-deployment/vllm/qwen3.md">✅</a></td>
     </tr>
     <tr>
       <td>SGLang</td>
@@ -195,7 +195,7 @@
     </tr>
     <tr>
       <td>SGLang</td>
-      <td align="center">-</td><td align="center">-</td><td align="center"><a href="docs/model-deployment/sglang/glm-5.md">✅</a></td>
+      <td align="center">-</td><td align="center"><a href="docs/model-deployment/sglang/glm-5.md">✅</a></td><td align="center"><a href="docs/model-deployment/sglang/glm-5.md">✅</a></td>
     </tr>
     <tr>
       <td rowspan="2">GLM-4.7</td>

--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@
 
 ## 📋 模型列表
 
+✅ 已验证 &nbsp;|&nbsp; 🚧 开发中 &nbsp;|&nbsp; `-` 暂不支持
+
 <table>
   <tr>
     <td align="center"><b>厂商</b></td>


### PR DESCRIPTION
- vLLM Qwen3.5: K100_AI `-` → ✅ (doc has K100_AI rows)
- vLLM Qwen3: K100_AI `-` → ✅ (doc has K100_AI rows)
- SGLang GLM-5: BW1000 `-` → ✅ (doc covers BW1000)