### PR TITLE
Add Qwen3-4B-Thinking-2507 vLLM deployment guide

### DIFF
--- a/docs/model-deployment/vllm/qwen3.md
+++ b/docs/model-deployment/vllm/qwen3.md
@@ -25,6 +25,9 @@ Qwen3 是阿里通义千问第三代大语言模型，支持 0.6B ~ 235B 多种�
 |                                                                               | BF16 | 0.15 | BW1000 | 8 | IFB | [**`>_`**](#qwen3-235b-a22b-instruct-2507-ifb-bw1000-8x-vllm-015) |
 |                                                                               | BF16 | 0.15 | K100_AI | 8 | IFB | [**`>_`**](#qwen3-235b-a22b-instruct-2507-ifb-k100_ai-8x-vllm-015) |
 | [Qwen/Qwen3-235B-A22B-FP8-Channel](https://www.modelscope.cn/models/hygon/Qwen3-235B-A22B-W8A8) | FP8 | 0.15 | BW1100 | 4 | IFB | [**`>_`**](#qwen3-235b-a22b-fp8-channelwise-ifb-bw1100-4x-vllm-015) |
+| [Qwen/Qwen3-4B-Thinking-2507](https://www.modelscope.cn/models/Qwen/Qwen3-4B-Thinking-2507) | BF16 | 0.15 | BW1100 | 1 | IFB | [**`>_`**](#qwen3-4b-thinking-2507-ifb-bw1100-1x-vllm-015) |
+|                                                                               | BF16 | 0.15 | BW1000 | 1 | IFB | [**`>_`**](#qwen3-4b-thinking-2507-ifb-bw1000-1x-vllm-015) |
+|                                                                               | BF16 | 0.15 | K100_AI | 1 | IFB | [**`>_`**](#qwen3-4b-thinking-2507-ifb-k100_ai-1x-vllm-015) |
 
 ## 启动命令
 
@@ -111,7 +114,7 @@ export VLLM_RANK5_NUMA=2
 export VLLM_RANK6_NUMA=3
 export VLLM_RANK7_NUMA=3
 
-vllm serve /Qwen/Qwen3-235B-A22B-Instruct-2507 \
+vllm serve Qwen/Qwen3-235B-A22B-Instruct-2507 \
   --dtype float16 \
   --trust-remote-code \
   -tp 8 \
@@ -130,7 +133,7 @@ export VLLM_RANK5_NUMA=3
 export VLLM_RANK6_NUMA=3
 export VLLM_RANK7_NUMA=3
 
-vllm serve /Qwen/Qwen3-235B-A22B-Instruct-2507 \
+vllm serve Qwen/Qwen3-235B-A22B-Instruct-2507 \
   --dtype float16 \
   --trust-remote-code \
   -tp 8 \
@@ -152,7 +155,7 @@ export VLLM_RANK6_NUMA=3
 export VLLM_RANK7_NUMA=3
 export ALLREDUCE_STREAM_WITH_COMPUTE=1
 
-vllm serve /Qwen/Qwen3-235B-A22B-Instruct-2507 \
+vllm serve Qwen/Qwen3-235B-A22B-Instruct-2507 \
   --dtype float16 \
   --trust-remote-code \
   -tp 8 \
@@ -182,6 +185,37 @@ vllm serve Qwen/Qwen3-235B-A22B-FP8-Channel \
   --disable-cascade-attn \
   -cc '{"pass_config": {"fuse_act_quant": false}, "custom_ops": ["all"]}'
 ```
+
+### Qwen3-4B-Thinking-2507 IFB BW1100 1x vLLM 0.15
+
+```bash
+vllm serve Qwen/Qwen3-4B-Thinking-2507 \
+  -tp 1 \
+  --max-num-batched-tokens 10240 \
+  --trust-remote-code \
+  --disable-cascade-attn
+```
+
+### Qwen3-4B-Thinking-2507 IFB BW1000 1x vLLM 0.15
+
+```bash
+vllm serve Qwen/Qwen3-4B-Thinking-2507 \
+  -tp 1 \
+  --max-num-batched-tokens 10240 \
+  --trust-remote-code \
+  --disable-cascade-attn
+```
+
+### Qwen3-4B-Thinking-2507 IFB K100_AI 1x vLLM 0.15
+
+```bash
+vllm serve Qwen/Qwen3-4B-Thinking-2507 \
+  -tp 1 \
+  --max-num-batched-tokens 10240 \
+  --trust-remote-code \
+  --disable-cascade-attn
+```
+
 ## 环境变量
 
 | 环境变量 | 值 | 对总吞吐 | 对 TPOT | 说明 |


### PR DESCRIPTION
## Summary
- Add Qwen3-4B-Thinking-2507 vLLM 0.15 deployment entries for BW1100, BW1000, and K100_AI
- Add corresponding IFB startup command sections using the provided vllm serve command

## Tests
- Not run; documentation-only change