### PR TITLE
fix: correct Qwen vendor rowspan to fix DeepSeek-V4 matrix alignment

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@
   </tr>
   <tbody>
     <tr>
-      <td rowspan="20" align="center"><img src="https://cdn-avatars.huggingface.co/v1/production/uploads/620760a26e3b7210c2ff1943/-s1gyJfvbE1RgO5iBeNOi.png" height="40"/><br/>Qwen</td>
+      <td rowspan="18" align="center"><img src="https://cdn-avatars.huggingface.co/v1/production/uploads/620760a26e3b7210c2ff1943/-s1gyJfvbE1RgO5iBeNOi.png" height="40"/><br/>Qwen</td>
       <td rowspan="2">Qwen3.6</td>
       <td>vLLM</td>
       <td align="center">🚧</td><td align="center">🚧</td><td align="center">🚧</td>


### PR DESCRIPTION
The Qwen vendor `<td rowspan="20">` covered 9 models × 2 rows = 18 actual rows, not 20. The extra 2 rows bled into the DeepSeek-V4 rows, shifting all DeepSeek-V4 cells one column to the right.

Fix: change `rowspan="20"` → `rowspan="18"`.