### PR TITLE
docs: add DeepSeek-R1 Channel FP8 vLLM guide

### DIFF
--- a/docs/model-deployment/vllm/deepseek-r1.md
+++ b/docs/model-deployment/vllm/deepseek-r1.md
@@ -10,6 +10,7 @@ DeepSeek-R1 是 DeepSeek 推出的推理强化模型，面向复杂推理、数�
 | -------- | -------- | --------- | -------- | ---- | -------- | -------- |
 | [hygon/DeepSeek-R1-0528-W4A8-V2](https://www.modelscope.cn/models/hygon/DeepSeek-R1-0528-W4A8-V2) | W4A8 | 0.15 | BW1100 | 8 | IFB | [**`>_`**](#deepseek-r1-w4a8-ifb-bw1100-8x-vllm-015) |
 | [hygon/DeepSeek-R1-0528-W4A8-V2](https://www.modelscope.cn/models/hygon/DeepSeek-R1-0528-W4A8-V2) | W4A8 | 0.15 | BW1000 | 8 | IFB | [**`>_`**](#deepseek-r1-w4a8-ifb-bw1000-8x-vllm-015) |
+| [hygon/DeepSeek-R1-Channel-FP8-w8a8](https://www.modelscope.cn/models/hygon/DeepSeek-R1-Channel-FP8-w8a8) | FP8 W8A8 | 0.15 | BW1100 | 8 | IFB | [**`>_`**](#deepseek-r1-channel-fp8-w8a8-ifb-bw1100-8x-vllm-015) |
 
 ## 启动命令
 
@@ -92,6 +93,49 @@ vllm serve hygon/DeepSeek-R1-0528-W4A8-V2 \
   --enable-prefix-caching \
   --kv-cache-dtype fp8_e5m2 \
   --speculative_config '{"method": "mtp", "num_speculative_tokens": 3, "quantization": "slimquant_w4a8_marlin"}'
+```
+
+### DeepSeek-R1-Channel-FP8-w8a8 IFB BW1100 8x vLLM 0.15
+
+```bash
+rm -rf ~/.cache
+rm -rf ~/.triton
+export HIP_VISIBLE_DEVICES=0,1,2,3,4,5,6,7
+export ALLREDUCE_STREAM_WITH_COMPUTE=1
+export NCCL_MAX_NCHANNELS=16
+export NCCL_MIN_NCHANNELS=16
+export Allgather_Base_STREAM_WITH_COMPUTE=1
+export SENDRECV_STREAM_WITH_COMPUTE=1
+export HIP_KERNEL_EVENT_SYSTENFENCE=1
+export VLLM_REJECT_SAMPLE_OPT=0
+export VLLM_USE_PIECEWISE=1
+export VLLM_SPEC_DECODE_EAGER=0
+export VLLM_USE_GLOBAL_CACHE13=1
+export VLLM_FUSED_MOE_CHUNK_SIZE=16384
+export USE_FUSED_RMS_QUANT=0
+export USE_FUSED_SILU_MUL_QUANT=1
+export VLLM_USE_OPT_CAT=1
+export VLLM_USE_FUSED_FILL_RMS_CAT=1
+export VLLM_USE_LIGHTOP_MOE_SUM_MUL_ADD=1
+export VLLM_USE_LIGHTOP_RMS_ROPE_CONCAT=1
+export VLLM_USE_FLASH_ATTN_FP8=1
+export VLLM_USE_CAT_MLA=1
+export VLLM_USE_LIGHTOP=1
+export VLLM_USE_LIGHTOP_FILL_MOE_ALIGN=1
+
+vllm serve hygon/DeepSeek-R1-Channel-FP8-w8a8\
+  --trust-remote-code \
+  -q slimquant_marlin \
+  -tp 8 \
+  --dtype bfloat16 \
+  --max-model-len 35000 \
+  --disable-log-requests \
+  --gpu-memory-utilization 0.90 \
+  --max-num-batched-tokens 16384 \
+  --no-enable-prefix-caching \
+  --compilation-config '{"pass_config": {"fuse_act_quant": false}}' \
+  --speculative_config '{"method": "deepseek_mtp", "num_speculative_tokens": 2,"quantization": "slimquant_marlin"}' \
+  --kv-cache-dtype fp8_e4m3 
 ```
 
 ## API 调用


### PR DESCRIPTION
## Summary

- Add DeepSeek-R1-Channel-FP8-w8a8 vLLM 0.15 deployment entry for BW1100
- Add the corresponding IFB startup command section