### PR TITLE
[bugfix]删掉可能会影响精度的--chunked-prefill-size -1

### DIFF
--- a/docs/model-deployment/sglang/qwen3.6.md
+++ b/docs/model-deployment/sglang/qwen3.6.md
@@ -35,8 +35,7 @@ sglang serve --model-path Qwen/Qwen3.6-27B \
     --page-size 64 \
     --mamba-scheduler-strategy extra_buffer \
     --kv-cache-dtype fp8_e4m3 \
-    --trust-remote-code \
-    --chunked-prefill-size -1
+    --trust-remote-code
 ```
 
 ### Qwen3.6-35B-A3B IFB BW1100 2x SGLang 0.5.10


### PR DESCRIPTION
在sglang框架中，增加--chunked-prefill-size -1后qwen3.6-27b精度下降，N卡上同样存在此问题，为了精度最优，暂时删掉此参数