### PR TITLE
docs(vllm/qwen3.5): 更新 BF16 模型启动命令的环境变量与推理参数

### DIFF
--- a/docs/model-deployment/vllm/qwen3.5.md
+++ b/docs/model-deployment/vllm/qwen3.5.md
@@ -248,16 +248,16 @@ vllm serve hygon/Qwen3.5-27B-Channel-INT8-w8a8 \
 ### Qwen3.5-35B-A3B IFB BW1100 1x vLLM 0.18
 
 ```bash
-export VLLM_HCU_USE_FLASH_ATTN=1
-export VLLM_HCU_USE_CUSTOM_TOPK_TOPP_SAMPLER=1
-export VLLM_ROCM_USE_AITER=1
+export VLLM_HCU_USE_CUSTOM_FLASH_ATTN=1
 export VLLM_ROCM_USE_AITER_MOE=1
-export VLLM_HCU_USE_PD_SPLIT=1
 
 vllm serve Qwen/Qwen3.5-35B-A3B \
   -tp 1 \
   --trust-remote-code \
   --max-num-batched-tokens 10240 \
+  --attention-backend FLASH_ATTN_CUTLASS \
+  --kv-cache-dtype fp8_e4m3 \
+  --enable-prefix-caching \
   --speculative-config.method mtp \
   --speculative-config.num_speculative_tokens 3
 ```
@@ -265,16 +265,16 @@ vllm serve Qwen/Qwen3.5-35B-A3B \
 ### Qwen3.5-35B-A3B IFB BW1000 2x vLLM 0.18
 
 ```bash
-export VLLM_HCU_USE_FLASH_ATTN=1
-export VLLM_HCU_USE_CUSTOM_TOPK_TOPP_SAMPLER=1
-export VLLM_ROCM_USE_AITER=1
+export VLLM_HCU_USE_CUSTOM_FLASH_ATTN=1
 export VLLM_ROCM_USE_AITER_MOE=1
-export VLLM_HCU_USE_PD_SPLIT=1
 
 vllm serve Qwen/Qwen3.5-35B-A3B \
   -tp 2 \
   --trust-remote-code \
   --max-num-batched-tokens 10240 \
+  --attention-backend FLASH_ATTN_CUTLASS \
+  --kv-cache-dtype fp8_e5m2 \
+  --enable-prefix-caching \
   --speculative-config.method mtp \
   --speculative-config.num_speculative_tokens 3
 ```
@@ -358,16 +358,16 @@ vllm serve hygon/Qwen3.5-35B-A3B-Channel-FP8-w8a8 \
 ### Qwen3.5-122B-A10B IFB BW1100 4x vLLM 0.18
 
 ```bash
-export VLLM_HCU_USE_FLASH_ATTN=1
-export VLLM_HCU_USE_CUSTOM_TOPK_TOPP_SAMPLER=1
-export VLLM_ROCM_USE_AITER=1
+export VLLM_HCU_USE_CUSTOM_FLASH_ATTN=1
 export VLLM_ROCM_USE_AITER_MOE=1
-export VLLM_HCU_USE_PD_SPLIT=1
 
 vllm serve Qwen/Qwen3.5-122B-A10B \
   -tp 4 \
   --trust-remote-code \
   --max-num-batched-tokens 10240 \
+  --attention-backend FLASH_ATTN_CUTLASS \
+  --kv-cache-dtype fp8_e4m3 \
+  --enable-prefix-caching \
   --speculative-config.method mtp \
   --speculative-config.num_speculative_tokens 3
 ```
@@ -375,16 +375,16 @@ vllm serve Qwen/Qwen3.5-122B-A10B \
 ### Qwen3.5-122B-A10B IFB BW1000 8x vLLM 0.18
 
 ```bash
-export VLLM_HCU_USE_FLASH_ATTN=1
-export VLLM_HCU_USE_CUSTOM_TOPK_TOPP_SAMPLER=1
-export VLLM_ROCM_USE_AITER=1
+export VLLM_HCU_USE_CUSTOM_FLASH_ATTN=1
 export VLLM_ROCM_USE_AITER_MOE=1
-export VLLM_HCU_USE_PD_SPLIT=1
 
 vllm serve Qwen/Qwen3.5-122B-A10B \
   -tp 8 \
   --trust-remote-code \
   --max-num-batched-tokens 10240 \
+  --attention-backend FLASH_ATTN_CUTLASS \
+  --kv-cache-dtype fp8_e5m2 \
+  --enable-prefix-caching \
   --speculative-config.method mtp \
   --speculative-config.num_speculative_tokens 3
 ```

--- a/docs/model-deployment/vllm/qwen3.5.md
+++ b/docs/model-deployment/vllm/qwen3.5.md
@@ -46,30 +46,40 @@ Qwen3.5 是 Qwen3 系列的增强版本，在推理能力、代码生成、多�
 ### Qwen3.5-4B IFB BW1100 1x vLLM 0.18
 
 ```bash
-export VLLM_HCU_USE_FLASH_ATTN=1
-export VLLM_HCU_USE_CUSTOM_TOPK_TOPP_SAMPLER=1
+export VLLM_HCU_USE_CUSTOM_FLASH_ATTN=1
 
 vllm serve Qwen/Qwen3.5-4B \
   -tp 1 \
   --trust-remote-code \
   --max-num-batched-tokens 10240 \
+  --attention-backend FLASH_ATTN_CUTLASS \
+  --kv-cache-dtype fp8_e4m3 \
+  --enable-prefix-caching \
   --speculative-config.method mtp \
   --speculative-config.num_speculative_tokens 3
 ```
+
+> `--max-num-batched-tokens` 可按实际负载调优。
+> `VLLM_HCU_USE_PD_SPLIT=1`：追求总吞吐 / TTFT。
 
 ### Qwen3.5-4B IFB BW1000 1x vLLM 0.18
 
 ```bash
-export VLLM_HCU_USE_FLASH_ATTN=1
-export VLLM_HCU_USE_CUSTOM_TOPK_TOPP_SAMPLER=1
+export VLLM_HCU_USE_CUSTOM_FLASH_ATTN=1
 
 vllm serve Qwen/Qwen3.5-4B \
   -tp 1 \
   --trust-remote-code \
   --max-num-batched-tokens 10240 \
+  --attention-backend FLASH_ATTN_CUTLASS \
+  --kv-cache-dtype fp8_e5m2 \
+  --enable-prefix-caching \
   --speculative-config.method mtp \
   --speculative-config.num_speculative_tokens 3
 ```
+
+> `--max-num-batched-tokens` 可按实际负载调优。
+> `VLLM_HCU_USE_PD_SPLIT=1`：追求总吞吐 / TTFT。
 
 ### Qwen3.5-4B IFB K100_AI 1x vLLM 0.18
 
@@ -88,30 +98,40 @@ vllm serve Qwen/Qwen3.5-4B \
 ### Qwen3.5-9B IFB BW1100 1x vLLM 0.18
 
 ```bash
-export VLLM_HCU_USE_FLASH_ATTN=1
-export VLLM_HCU_USE_CUSTOM_TOPK_TOPP_SAMPLER=1
+export VLLM_HCU_USE_CUSTOM_FLASH_ATTN=1
 
 vllm serve Qwen/Qwen3.5-9B \
   -tp 1 \
   --trust-remote-code \
   --max-num-batched-tokens 10240 \
+  --attention-backend FLASH_ATTN_CUTLASS \
+  --kv-cache-dtype fp8_e4m3 \
+  --enable-prefix-caching \
   --speculative-config.method mtp \
   --speculative-config.num_speculative_tokens 3
 ```
+
+> `--max-num-batched-tokens` 可按实际负载调优。
+> `VLLM_HCU_USE_PD_SPLIT=1`：追求总吞吐 / TTFT。
 
 ### Qwen3.5-9B IFB BW1000 1x vLLM 0.18
 
 ```bash
-export VLLM_HCU_USE_FLASH_ATTN=1
-export VLLM_HCU_USE_CUSTOM_TOPK_TOPP_SAMPLER=1
+export VLLM_HCU_USE_CUSTOM_FLASH_ATTN=1
 
 vllm serve Qwen/Qwen3.5-9B \
   -tp 1 \
   --trust-remote-code \
   --max-num-batched-tokens 10240 \
+  --attention-backend FLASH_ATTN_CUTLASS \
+  --kv-cache-dtype fp8_e5m2 \
+  --enable-prefix-caching \
   --speculative-config.method mtp \
   --speculative-config.num_speculative_tokens 3
 ```
+
+> `--max-num-batched-tokens` 可按实际负载调优。
+> `VLLM_HCU_USE_PD_SPLIT=1`：追求总吞吐 / TTFT。
 
 ### Qwen3.5-9B IFB K100_AI 1x vLLM 0.18
 
@@ -130,30 +150,40 @@ vllm serve Qwen/Qwen3.5-9B \
 ### Qwen3.5-27B IFB BW1100 1x vLLM 0.18
 
 ```bash
-export VLLM_HCU_USE_FLASH_ATTN=1
-export VLLM_HCU_USE_CUSTOM_TOPK_TOPP_SAMPLER=1
+export VLLM_HCU_USE_CUSTOM_FLASH_ATTN=1
 
 vllm serve Qwen/Qwen3.5-27B \
   -tp 1 \
   --trust-remote-code \
   --max-num-batched-tokens 10240 \
+  --attention-backend FLASH_ATTN_CUTLASS \
+  --kv-cache-dtype fp8_e4m3 \
+  --enable-prefix-caching \
   --speculative-config.method mtp \
   --speculative-config.num_speculative_tokens 3
 ```
 
+> `--max-num-batched-tokens` 可按实际负载调优。
+> `VLLM_HCU_USE_PD_SPLIT=1`：追求总吞吐 / TTFT。
+
 ### Qwen3.5-27B IFB BW1000 2x vLLM 0.18
 
 ```bash
-export VLLM_HCU_USE_FLASH_ATTN=1
-export VLLM_HCU_USE_CUSTOM_TOPK_TOPP_SAMPLER=1
+export VLLM_HCU_USE_CUSTOM_FLASH_ATTN=1
 
 vllm serve Qwen/Qwen3.5-27B \
   -tp 2 \
   --trust-remote-code \
   --max-num-batched-tokens 10240 \
+  --attention-backend FLASH_ATTN_CUTLASS \
+  --kv-cache-dtype fp8_e5m2 \
+  --enable-prefix-caching \
   --speculative-config.method mtp \
   --speculative-config.num_speculative_tokens 3
 ```
+
+> `--max-num-batched-tokens` 可按实际负载调优。
+> `VLLM_HCU_USE_PD_SPLIT=1`：追求总吞吐 / TTFT。
 
 ### Qwen3.5-27B IFB K100_AI 2x vLLM 0.18
 


### PR DESCRIPTION
将 Qwen3.5-4B/9B/27B 在 BW1100/BW1000 上的启动命令与 qwen3 系列文档对齐：

- 环境变量由 VLLM_HCU_USE_FLASH_ATTN + VLLM_HCU_USE_CUSTOM_TOPK_TOPP_SAMPLER 更新为 VLLM_HCU_USE_CUSTOM_FLASH_ATTN
- 新增 --attention-backend FLASH_ATTN_CUTLASS
- 新增 --kv-cache-dtype（BW1100 用 fp8_e4m3，BW1000 用 fp8_e5m2）
- 新增 --enable-prefix-caching
- 补充 --max-num-batched-tokens 与 VLLM_HCU_USE_PD_SPLIT 的调优说明