### PR TITLE
docs: update support matrix - MiniMax-M2.7 SGLang BW1100 verified

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,7 +280,7 @@
     </tr>
     <tr>
       <td>SGLang</td>
-      <td align="center">-</td><td align="center">-</td><td align="center">-</td>
+      <td align="center">-</td><td align="center">-</td><td align="center"><a href="docs/model-deployment/sglang/minimax-m2.7.md">✅</a></td>
     </tr>
     <tr>
       <td rowspan="2">MiniMax-M2.5</td>


### PR DESCRIPTION
`sglang/minimax-m2.7.md` exists on main with BW1100 support, but the matrix was still showing `-` for all hardware. Updated SGLang BW1100 cell to ✅.