### PR TITLE
docs: update add-model skill with hw ordering and model family file convention

### DIFF
--- a/.claude/skills/add-model/SKILL.md
+++ b/.claude/skills/add-model/SKILL.md
@@ -55,6 +55,8 @@ description: Guide for adding a new model deployment doc to dcu-inference-cookbo
   - `BW1000 64GB`（简写 `BW1000`）
   - `BW1100 144GB`（简写 `BW1100`）
 
+  **表格行排序**：同一模型的多条行按硬件平台排序，顺序固定为 **BW1100 → BW1000 → K100_AI**。
+
 - **卡数**：整数，表示所需 DCU 数量。
 
 - **部署方式**：
@@ -354,12 +356,12 @@ curl http://<P_node_ip>:30001/v1/chat/completions ...
 
 | 模型权重 | 量化方式 | SGLang 版本 | 推荐硬件 | 卡数 | 部署方式 | 启动命令 |
 | -------- | -------- | ----------- | -------- | ---- | -------- | -------- |
-| [hygon/GLM-5-Channel-INT4-w4a8](https://www.modelscope.cn/models/hygon/GLM-5-Channel-INT4-w4a8) | INT4 W4A8 | 0.5.10 | BW1000 |  8 | IFB  | [**`>_`**](#glm-5-channel-int4-w4a8-ifb-bw1000-8x-sglang-0510)   |
-|                                                                                                 | INT4 W4A8 | 0.5.10 | BW1000 | 32 | 2P2D | [**`>_`**](#glm-5-channel-int4-w4a8-2p2d-bw1000-32x-sglang-0510) |
 | [hygon/GLM-5-Channel-INT8-w8a8](https://www.modelscope.cn/models/hygon/GLM-5-Channel-INT8-w8a8) | INT8 W8A8 | 0.5.10 | BW1100 |  8 | IFB  | [**`>_`**](#glm-5-channel-int8-w8a8-ifb-bw1100-8x-sglang-0510)   |
 |                                                                                                 | INT8 W8A8 | 0.5.10 | BW1100 | 24 | 1P2D | [**`>_`**](#glm-5-channel-int8-w8a8-1p2d-bw1100-24x-sglang-0510) |
 | [hygon/GLM-5-Channel-FP8-w8a8](https://www.modelscope.cn/models/hygon/GLM-5-Channel-FP8-w8a8)   |  FP8 W8A8 | 0.5.10 | BW1100 |  8 | IFB  | [**`>_`**](#glm-5-channel-fp8-w8a8-ifb-bw1100-8x-sglang-0510)    |
 |                                                                                                 |  FP8 W8A8 | 0.5.10 | BW1100 | 24 | 1P2D | [**`>_`**](#glm-5-channel-fp8-w8a8-1p2d-bw1100-24x-sglang-0510)  |
+| [hygon/GLM-5-Channel-INT4-w4a8](https://www.modelscope.cn/models/hygon/GLM-5-Channel-INT4-w4a8) | INT4 W4A8 | 0.5.10 | BW1000 |  8 | IFB  | [**`>_`**](#glm-5-channel-int4-w4a8-ifb-bw1000-8x-sglang-0510)   |
+|                                                                                                 | INT4 W4A8 | 0.5.10 | BW1000 | 32 | 2P2D | [**`>_`**](#glm-5-channel-int4-w4a8-2p2d-bw1000-32x-sglang-0510) |
 ````
 
 ## 示例（vLLM GLM-5）
@@ -373,6 +375,17 @@ curl http://<P_node_ip>:30001/v1/chat/completions ...
 | [hygon/GLM-5-Channel-INT8-w8a8](https://www.modelscope.cn/models/hygon/GLM-5-Channel-INT8-w8a8) | INT8 W8A8 | 0.18 | BW1100 |  8 | IFB  | [**`>_`**](#glm-5-channel-int8-w8a8-ifb-bw1100-8x-vllm-018)   |
 |                                                                                                 | INT8 W8A8 | 0.18 | BW1100 | 24 | 1P2D | [**`>_`**](#glm-5-channel-int8-w8a8-1p2d-bw1100-24x-vllm-018) |
 ````
+
+## 文件命名规范
+
+**不要为每个具体模型变体单独创建文件。** 使用**模型系列**文件，将同系列的不同版本/规格合并在一个文件中：
+
+- ✅ 正确：在 `qwen3.md` 中增加 Qwen3-235B-A22B 的章节
+- ❌ 错误：新建 `qwen3-235b-a22b.md`
+
+**判断规则**：
+- 若 `docs/model-deployment/{vllm|sglang}/` 下已存在同系列文件（如 `qwen3.md`、`kimi-k2.md`），直接在该文件的 `## 模型列表` 表格末尾追加行，并在 `## 启动命令` 末尾追加对应章节。
+- 若不存在同系列文件，新建以系列命名的文件（如 `deepseek-v3.md`、`glm-5.md`）。
 
 ## 最终步骤：更新 README 支持矩阵
 

--- a/.claude/skills/add-model/SKILL.md
+++ b/.claude/skills/add-model/SKILL.md
@@ -11,23 +11,17 @@ description: Guide for adding a new model deployment doc to dcu-inference-cookbo
 
 1. **模型卡**：模型在 ModelScope 或 HuggingFace 上的完整路径或 URL。
    例如：`hygon/GLM-5-Channel-INT4-w4a8`、`LLM-Research/Meta-Llama-3.1-70B-Instruct`
+   **后续所有文档严格使用此处用户指定的模型 ID，不得推断或替换为其他模型 ID。**
 
-2. **HYGON 量化模型**（仅当步骤 1 填写的不是 `hygon/` 前缀的模型时询问）：
-   询问用户是否有对应的 HYGON 量化版本，如有请提供完整模型 ID。
-   例如：`hygon/DeepSeek-R1-Channel-FP8-w8a8`
-   - 若用户提供了 `hygon/` 模型 ID，后续文档使用该 ID，并从名称中解析量化方式（`INT4`/`INT8`/`FP8` 等）
-   - 若用户明确表示没有 HYGON 量化版本，则直接使用步骤 1 的上游模型 ID（量化方式填 `BF16` 或用户指定值）
-   - **绝对不能**根据上游模型名称自行推断或猜测对应的 HYGON 模型 ID
+2. **框架**：`vLLM` 还是 `SGLang`（二选一）
 
-3. **框架**：`vLLM` 还是 `SGLang`（二选一）
-
-4. **框架版本**：
+3. **框架版本**：
    - 选择 vLLM 时只接受：`0.15` 或 `0.18`（其他版本需要用户重新输入）
    - 选择 SGLang 时只接受：`0.5.10`（其他版本需要用户重新输入）
 
-5. **硬件平台**：从 `K100_AI`、`BW1000`、`BW1100` 中选择，可多选（其他值需要用户重新输入）
+4. **硬件平台**：从 `K100_AI`、`BW1000`、`BW1100` 中选择，可多选（其他值需要用户重新输入）
 
-6. **启动命令**：
+5. **启动命令**：
    - 若用户提供了完整的 `vllm serve` 或 `sglang serve` 命令，**原样采用，不做任何修改**
    - 若用户未提供，根据模型信息和硬件平台**生成模板命令**，告知用户可按需修改
 
@@ -46,14 +40,9 @@ description: Guide for adding a new model deployment doc to dcu-inference-cookbo
 
 - **框架版本**：使用信息收集阶段用户指定的框架版本（如 `0.18`、`0.5.10`）。
 
-- **模型权重**：模型在 ModelScope 上的完整路径，带链接。
-  - 信息收集步骤 2 用户提供了 HYGON 量化 ID 时，使用该 ID（`hygon/` 前缀）：
-    `[hygon/<MODEL-NAME>](https://www.modelscope.cn/models/hygon/<MODEL-NAME>)`
+- **模型权重**：严格使用信息收集步骤 1 中用户指定的模型 ID，带 ModelScope 链接。不得推断、替换或猜测为其他模型 ID。
+  - `[<MODEL-ID>](https://www.modelscope.cn/models/<MODEL-ID>)`
     例如：`[hygon/GLM-5-Channel-INT4-w4a8](https://www.modelscope.cn/models/hygon/GLM-5-Channel-INT4-w4a8)`
-  - 无 HYGON 量化版本时（如 BF16 部署），使用上游原始模型 ID：
-    例如：`[Qwen/Qwen3-235B-A22B](https://www.modelscope.cn/models/Qwen/Qwen3-235B-A22B)`
-    或：`[moonshotai/Kimi-K2-Instruct](https://www.modelscope.cn/models/moonshotai/Kimi-K2-Instruct)`
-  - **严禁**根据上游模型名称自行推断 HYGON 模型 ID（如把 `deepseek-ai/DeepSeek-R1` 猜测为 `hygon/DeepSeek-R1-Channel-INT8-w8a8`）——必须由用户在步骤 2 明确提供。
   - 同一模型的多个行，后续行的模型权重列留空（用空格对齐）。
 
 - **量化方式**：使用标准格式，例如：`INT4 W4A8`、`INT8 W8A8`、`FP8 W8A8`、`BF16`。

--- a/.claude/skills/add-model/SKILL.md
+++ b/.claude/skills/add-model/SKILL.md
@@ -12,15 +12,22 @@ description: Guide for adding a new model deployment doc to dcu-inference-cookbo
 1. **模型卡**：模型在 ModelScope 或 HuggingFace 上的完整路径或 URL。
    例如：`hygon/GLM-5-Channel-INT4-w4a8`、`LLM-Research/Meta-Llama-3.1-70B-Instruct`
 
-2. **框架**：`vLLM` 还是 `SGLang`（二选一）
+2. **HYGON 量化模型**（仅当步骤 1 填写的不是 `hygon/` 前缀的模型时询问）：
+   询问用户是否有对应的 HYGON 量化版本，如有请提供完整模型 ID。
+   例如：`hygon/DeepSeek-R1-Channel-FP8-w8a8`
+   - 若用户提供了 `hygon/` 模型 ID，后续文档使用该 ID，并从名称中解析量化方式（`INT4`/`INT8`/`FP8` 等）
+   - 若用户明确表示没有 HYGON 量化版本，则直接使用步骤 1 的上游模型 ID（量化方式填 `BF16` 或用户指定值）
+   - **绝对不能**根据上游模型名称自行推断或猜测对应的 HYGON 模型 ID
 
-3. **框架版本**：
+3. **框架**：`vLLM` 还是 `SGLang`（二选一）
+
+4. **框架版本**：
    - 选择 vLLM 时只接受：`0.15` 或 `0.18`（其他版本需要用户重新输入）
    - 选择 SGLang 时只接受：`0.5.10`（其他版本需要用户重新输入）
 
-4. **硬件平台**：从 `K100_AI`、`BW1000`、`BW1100` 中选择，可多选（其他值需要用户重新输入）
+5. **硬件平台**：从 `K100_AI`、`BW1000`、`BW1100` 中选择，可多选（其他值需要用户重新输入）
 
-5. **启动命令**：
+6. **启动命令**：
    - 若用户提供了完整的 `vllm serve` 或 `sglang serve` 命令，**原样采用，不做任何修改**
    - 若用户未提供，根据模型信息和硬件平台**生成模板命令**，告知用户可按需修改
 
@@ -40,12 +47,13 @@ description: Guide for adding a new model deployment doc to dcu-inference-cookbo
 - **框架版本**：使用信息收集阶段用户指定的框架版本（如 `0.18`、`0.5.10`）。
 
 - **模型权重**：模型在 ModelScope 上的完整路径，带链接。
-  - 有 HYGON 量化版本时，优先使用 `hygon/` 前缀的 channelwise 模型：
+  - 信息收集步骤 2 用户提供了 HYGON 量化 ID 时，使用该 ID（`hygon/` 前缀）：
     `[hygon/<MODEL-NAME>](https://www.modelscope.cn/models/hygon/<MODEL-NAME>)`
     例如：`[hygon/GLM-5-Channel-INT4-w4a8](https://www.modelscope.cn/models/hygon/GLM-5-Channel-INT4-w4a8)`
   - 无 HYGON 量化版本时（如 BF16 部署），使用上游原始模型 ID：
     例如：`[Qwen/Qwen3-235B-A22B](https://www.modelscope.cn/models/Qwen/Qwen3-235B-A22B)`
     或：`[moonshotai/Kimi-K2-Instruct](https://www.modelscope.cn/models/moonshotai/Kimi-K2-Instruct)`
+  - **严禁**根据上游模型名称自行推断 HYGON 模型 ID（如把 `deepseek-ai/DeepSeek-R1` 猜测为 `hygon/DeepSeek-R1-Channel-INT8-w8a8`）——必须由用户在步骤 2 明确提供。
   - 同一模型的多个行，后续行的模型权重列留空（用空格对齐）。
 
 - **量化方式**：使用标准格式，例如：`INT4 W4A8`、`INT8 W8A8`、`FP8 W8A8`、`BF16`。


### PR DESCRIPTION
Two rule updates to the add-model skill:

1. **Hardware row ordering**: Model list table rows are now sorted **BW1100 → BW1000 → K100_AI** (highest-spec first).
2. **Model family files**: Instead of creating `qwen3-235b-a22b.md`, append to the existing `qwen3.md`. New rule documented with examples.