### PR TITLE
docs/vllm: 为 0.18 启动命令新增 hotfix 镜像变体

### DIFF
--- a/docs/model-deployment/vllm/kimi-k2.5.md
+++ b/docs/model-deployment/vllm/kimi-k2.5.md
@@ -8,7 +8,8 @@ Kimi-K2.5 是月之暗面（Moonshot AI）推出的新一代大语言模型，�
 
 | 模型权重 | 量化方式 | vLLM 版本 | 推荐硬件 | 卡数 | 部署方式 | 启动命令 |
 | -------- | -------- | --------- | -------- | ---- | -------- | -------- |
-| [moonshotai/Kimi-K2.5](https://www.modelscope.cn/models/moonshotai/Kimi-K2.5) | INT4 W4A16 | 0.18 | BW1100 | 8 | IFB | [**`>_`**](#kimi-k25-ifb-bw1100-8x-vllm-015) |
+| [moonshotai/Kimi-K2.5](https://www.modelscope.cn/models/moonshotai/Kimi-K2.5) | INT4 W4A16 | 0.18 | BW1100 | 8 | IFB | [**`>_`**](#kimi-k25-ifb-bw1100-8x-vllm-018) |
+|  | INT4 W4A16 | 0.18-hotfix | BW1100 | 8 | IFB | [**`>_`**](#kimi-k25-ifb-bw1100-8x-vllm-018-hotfix) |
 | [moonshotai/Kimi-K2.5](https://www.modelscope.cn/models/moonshotai/Kimi-K2.5) | INT4 W4A16 | 0.15 | BW1100 | 8 | IFB | [**`>_`**](#kimi-k25-ifb-bw1100-8x-vllm-015) |
 
 ## 启动命令
@@ -31,6 +32,23 @@ vllm serve moonshotai/Kimi-K2.5 \
     --kv-cache-dtype fp8_e4m3
 ```
 
+### Kimi-K2.5 IFB BW1100 8x vLLM 0.18-hotfix
+
+```bash
+rm -rf ~/.cache
+rm -rf ~/.triton
+
+vllm serve moonshotai/Kimi-K2.5 \
+    -tp 8 \
+    --trust-remote-code   \
+    --dtype bfloat16  \
+    --max-model-len 65536  \
+    --enable-prefix-caching \
+    --gpu-memory-utilization 0.90 \
+    --max-num-batched-tokens 16384 \
+    --kv-cache-dtype fp8_e4m3 \
+    --moe-backend aiter
+```
 ### Kimi-K2.5 IFB BW1100 8x vLLM 0.15
 
 ```bash

--- a/docs/model-deployment/vllm/kimi-k2.5.md
+++ b/docs/model-deployment/vllm/kimi-k2.5.md
@@ -8,8 +8,7 @@ Kimi-K2.5 是月之暗面（Moonshot AI）推出的新一代大语言模型，�
 
 | 模型权重 | 量化方式 | vLLM 版本 | 推荐硬件 | 卡数 | 部署方式 | 启动命令 |
 | -------- | -------- | --------- | -------- | ---- | -------- | -------- |
-| [moonshotai/Kimi-K2.5](https://www.modelscope.cn/models/moonshotai/Kimi-K2.5) | INT4 W4A16 | 0.18 | BW1100 | 8 | IFB | [**`>_`**](#kimi-k25-ifb-bw1100-8x-vllm-018) |
-|  | INT4 W4A16 | 0.18-hotfix | BW1100 | 8 | IFB | [**`>_`**](#kimi-k25-ifb-bw1100-8x-vllm-018-hotfix) |
+| [moonshotai/Kimi-K2.5](https://www.modelscope.cn/models/moonshotai/Kimi-K2.5) | INT4 W4A16 | 0.18 | BW1100 | 8 | IFB | [**`>_`**](#kimi-k25-ifb-bw1100-8x-vllm-015) |
 | [moonshotai/Kimi-K2.5](https://www.modelscope.cn/models/moonshotai/Kimi-K2.5) | INT4 W4A16 | 0.15 | BW1100 | 8 | IFB | [**`>_`**](#kimi-k25-ifb-bw1100-8x-vllm-015) |
 
 ## 启动命令
@@ -32,23 +31,6 @@ vllm serve moonshotai/Kimi-K2.5 \
     --kv-cache-dtype fp8_e4m3
 ```
 
-### Kimi-K2.5 IFB BW1100 8x vLLM 0.18-hotfix
-
-```bash
-rm -rf ~/.cache
-rm -rf ~/.triton
-
-vllm serve moonshotai/Kimi-K2.5 \
-    -tp 8 \
-    --trust-remote-code   \
-    --dtype bfloat16  \
-    --max-model-len 65536  \
-    --enable-prefix-caching \
-    --gpu-memory-utilization 0.90 \
-    --max-num-batched-tokens 16384 \
-    --kv-cache-dtype fp8_e4m3 \
-    --moe-backend aiter
-```
 ### Kimi-K2.5 IFB BW1100 8x vLLM 0.15
 
 ```bash

--- a/docs/model-deployment/vllm/qwen2-vl.md
+++ b/docs/model-deployment/vllm/qwen2-vl.md
@@ -9,8 +9,11 @@ Qwen2-VL 是阿里通义千问视觉语言模型系列，支持图像、视频�
 | 模型权重 | 量化方式 | vLLM 版本 | 推荐硬件 | 卡数 | 部署方式 | 启动命令 |
 | -------- | -------- | --------- | -------- | ---- | -------- | -------- |
 | [Qwen/Qwen2-VL-2B](https://www.modelscope.cn/models/Qwen/Qwen2-VL-2B) | BF16 | 0.18 | BW1100 | 1 | IFB | [**`>_`**](#qwen2-vl-2b-ifb-bw1100-1x-vllm-018) |
+|  | BF16 | 0.18-hotfix | BW1100 | 1 | IFB | [**`>_`**](#qwen2-vl-2b-ifb-bw1100-1x-vllm-018-hotfix) |
 |                                                                               | BF16 | 0.18 | BW1000 | 1 | IFB | [**`>_`**](#qwen2-vl-2b-ifb-bw1000-1x-vllm-018) |
+|  | BF16 | 0.18-hotfix | BW1000 | 1 | IFB | [**`>_`**](#qwen2-vl-2b-ifb-bw1000-1x-vllm-018-hotfix) |
 |                                                                               | BF16 | 0.18 | K100_AI | 1 | IFB | [**`>_`**](#qwen2-vl-2b-ifb-k100_ai-1x-vllm-018) |
+|  | BF16 | 0.18-hotfix | K100_AI | 1 | IFB | [**`>_`**](#qwen2-vl-2b-ifb-k100_ai-1x-vllm-018-hotfix) |
 
 ## 启动命令
 
@@ -29,6 +32,20 @@ vllm serve Qwen/Qwen2-VL-2B \
     --allowed-local-media-path /path-to/VL_data/
 ```
 
+### Qwen2-VL-2B IFB BW1100 1x vLLM 0.18-hotfix
+
+```bash
+export VLLM_HCU_USE_PD_SPLIT=1
+
+vllm serve Qwen/Qwen2-VL-2B \
+    -tp 1 \
+    --trust-remote-code \
+    --gpu-memory-utilization 0.95 \
+    --chat-template-content-format openai \
+    --chat-template qwen2_vl_openai_chat_template.jinja \
+    --allowed-local-media-path /path-to/VL_data/ \
+    --attention-backend FLASH_ATTN_CUSTOM
+```
 ### Qwen2-VL-2B IFB BW1000 1x vLLM 0.18
 
 ```bash
@@ -44,6 +61,20 @@ vllm serve Qwen/Qwen2-VL-2B \
     --allowed-local-media-path /path-to/VL_data/
 ```
 
+### Qwen2-VL-2B IFB BW1000 1x vLLM 0.18-hotfix
+
+```bash
+export VLLM_HCU_USE_PD_SPLIT=1
+
+vllm serve Qwen/Qwen2-VL-2B \
+    -tp 1 \
+    --trust-remote-code \
+    --gpu-memory-utilization 0.95 \
+    --chat-template-content-format openai \
+    --chat-template qwen2_vl_openai_chat_template.jinja \
+    --allowed-local-media-path /path-to/VL_data/ \
+    --attention-backend FLASH_ATTN_CUSTOM
+```
 ### Qwen2-VL-2B IFB K100_AI 1x vLLM 0.18
 
 ```bash
@@ -59,6 +90,20 @@ vllm serve Qwen/Qwen2-VL-2B \
     --allowed-local-media-path /path-to/VL_data/
 ```
 
+### Qwen2-VL-2B IFB K100_AI 1x vLLM 0.18-hotfix
+
+```bash
+export VLLM_HCU_USE_CUSTOM_QUANTIZATION_GEMM=0
+export VLLM_HCU_USE_CUSTOM_OPS=0
+
+vllm serve Qwen/Qwen2-VL-2B \
+    -tp 1 \
+    --trust-remote-code \
+    --gpu-memory-utilization 0.95 \
+    --chat-template-content-format openai \
+    --chat-template qwen2_vl_openai_chat_template.jinja \
+    --allowed-local-media-path /path-to/VL_data/
+```
 ## Chat Template
 
 将以下内容保存为 `qwen2_vl_openai_chat_template.jinja`，并通过 `--chat-template` 参数指定该模板。

--- a/docs/model-deployment/vllm/qwen2.5-vl.md
+++ b/docs/model-deployment/vllm/qwen2.5-vl.md
@@ -9,8 +9,11 @@ Qwen2.5-VL 是阿里通义千问视觉语言模型系列，支持图像、视频
 | 模型权重 | 量化方式 | vLLM 版本 | 推荐硬件 | 卡数 | 部署方式 | 启动命令 |
 | -------- | -------- | --------- | -------- | ---- | -------- | -------- |
 | [Qwen/Qwen2.5-VL-32B-Instruct](https://www.modelscope.cn/models/Qwen/Qwen2.5-VL-32B-Instruct) | BF16 | 0.18 | BW1000 | 2 | IFB | [**`>_`**](#qwen25-vl-32b-instruct-ifb-bw1000-2x-vllm-018) |
+|  | BF16 | 0.18-hotfix | BW1000 | 2 | IFB | [**`>_`**](#qwen25-vl-32b-instruct-ifb-bw1000-2x-vllm-018-hotfix) |
 |                                                                               | BF16 | 0.18 | BW1100 | 1 | IFB | [**\`>_\`**](#qwen25-vl-32b-instruct-ifb-bw1100-1x-vllm-018) |
+|  | BF16 | 0.18-hotfix | BW1100 | 1 | IFB | [**\`>_\`**](#qwen25-vl-32b-instruct-ifb-bw1100-1x-vllm-018-hotfix) |
 |                                                                               | BF16 | 0.18 | K100_AI | 4 | IFB | [**\`>_\`**](#qwen25-vl-32b-instruct-ifb-k100_ai-4x-vllm-018) |
+|  | BF16 | 0.18-hotfix | K100_AI | 4 | IFB | [**\`>_\`**](#qwen25-vl-32b-instruct-ifb-k100_ai-4x-vllm-018-hotfix) |
 
 ## 启动命令
 
@@ -26,6 +29,17 @@ vllm serve Qwen/Qwen2.5-VL-32B-Instruct \
     --allowed-local-media-path /path-to/VL_data/ \
 ```
 
+### Qwen2.5-VL-32B-Instruct IFB BW1000 2x vLLM 0.18-hotfix
+
+```bash
+export VLLM_HCU_USE_PD_SPLIT=1
+
+vllm serve Qwen/Qwen2.5-VL-32B-Instruct \
+    -tp 2 \
+    --trust-remote-code \
+    --allowed-local-media-path /path-to/VL_data/ \
+    --attention-backend FLASH_ATTN_CUSTOM
+```
 ### Qwen2.5-VL-32B-Instruct IFB BW1100 1x vLLM 0.18
 
 ```bash
@@ -39,6 +53,19 @@ vllm serve Qwen/Qwen2.5-VL-32B-Instruct \
     --allowed-local-media-path /path-to/VL_data/ \
 ```
 
+### Qwen2.5-VL-32B-Instruct IFB BW1100 1x vLLM 0.18-hotfix
+
+```bash
+export VLLM_HCU_USE_PD_SPLIT=1
+
+vllm serve Qwen/Qwen2.5-VL-32B-Instruct \
+    -tp 1 \
+    --trust-remote-code \
+    --enable-chunked-prefill \
+    --max-model-len 32768 \
+    --allowed-local-media-path /path-to/VL_data/ \
+    --attention-backend FLASH_ATTN_CUSTOM
+```
 ### Qwen2.5-VL-32B-Instruct IFB K100_AI 4x vLLM 0.18
 
 ```bash
@@ -50,6 +77,16 @@ vllm serve Qwen/Qwen2.5-VL-32B-Instruct \
     --allowed-local-media-path /path-to/VL_data/ \
 ```
 
+### Qwen2.5-VL-32B-Instruct IFB K100_AI 4x vLLM 0.18-hotfix
+
+```bash
+export VLLM_HCU_USE_CUSTOM_QUANTIZATION_GEMM=0
+export VLLM_HCU_USE_CUSTOM_OPS=0
+vllm serve Qwen/Qwen2.5-VL-32B-Instruct \
+    -tp 4 \
+    --trust-remote-code \
+    --allowed-local-media-path /path-to/VL_data/ \
+```
 ## API 调用
 
 ### IFB

--- a/docs/model-deployment/vllm/qwen2.md
+++ b/docs/model-deployment/vllm/qwen2.md
@@ -9,20 +9,35 @@ Qwen2 是阿里通义千问开源大语言模型系列，支持多种参数规�
 | 模型权重 | 量化方式 | vLLM 版本 | 推荐硬件 | 卡数 | 部署方式 | 启动命令 |
 | -------- | -------- | --------- | -------- | ---- | -------- | -------- |
 | [Qwen/Qwen2-0.5B-Instruct](https://www.modelscope.cn/models/Qwen/Qwen2-0.5B-Instruct) | BF16 | 0.18 | BW1100  | 1 | IFB | [**`>_`**](#qwen2-05b-instruct-ifb-bw1100-1x-vllm-018) |
+|  | BF16 | 0.18-hotfix | BW1100 | 1 | IFB | [**`>_`**](#qwen2-05b-instruct-ifb-bw1100-1x-vllm-018-hotfix) |
 |                                                                               | BF16      | 0.18 | BW1000  | 1 | IFB | [**`>_`**](#qwen2-05b-instruct-ifb-bw1000-1x-vllm-018) |
+|  | BF16 | 0.18-hotfix | BW1000 | 1 | IFB | [**`>_`**](#qwen2-05b-instruct-ifb-bw1000-1x-vllm-018-hotfix) |
 |                                                                               | BF16      | 0.18 | K100_AI | 1 | IFB | [**`>_`**](#qwen2-05b-instruct-ifb-k100_ai-1x-vllm-018) |
+|  | BF16 | 0.18-hotfix | K100_AI | 1 | IFB | [**`>_`**](#qwen2-05b-instruct-ifb-k100_ai-1x-vllm-018-hotfix) |
 | [Qwen/Qwen2-1.5B-Instruct](https://www.modelscope.cn/models/Qwen/Qwen2-1.5B-Instruct) | BF16 | 0.18 | BW1100  | 1 | IFB | [**`>_`**](#qwen2-15b-instruct-ifb-bw1100-1x-vllm-018) |
+|  | BF16 | 0.18-hotfix | BW1100 | 1 | IFB | [**`>_`**](#qwen2-15b-instruct-ifb-bw1100-1x-vllm-018-hotfix) |
 |                                                                               | BF16      | 0.18 | BW1000  | 1 | IFB | [**`>_`**](#qwen2-15b-instruct-ifb-bw1000-1x-vllm-018) |
+|  | BF16 | 0.18-hotfix | BW1000 | 1 | IFB | [**`>_`**](#qwen2-15b-instruct-ifb-bw1000-1x-vllm-018-hotfix) |
 |                                                                               | BF16      | 0.18 | K100_AI | 1 | IFB | [**`>_`**](#qwen2-15b-instruct-ifb-k100_ai-1x-vllm-018) |
+|  | BF16 | 0.18-hotfix | K100_AI | 1 | IFB | [**`>_`**](#qwen2-15b-instruct-ifb-k100_ai-1x-vllm-018-hotfix) |
 | [Qwen/Qwen2-7B-Instruct](https://www.modelscope.cn/models/Qwen/Qwen2-7B-Instruct) | BF16 | 0.18 | BW1100  | 1 | IFB | [**`>_`**](#qwen2-7b-instruct-ifb-bw1100-1x-vllm-018) |
+|  | BF16 | 0.18-hotfix | BW1100 | 1 | IFB | [**`>_`**](#qwen2-7b-instruct-ifb-bw1100-1x-vllm-018-hotfix) |
 |                                                                               | BF16      | 0.18 | BW1000  | 1 | IFB | [**`>_`**](#qwen2-7b-instruct-ifb-bw1000-1x-vllm-018) |
+|  | BF16 | 0.18-hotfix | BW1000 | 1 | IFB | [**`>_`**](#qwen2-7b-instruct-ifb-bw1000-1x-vllm-018-hotfix) |
 |                                                                               | BF16      | 0.18 | K100_AI | 1 | IFB | [**`>_`**](#qwen2-7b-instruct-ifb-k100_ai-1x-vllm-018) |
+|  | BF16 | 0.18-hotfix | K100_AI | 1 | IFB | [**`>_`**](#qwen2-7b-instruct-ifb-k100_ai-1x-vllm-018-hotfix) |
 | [Qwen/Qwen2-57B-A14B-Instruct](https://www.modelscope.cn/models/Qwen/Qwen2-57B-A14B-Instruct) | BF16 | 0.18 | BW1100  | 2 | IFB | [**`>_`**](#qwen2-57b-a14b-instruct-ifb-bw1100-2x-vllm-018) |
+|  | BF16 | 0.18-hotfix | BW1100 | 2 | IFB | [**`>_`**](#qwen2-57b-a14b-instruct-ifb-bw1100-2x-vllm-018-hotfix) |
 |                                                                               | BF16      | 0.18 | BW1000  | 4 | IFB | [**`>_`**](#qwen2-57b-a14b-instruct-ifb-bw1000-4x-vllm-018) |
+|  | BF16 | 0.18-hotfix | BW1000 | 4 | IFB | [**`>_`**](#qwen2-57b-a14b-instruct-ifb-bw1000-4x-vllm-018-hotfix) |
 |                                                                               | BF16      | 0.18 | K100_AI | 4 | IFB | [**`>_`**](#qwen2-57b-a14b-instruct-ifb-k100_ai-4x-vllm-018) |
+|  | BF16 | 0.18-hotfix | K100_AI | 4 | IFB | [**`>_`**](#qwen2-57b-a14b-instruct-ifb-k100_ai-4x-vllm-018-hotfix) |
 | [Qwen/Qwen2-72B-Instruct](https://www.modelscope.cn/models/Qwen/Qwen2-72B-Instruct) | BF16 | 0.18 | BW1100  | 2 | IFB | [**`>_`**](#qwen2-72b-instruct-ifb-bw1100-2x-vllm-018) |
+|  | BF16 | 0.18-hotfix | BW1100 | 2 | IFB | [**`>_`**](#qwen2-72b-instruct-ifb-bw1100-2x-vllm-018-hotfix) |
 |                                                                               | BF16      | 0.18 | BW1000  | 4 | IFB | [**`>_`**](#qwen2-72b-instruct-ifb-bw1000-4x-vllm-018) |
+|  | BF16 | 0.18-hotfix | BW1000 | 4 | IFB | [**`>_`**](#qwen2-72b-instruct-ifb-bw1000-4x-vllm-018-hotfix) |
 |                                                                               | BF16      | 0.18 | K100_AI | 4 | IFB | [**`>_`**](#qwen2-72b-instruct-ifb-k100_ai-4x-vllm-018) |
+|  | BF16 | 0.18-hotfix | K100_AI | 4 | IFB | [**`>_`**](#qwen2-72b-instruct-ifb-k100_ai-4x-vllm-018-hotfix) |
 
 ## 启动命令
 
@@ -37,6 +52,17 @@ vllm serve Qwen/Qwen2-0.5B-Instruct \
   --trust-remote-code
 ```
 
+### Qwen2-0.5B-Instruct IFB BW1100 1x vLLM 0.18-hotfix
+
+```bash
+export VLLM_HCU_USE_PD_SPLIT=1
+export VLLM_USE_MODELSCOPE=1
+
+vllm serve Qwen/Qwen2-0.5B-Instruct \
+  -tp 1 \
+  --trust-remote-code \
+  --attention-backend FLASH_ATTN_CUSTOM
+```
 ### Qwen2-0.5B-Instruct IFB BW1000 1x vLLM 0.18
 ```bash
 export VLLM_USE_MODELSCOPE=1
@@ -48,6 +74,17 @@ vllm serve Qwen/Qwen2-0.5B-Instruct \
   --trust-remote-code
 ```
 
+### Qwen2-0.5B-Instruct IFB BW1000 1x vLLM 0.18-hotfix
+
+```bash
+export VLLM_HCU_USE_PD_SPLIT=1
+export VLLM_USE_MODELSCOPE=1
+
+vllm serve Qwen/Qwen2-0.5B-Instruct \
+  -tp 1 \
+  --trust-remote-code \
+  --attention-backend FLASH_ATTN_CUSTOM
+```
 ### Qwen2-0.5B-Instruct IFB K100_AI 1x vLLM 0.18
 ```bash
 export VLLM_HCU_USE_CUSTOM_QUANTIZATION_GEMM=0
@@ -60,6 +97,17 @@ vllm serve Qwen/Qwen2-0.5B-Instruct \
   --trust-remote-code
 ```
 
+### Qwen2-0.5B-Instruct IFB K100_AI 1x vLLM 0.18-hotfix
+
+```bash
+export VLLM_HCU_USE_CUSTOM_QUANTIZATION_GEMM=0
+export VLLM_HCU_USE_CUSTOM_OPS=0
+export VLLM_USE_MODELSCOPE=1
+
+vllm serve Qwen/Qwen2-0.5B-Instruct \
+  -tp 1 \
+  --trust-remote-code
+```
 ### Qwen2-1.5B-Instruct IFB BW1100 1x vLLM 0.18
 ```bash
 export VLLM_USE_MODELSCOPE=1
@@ -71,6 +119,17 @@ vllm serve Qwen/Qwen2-1.5B-Instruct \
   --trust-remote-code
 ```
 
+### Qwen2-1.5B-Instruct IFB BW1100 1x vLLM 0.18-hotfix
+
+```bash
+export VLLM_HCU_USE_PD_SPLIT=1
+export VLLM_USE_MODELSCOPE=1
+
+vllm serve Qwen/Qwen2-1.5B-Instruct \
+  -tp 1 \
+  --trust-remote-code \
+  --attention-backend FLASH_ATTN_CUSTOM
+```
 ### Qwen2-1.5B-Instruct IFB BW1000 1x vLLM 0.18
 ```bash
 export VLLM_USE_MODELSCOPE=1
@@ -82,6 +141,17 @@ vllm serve Qwen/Qwen2-1.5B-Instruct \
   --trust-remote-code
 ```
 
+### Qwen2-1.5B-Instruct IFB BW1000 1x vLLM 0.18-hotfix
+
+```bash
+export VLLM_HCU_USE_PD_SPLIT=1
+export VLLM_USE_MODELSCOPE=1
+
+vllm serve Qwen/Qwen2-1.5B-Instruct \
+  -tp 1 \
+  --trust-remote-code \
+  --attention-backend FLASH_ATTN_CUSTOM
+```
 ### Qwen2-1.5B-Instruct IFB K100_AI 1x vLLM 0.18
 ```bash
 export VLLM_HCU_USE_CUSTOM_QUANTIZATION_GEMM=0
@@ -94,6 +164,17 @@ vllm serve Qwen/Qwen2-1.5B-Instruct \
   --trust-remote-code
 ```
 
+### Qwen2-1.5B-Instruct IFB K100_AI 1x vLLM 0.18-hotfix
+
+```bash
+export VLLM_HCU_USE_CUSTOM_QUANTIZATION_GEMM=0
+export VLLM_HCU_USE_CUSTOM_OPS=0
+export VLLM_USE_MODELSCOPE=1
+
+vllm serve Qwen/Qwen2-1.5B-Instruct \
+  -tp 1 \
+  --trust-remote-code
+```
 ### Qwen2-7B-Instruct IFB BW1100 1x vLLM 0.18
 ```bash
 export VLLM_USE_MODELSCOPE=1
@@ -105,6 +186,17 @@ vllm serve Qwen/Qwen2-7B-Instruct \
   --trust-remote-code
 ```
 
+### Qwen2-7B-Instruct IFB BW1100 1x vLLM 0.18-hotfix
+
+```bash
+export VLLM_HCU_USE_PD_SPLIT=1
+export VLLM_USE_MODELSCOPE=1
+
+vllm serve Qwen/Qwen2-7B-Instruct \
+  -tp 1 \
+  --trust-remote-code \
+  --attention-backend FLASH_ATTN_CUSTOM
+```
 ### Qwen2-7B-Instruct IFB BW1000 1x vLLM 0.18
 ```bash
 export VLLM_USE_MODELSCOPE=1
@@ -116,6 +208,17 @@ vllm serve Qwen/Qwen2-7B-Instruct \
   --trust-remote-code
 ```
 
+### Qwen2-7B-Instruct IFB BW1000 1x vLLM 0.18-hotfix
+
+```bash
+export VLLM_HCU_USE_PD_SPLIT=1
+export VLLM_USE_MODELSCOPE=1
+
+vllm serve Qwen/Qwen2-7B-Instruct \
+  -tp 1 \
+  --trust-remote-code \
+  --attention-backend FLASH_ATTN_CUSTOM
+```
 ### Qwen2-7B-Instruct IFB K100_AI 1x vLLM 0.18
 ```bash
 export VLLM_HCU_USE_CUSTOM_QUANTIZATION_GEMM=0
@@ -128,6 +231,17 @@ vllm serve Qwen/Qwen2-7B-Instruct \
   --trust-remote-code
 ```
 
+### Qwen2-7B-Instruct IFB K100_AI 1x vLLM 0.18-hotfix
+
+```bash
+export VLLM_HCU_USE_CUSTOM_QUANTIZATION_GEMM=0
+export VLLM_HCU_USE_CUSTOM_OPS=0
+export VLLM_USE_MODELSCOPE=1
+
+vllm serve Qwen/Qwen2-7B-Instruct \
+  -tp 1 \
+  --trust-remote-code
+```
 ### Qwen2-57B-A14B-Instruct IFB BW1100 2x vLLM 0.18
 ```bash
 export VLLM_USE_MODELSCOPE=1
@@ -139,6 +253,17 @@ vllm serve Qwen/Qwen2-57B-A14B-Instruct \
   --trust-remote-code
 ```
 
+### Qwen2-57B-A14B-Instruct IFB BW1100 2x vLLM 0.18-hotfix
+
+```bash
+export VLLM_HCU_USE_PD_SPLIT=1
+export VLLM_USE_MODELSCOPE=1
+
+vllm serve Qwen/Qwen2-57B-A14B-Instruct \
+  -tp 2 \
+  --trust-remote-code \
+  --attention-backend FLASH_ATTN_CUSTOM
+```
 ### Qwen2-57B-A14B-Instruct IFB BW1000 4x vLLM 0.18
 ```bash
 export VLLM_USE_MODELSCOPE=1
@@ -150,6 +275,17 @@ vllm serve Qwen/Qwen2-57B-A14B-Instruct \
   --trust-remote-code
 ```
 
+### Qwen2-57B-A14B-Instruct IFB BW1000 4x vLLM 0.18-hotfix
+
+```bash
+export VLLM_HCU_USE_PD_SPLIT=1
+export VLLM_USE_MODELSCOPE=1
+
+vllm serve Qwen/Qwen2-57B-A14B-Instruct \
+  -tp 4 \
+  --trust-remote-code \
+  --attention-backend FLASH_ATTN_CUSTOM
+```
 ### Qwen2-57B-A14B-Instruct IFB K100_AI 4x vLLM 0.18
 ```bash
 export VLLM_HCU_USE_CUSTOM_QUANTIZATION_GEMM=0
@@ -162,6 +298,17 @@ vllm serve Qwen/Qwen2-57B-A14B-Instruct \
   --trust-remote-code
 ```
 
+### Qwen2-57B-A14B-Instruct IFB K100_AI 4x vLLM 0.18-hotfix
+
+```bash
+export VLLM_HCU_USE_CUSTOM_QUANTIZATION_GEMM=0
+export VLLM_HCU_USE_CUSTOM_OPS=0
+export VLLM_USE_MODELSCOPE=1
+
+vllm serve Qwen/Qwen2-57B-A14B-Instruct \
+  -tp 4 \
+  --trust-remote-code
+```
 ### Qwen2-72B-Instruct IFB BW1100 2x vLLM 0.18
 ```bash
 export VLLM_USE_MODELSCOPE=1
@@ -173,6 +320,17 @@ vllm serve Qwen/Qwen2-72B-Instruct \
   --trust-remote-code
 ```
 
+### Qwen2-72B-Instruct IFB BW1100 2x vLLM 0.18-hotfix
+
+```bash
+export VLLM_HCU_USE_PD_SPLIT=1
+export VLLM_USE_MODELSCOPE=1
+
+vllm serve Qwen/Qwen2-72B-Instruct \
+  -tp 2 \
+  --trust-remote-code \
+  --attention-backend FLASH_ATTN_CUSTOM
+```
 ### Qwen2-72B-Instruct IFB BW1000 4x vLLM 0.18
 ```bash
 export VLLM_USE_MODELSCOPE=1
@@ -184,6 +342,17 @@ vllm serve Qwen/Qwen2-72B-Instruct \
   --trust-remote-code
 ```
 
+### Qwen2-72B-Instruct IFB BW1000 4x vLLM 0.18-hotfix
+
+```bash
+export VLLM_HCU_USE_PD_SPLIT=1
+export VLLM_USE_MODELSCOPE=1
+
+vllm serve Qwen/Qwen2-72B-Instruct \
+  -tp 4 \
+  --trust-remote-code \
+  --attention-backend FLASH_ATTN_CUSTOM
+```
 ### Qwen2-72B-Instruct IFB K100_AI 4x vLLM 0.18
 ```bash
 export VLLM_HCU_USE_CUSTOM_QUANTIZATION_GEMM=0
@@ -196,6 +365,17 @@ vllm serve Qwen/Qwen2-72B-Instruct \
   --trust-remote-code
 ```
 
+### Qwen2-72B-Instruct IFB K100_AI 4x vLLM 0.18-hotfix
+
+```bash
+export VLLM_HCU_USE_CUSTOM_QUANTIZATION_GEMM=0
+export VLLM_HCU_USE_CUSTOM_OPS=0
+export VLLM_USE_MODELSCOPE=1
+
+vllm serve Qwen/Qwen2-72B-Instruct \
+  -tp 4 \
+  --trust-remote-code
+```
 ## API 调用
 
 ### IFB

--- a/docs/model-deployment/vllm/qwen3-vl.md
+++ b/docs/model-deployment/vllm/qwen3-vl.md
@@ -21,38 +21,71 @@ Qwen3-VL 是阿里云推出的新一代多模态视觉语言模型（Vision-Lang
 | 模型权重 | 量化方式 | vLLM 版本 | 推荐硬件 | 卡数 | 部署方式 | 启动命令 |
 | -------- | -------- | --------- | -------- | ---- | -------- | -------- |
 | [Qwen/Qwen3-VL-2B-Instruct](https://www.modelscope.cn/models/Qwen/Qwen3-VL-2B-Instruct) | BF16 | 0.18 | BW1100  | 1x | IFB | [**`>_`**](#qwen3-vl-2b-instruct-ifb-bw1100-1x-vllm-018) |
+|  | BF16 | 0.18-hotfix | BW1100 | 1x | IFB | [**`>_`**](#qwen3-vl-2b-instruct-ifb-bw1100-1x-vllm-018-hotfix) |
 |                                                                               | BF16      | 0.18 | BW1000  | 1x | IFB | [**`>_`**](#qwen3-vl-2b-instruct-ifb-bw1000-1x-vllm-018) |
+|  | BF16 | 0.18-hotfix | BW1000 | 1x | IFB | [**`>_`**](#qwen3-vl-2b-instruct-ifb-bw1000-1x-vllm-018-hotfix) |
 |                                                                               | BF16      | 0.18 | K100_AI | 1x | IFB | [**`>_`**](#qwen3-vl-2b-instruct-ifb-k100_ai-1x-vllm-018) |
+|  | BF16 | 0.18-hotfix | K100_AI | 1x | IFB | [**`>_`**](#qwen3-vl-2b-instruct-ifb-k100_ai-1x-vllm-018-hotfix) |
 | [Qwen/Qwen3-VL-2B-Thinking](https://www.modelscope.cn/models/Qwen/Qwen3-VL-2B-Thinking) | BF16 | 0.18 | BW1100  | 1x | IFB | [**`>_`**](#qwen3-vl-2b-thinking-ifb-bw1100-1x-vllm-018) |
+|  | BF16 | 0.18-hotfix | BW1100 | 1x | IFB | [**`>_`**](#qwen3-vl-2b-thinking-ifb-bw1100-1x-vllm-018-hotfix) |
 |                                                                               | BF16      | 0.18 | BW1000  | 1x | IFB | [**`>_`**](#qwen3-vl-2b-thinking-ifb-bw1000-1x-vllm-018) |
+|  | BF16 | 0.18-hotfix | BW1000 | 1x | IFB | [**`>_`**](#qwen3-vl-2b-thinking-ifb-bw1000-1x-vllm-018-hotfix) |
 |                                                                               | BF16      | 0.18 | K100_AI | 1x | IFB | [**`>_`**](#qwen3-vl-2b-thinking-ifb-k100_ai-1x-vllm-018) |
+|  | BF16 | 0.18-hotfix | K100_AI | 1x | IFB | [**`>_`**](#qwen3-vl-2b-thinking-ifb-k100_ai-1x-vllm-018-hotfix) |
 | [Qwen/Qwen3-VL-4B-Instruct](https://www.modelscope.cn/models/Qwen/Qwen3-VL-4B-Instruct) | BF16 | 0.18 | BW1100  | 1x | IFB | [**`>_`**](#qwen3-vl-4b-instruct-ifb-bw1100-1x-vllm-018) |
+|  | BF16 | 0.18-hotfix | BW1100 | 1x | IFB | [**`>_`**](#qwen3-vl-4b-instruct-ifb-bw1100-1x-vllm-018-hotfix) |
 |                                                                               | BF16      | 0.18 | BW1000  | 1x | IFB | [**`>_`**](#qwen3-vl-4b-instruct-ifb-bw1000-1x-vllm-018) |
+|  | BF16 | 0.18-hotfix | BW1000 | 1x | IFB | [**`>_`**](#qwen3-vl-4b-instruct-ifb-bw1000-1x-vllm-018-hotfix) |
 |                                                                               | BF16      | 0.18 | K100_AI | 1x | IFB | [**`>_`**](#qwen3-vl-4b-instruct-ifb-k100_ai-1x-vllm-018) |
+|  | BF16 | 0.18-hotfix | K100_AI | 1x | IFB | [**`>_`**](#qwen3-vl-4b-instruct-ifb-k100_ai-1x-vllm-018-hotfix) |
 | [Qwen/Qwen3-VL-4B-Thinking](https://www.modelscope.cn/models/Qwen/Qwen3-VL-4B-Thinking) | BF16 | 0.18 | BW1100  | 1x | IFB | [**`>_`**](#qwen3-vl-4b-thinking-ifb-bw1100-1x-vllm-018) |
+|  | BF16 | 0.18-hotfix | BW1100 | 1x | IFB | [**`>_`**](#qwen3-vl-4b-thinking-ifb-bw1100-1x-vllm-018-hotfix) |
 |                                                                               | BF16      | 0.18 | BW1000  | 1x | IFB | [**`>_`**](#qwen3-vl-4b-thinking-ifb-bw1000-1x-vllm-018) |
+|  | BF16 | 0.18-hotfix | BW1000 | 1x | IFB | [**`>_`**](#qwen3-vl-4b-thinking-ifb-bw1000-1x-vllm-018-hotfix) |
 |                                                                               | BF16      | 0.18 | K100_AI | 1x | IFB | [**`>_`**](#qwen3-vl-4b-thinking-ifb-k100_ai-1x-vllm-018) |
+|  | BF16 | 0.18-hotfix | K100_AI | 1x | IFB | [**`>_`**](#qwen3-vl-4b-thinking-ifb-k100_ai-1x-vllm-018-hotfix) |
 | [Qwen/Qwen3-VL-8B-Instruct](https://www.modelscope.cn/models/Qwen/Qwen3-VL-8B-Instruct) | BF16 | 0.18 | BW1100  | 1x | IFB | [**`>_`**](#qwen3-vl-8b-instruct-ifb-bw1100-1x-vllm-018) |
+|  | BF16 | 0.18-hotfix | BW1100 | 1x | IFB | [**`>_`**](#qwen3-vl-8b-instruct-ifb-bw1100-1x-vllm-018-hotfix) |
 |                                                                               | BF16      | 0.18 | BW1000  | 1x | IFB | [**`>_`**](#qwen3-vl-8b-instruct-ifb-bw1000-1x-vllm-018) |
+|  | BF16 | 0.18-hotfix | BW1000 | 1x | IFB | [**`>_`**](#qwen3-vl-8b-instruct-ifb-bw1000-1x-vllm-018-hotfix) |
 |                                                                               | BF16      | 0.18 | K100_AI | 1x | IFB | [**`>_`**](#qwen3-vl-8b-instruct-ifb-k100_ai-1x-vllm-018) |
+|  | BF16 | 0.18-hotfix | K100_AI | 1x | IFB | [**`>_`**](#qwen3-vl-8b-instruct-ifb-k100_ai-1x-vllm-018-hotfix) |
 | [Qwen/Qwen3-VL-8B-Thinking](https://www.modelscope.cn/models/Qwen/Qwen3-VL-8B-Thinking) | BF16 | 0.18 | BW1100  | 1x | IFB | [**`>_`**](#qwen3-vl-8b-thinking-ifb-bw1100-1x-vllm-018) |
+|  | BF16 | 0.18-hotfix | BW1100 | 1x | IFB | [**`>_`**](#qwen3-vl-8b-thinking-ifb-bw1100-1x-vllm-018-hotfix) |
 |                                                                               | BF16      | 0.18 | BW1000  | 1x | IFB | [**`>_`**](#qwen3-vl-8b-thinking-ifb-bw1000-1x-vllm-018) |
+|  | BF16 | 0.18-hotfix | BW1000 | 1x | IFB | [**`>_`**](#qwen3-vl-8b-thinking-ifb-bw1000-1x-vllm-018-hotfix) |
 |                                                                               | BF16      | 0.18 | K100_AI | 1x | IFB | [**`>_`**](#qwen3-vl-8b-thinking-ifb-k100_ai-1x-vllm-018) |
+|  | BF16 | 0.18-hotfix | K100_AI | 1x | IFB | [**`>_`**](#qwen3-vl-8b-thinking-ifb-k100_ai-1x-vllm-018-hotfix) |
 | [Qwen/Qwen3-VL-30B-A3B-Instruct](https://www.modelscope.cn/models/Qwen/Qwen3-VL-30B-A3B-Instruct) | BF16 | 0.18 | BW1100  | 1x | IFB | [**`>_`**](#qwen3-vl-30b-a3b-instruct-ifb-bw1100-1x-vllm-018) |
+|  | BF16 | 0.18-hotfix | BW1100 | 1x | IFB | [**`>_`**](#qwen3-vl-30b-a3b-instruct-ifb-bw1100-1x-vllm-018-hotfix) |
 |                                                                               | BF16      | 0.18 | BW1000  | 2x | IFB | [**`>_`**](#qwen3-vl-30b-a3b-instruct-ifb-bw1000-2x-vllm-018) |
+|  | BF16 | 0.18-hotfix | BW1000 | 2x | IFB | [**`>_`**](#qwen3-vl-30b-a3b-instruct-ifb-bw1000-2x-vllm-018-hotfix) |
 |                                                                               | BF16      | 0.18 | K100_AI | 2x | IFB | [**`>_`**](#qwen3-vl-30b-a3b-instruct-ifb-k100_ai-2x-vllm-018) |
+|  | BF16 | 0.18-hotfix | K100_AI | 2x | IFB | [**`>_`**](#qwen3-vl-30b-a3b-instruct-ifb-k100_ai-2x-vllm-018-hotfix) |
 | [Qwen/Qwen3-VL-30B-A3B-Thinking](https://www.modelscope.cn/models/Qwen/Qwen3-VL-30B-A3B-Thinking) | BF16 | 0.18 | BW1100  | 1x | IFB | [**`>_`**](#qwen3-vl-30b-a3b-thinking-ifb-bw1100-1x-vllm-018) |
+|  | BF16 | 0.18-hotfix | BW1100 | 1x | IFB | [**`>_`**](#qwen3-vl-30b-a3b-thinking-ifb-bw1100-1x-vllm-018-hotfix) |
 |                                                                               | BF16      | 0.18 | BW1000  | 2x | IFB | [**`>_`**](#qwen3-vl-30b-a3b-thinking-ifb-bw1000-2x-vllm-018) |
+|  | BF16 | 0.18-hotfix | BW1000 | 2x | IFB | [**`>_`**](#qwen3-vl-30b-a3b-thinking-ifb-bw1000-2x-vllm-018-hotfix) |
 |                                                                               | BF16      | 0.18 | K100_AI | 2x | IFB | [**`>_`**](#qwen3-vl-30b-a3b-thinking-ifb-k100_ai-2x-vllm-018) |
+|  | BF16 | 0.18-hotfix | K100_AI | 2x | IFB | [**`>_`**](#qwen3-vl-30b-a3b-thinking-ifb-k100_ai-2x-vllm-018-hotfix) |
 | [Qwen/Qwen3-VL-32B-Instruct](https://www.modelscope.cn/models/Qwen/Qwen3-VL-32B-Instruct) | BF16 | 0.18 | BW1100 | 1x | IFB | [**`>_`**](#qwen3-vl-32b-instruct-ifb-bw1100-1x-vllm-018) |
+|  | BF16 | 0.18-hotfix | BW1100 | 1x | IFB | [**`>_`**](#qwen3-vl-32b-instruct-ifb-bw1100-1x-vllm-018-hotfix) |
 |                                                                               | BF16 | 0.18 | BW1000 | 2x | IFB | [**`>_`**](#qwen3-vl-32b-instruct-ifb-bw1000-2x-vllm-018) |
+|  | BF16 | 0.18-hotfix | BW1000 | 2x | IFB | [**`>_`**](#qwen3-vl-32b-instruct-ifb-bw1000-2x-vllm-018-hotfix) |
 |                                                                               | BF16 | 0.18 | K100_AI | 2x | IFB | [**`>_`**](#qwen3-vl-32b-instruct-ifb-k100_ai-2x-vllm-018) |
+|  | BF16 | 0.18-hotfix | K100_AI | 2x | IFB | [**`>_`**](#qwen3-vl-32b-instruct-ifb-k100_ai-2x-vllm-018-hotfix) |
 | [Qwen/Qwen3-VL-235B-A22B-Instruct](https://www.modelscope.cn/models/Qwen/Qwen3-VL-235B-A22B-Instruct) | BF16 | 0.18 | BW1100  | 8x  | IFB | [**`>_`**](#qwen3-vl-235b-a22b-instruct-ifb-bw1100-8x-vllm-018) |
+|  | BF16 | 0.18-hotfix | BW1100 | 8x | IFB | [**`>_`**](#qwen3-vl-235b-a22b-instruct-ifb-bw1100-8x-vllm-018-hotfix) |
 |                                                                               | BF16      | 0.18 | BW1000  | 16x | IFB | [**`>_`**](#qwen3-vl-235b-a22b-instruct-ifb-bw1000-16x-vllm-018) |
+|  | BF16 | 0.18-hotfix | BW1000 | 16x | IFB | [**`>_`**](#qwen3-vl-235b-a22b-instruct-ifb-bw1000-16x-vllm-018-hotfix) |
 |                                                                               | BF16      | 0.18 | K100_AI | 16x | IFB | [**`>_`**](#qwen3-vl-235b-a22b-instruct-ifb-k100_ai-16x-vllm-018) |
+|  | BF16 | 0.18-hotfix | K100_AI | 16x | IFB | [**`>_`**](#qwen3-vl-235b-a22b-instruct-ifb-k100_ai-16x-vllm-018-hotfix) |
 | [Qwen/Qwen3-VL-235B-A22B-Thinking](https://www.modelscope.cn/models/Qwen/Qwen3-VL-235B-A22B-Thinking) | BF16 | 0.18 | BW1100  | 8x  | IFB | [**`>_`**](#qwen3-vl-235b-a22b-thinking-ifb-bw1100-8x-vllm-018) |
+|  | BF16 | 0.18-hotfix | BW1100 | 8x | IFB | [**`>_`**](#qwen3-vl-235b-a22b-thinking-ifb-bw1100-8x-vllm-018-hotfix) |
 |                                                                               | BF16      | 0.18 | BW1000  | 16x | IFB | [**`>_`**](#qwen3-vl-235b-a22b-thinking-ifb-bw1000-16x-vllm-018) |
+|  | BF16 | 0.18-hotfix | BW1000 | 16x | IFB | [**`>_`**](#qwen3-vl-235b-a22b-thinking-ifb-bw1000-16x-vllm-018-hotfix) |
 |                                                                               | BF16      | 0.18 | K100_AI | 16x | IFB | [**`>_`**](#qwen3-vl-235b-a22b-thinking-ifb-k100_ai-16x-vllm-018) |
+|  | BF16 | 0.18-hotfix | K100_AI | 16x | IFB | [**`>_`**](#qwen3-vl-235b-a22b-thinking-ifb-k100_ai-16x-vllm-018-hotfix) |
 
 ---
 
@@ -68,6 +101,16 @@ vllm serve Qwen/Qwen3-VL-2B-Instruct \
   --trust-remote-code 
 ```
 
+### Qwen3-VL-2B-Instruct IFB BW1100 1x vLLM 0.18-hotfix
+
+```bash
+export VLLM_HCU_USE_PD_SPLIT=1
+export VLLM_USE_MODELSCOPE=1
+vllm serve Qwen/Qwen3-VL-2B-Instruct \
+  -tp 1 \
+  --trust-remote-code \
+  --attention-backend FLASH_ATTN_CUSTOM
+```
 ### Qwen3-VL-2B-Instruct IFB BW1000 1x vLLM 0.18
 ```bash
 export VLLM_USE_MODELSCOPE=1
@@ -78,6 +121,16 @@ vllm serve Qwen/Qwen3-VL-2B-Instruct \
   --trust-remote-code 
 ```
 
+### Qwen3-VL-2B-Instruct IFB BW1000 1x vLLM 0.18-hotfix
+
+```bash
+export VLLM_HCU_USE_PD_SPLIT=1
+export VLLM_USE_MODELSCOPE=1
+vllm serve Qwen/Qwen3-VL-2B-Instruct \
+  -tp 1 \
+  --trust-remote-code \
+  --attention-backend FLASH_ATTN_CUSTOM
+```
 ### Qwen3-VL-2B-Instruct IFB K100_AI 1x vLLM 0.18
 ```bash
 export VLLM_HCU_USE_CUSTOM_QUANTIZATION_GEMM=0
@@ -88,6 +141,16 @@ vllm serve Qwen/Qwen3-VL-2B-Instruct \
   --trust-remote-code 
 ```
 
+### Qwen3-VL-2B-Instruct IFB K100_AI 1x vLLM 0.18-hotfix
+
+```bash
+export VLLM_HCU_USE_CUSTOM_QUANTIZATION_GEMM=0
+export VLLM_HCU_USE_CUSTOM_OPS=0
+export VLLM_USE_MODELSCOPE=1
+vllm serve Qwen/Qwen3-VL-2B-Instruct \
+  -tp 1 \
+  --trust-remote-code 
+```
 ### Qwen3-VL-2B-Thinking IFB BW1100 1x vLLM 0.18
 ```bash
 export VLLM_USE_MODELSCOPE=1
@@ -98,6 +161,16 @@ vllm serve Qwen/Qwen3-VL-2B-Thinking \
   --trust-remote-code 
 ```
 
+### Qwen3-VL-2B-Thinking IFB BW1100 1x vLLM 0.18-hotfix
+
+```bash
+export VLLM_HCU_USE_PD_SPLIT=1
+export VLLM_USE_MODELSCOPE=1
+vllm serve Qwen/Qwen3-VL-2B-Thinking \
+  -tp 1 \
+  --trust-remote-code \
+  --attention-backend FLASH_ATTN_CUSTOM
+```
 ### Qwen3-VL-2B-Thinking IFB BW1000 1x vLLM 0.18
 ```bash
 export VLLM_USE_MODELSCOPE=1
@@ -108,6 +181,16 @@ vllm serve Qwen/Qwen3-VL-2B-Thinking \
   --trust-remote-code 
 ```
 
+### Qwen3-VL-2B-Thinking IFB BW1000 1x vLLM 0.18-hotfix
+
+```bash
+export VLLM_HCU_USE_PD_SPLIT=1
+export VLLM_USE_MODELSCOPE=1
+vllm serve Qwen/Qwen3-VL-2B-Thinking \
+  -tp 1 \
+  --trust-remote-code \
+  --attention-backend FLASH_ATTN_CUSTOM
+```
 ### Qwen3-VL-2B-Thinking IFB K100_AI 1x vLLM 0.18
 ```bash
 export VLLM_HCU_USE_CUSTOM_QUANTIZATION_GEMM=0
@@ -118,6 +201,16 @@ vllm serve Qwen/Qwen3-VL-2B-Thinking \
   --trust-remote-code 
 ```
 
+### Qwen3-VL-2B-Thinking IFB K100_AI 1x vLLM 0.18-hotfix
+
+```bash
+export VLLM_HCU_USE_CUSTOM_QUANTIZATION_GEMM=0
+export VLLM_HCU_USE_CUSTOM_OPS=0
+export VLLM_USE_MODELSCOPE=1
+vllm serve Qwen/Qwen3-VL-2B-Thinking \
+  -tp 1 \
+  --trust-remote-code 
+```
 ### Qwen3-VL-4B-Instruct IFB BW1100 1x vLLM 0.18
 ```bash
 export VLLM_USE_MODELSCOPE=1
@@ -128,6 +221,16 @@ vllm serve Qwen/Qwen3-VL-4B-Instruct \
   --trust-remote-code 
 ```
 
+### Qwen3-VL-4B-Instruct IFB BW1100 1x vLLM 0.18-hotfix
+
+```bash
+export VLLM_HCU_USE_PD_SPLIT=1
+export VLLM_USE_MODELSCOPE=1
+vllm serve Qwen/Qwen3-VL-4B-Instruct \
+  -tp 1 \
+  --trust-remote-code \
+  --attention-backend FLASH_ATTN_CUSTOM
+```
 ### Qwen3-VL-4B-Instruct IFB BW1000 1x vLLM 0.18
 ```bash
 export VLLM_USE_MODELSCOPE=1
@@ -138,6 +241,16 @@ vllm serve Qwen/Qwen3-VL-4B-Instruct \
   --trust-remote-code 
 ```
 
+### Qwen3-VL-4B-Instruct IFB BW1000 1x vLLM 0.18-hotfix
+
+```bash
+export VLLM_HCU_USE_PD_SPLIT=1
+export VLLM_USE_MODELSCOPE=1
+vllm serve Qwen/Qwen3-VL-4B-Instruct \
+  -tp 1 \
+  --trust-remote-code \
+  --attention-backend FLASH_ATTN_CUSTOM
+```
 ### Qwen3-VL-4B-Instruct IFB K100_AI 1x vLLM 0.18
 ```bash
 export VLLM_HCU_USE_CUSTOM_QUANTIZATION_GEMM=0
@@ -148,6 +261,16 @@ vllm serve Qwen/Qwen3-VL-4B-Instruct \
   --trust-remote-code 
 ```
 
+### Qwen3-VL-4B-Instruct IFB K100_AI 1x vLLM 0.18-hotfix
+
+```bash
+export VLLM_HCU_USE_CUSTOM_QUANTIZATION_GEMM=0
+export VLLM_HCU_USE_CUSTOM_OPS=0
+export VLLM_USE_MODELSCOPE=1
+vllm serve Qwen/Qwen3-VL-4B-Instruct \
+  -tp 1 \
+  --trust-remote-code 
+```
 ### Qwen3-VL-4B-Thinking IFB BW1100 1x vLLM 0.18
 ```bash
 export VLLM_USE_MODELSCOPE=1
@@ -158,6 +281,16 @@ vllm serve Qwen/Qwen3-VL-4B-Thinking \
   --trust-remote-code 
 ```
 
+### Qwen3-VL-4B-Thinking IFB BW1100 1x vLLM 0.18-hotfix
+
+```bash
+export VLLM_HCU_USE_PD_SPLIT=1
+export VLLM_USE_MODELSCOPE=1
+vllm serve Qwen/Qwen3-VL-4B-Thinking \
+  -tp 1 \
+  --trust-remote-code \
+  --attention-backend FLASH_ATTN_CUSTOM
+```
 ### Qwen3-VL-4B-Thinking IFB BW1000 1x vLLM 0.18
 ```bash
 export VLLM_USE_MODELSCOPE=1
@@ -168,6 +301,16 @@ vllm serve Qwen/Qwen3-VL-4B-Thinking \
   --trust-remote-code 
 ```
 
+### Qwen3-VL-4B-Thinking IFB BW1000 1x vLLM 0.18-hotfix
+
+```bash
+export VLLM_HCU_USE_PD_SPLIT=1
+export VLLM_USE_MODELSCOPE=1
+vllm serve Qwen/Qwen3-VL-4B-Thinking \
+  -tp 1 \
+  --trust-remote-code \
+  --attention-backend FLASH_ATTN_CUSTOM
+```
 ### Qwen3-VL-4B-Thinking IFB K100_AI 1x vLLM 0.18
 ```bash
 export VLLM_HCU_USE_CUSTOM_QUANTIZATION_GEMM=0
@@ -178,6 +321,16 @@ vllm serve Qwen/Qwen3-VL-4B-Thinking \
   --trust-remote-code 
 ```
 
+### Qwen3-VL-4B-Thinking IFB K100_AI 1x vLLM 0.18-hotfix
+
+```bash
+export VLLM_HCU_USE_CUSTOM_QUANTIZATION_GEMM=0
+export VLLM_HCU_USE_CUSTOM_OPS=0
+export VLLM_USE_MODELSCOPE=1
+vllm serve Qwen/Qwen3-VL-4B-Thinking \
+  -tp 1 \
+  --trust-remote-code 
+```
 ### Qwen3-VL-8B-Instruct IFB BW1100 1x vLLM 0.18
 ```bash
 export VLLM_USE_MODELSCOPE=1
@@ -188,6 +341,16 @@ vllm serve Qwen/Qwen3-VL-8B-Instruct \
   --trust-remote-code 
 ```
 
+### Qwen3-VL-8B-Instruct IFB BW1100 1x vLLM 0.18-hotfix
+
+```bash
+export VLLM_HCU_USE_PD_SPLIT=1
+export VLLM_USE_MODELSCOPE=1
+vllm serve Qwen/Qwen3-VL-8B-Instruct \
+  -tp 1 \
+  --trust-remote-code \
+  --attention-backend FLASH_ATTN_CUSTOM
+```
 ### Qwen3-VL-8B-Instruct IFB BW1000 1x vLLM 0.18
 ```bash
 export VLLM_USE_MODELSCOPE=1
@@ -198,6 +361,16 @@ vllm serve Qwen/Qwen3-VL-8B-Instruct \
   --trust-remote-code 
 ```
 
+### Qwen3-VL-8B-Instruct IFB BW1000 1x vLLM 0.18-hotfix
+
+```bash
+export VLLM_HCU_USE_PD_SPLIT=1
+export VLLM_USE_MODELSCOPE=1
+vllm serve Qwen/Qwen3-VL-8B-Instruct \
+  -tp 1 \
+  --trust-remote-code \
+  --attention-backend FLASH_ATTN_CUSTOM
+```
 ### Qwen3-VL-8B-Instruct IFB K100_AI 1x vLLM 0.18
 ```bash
 export VLLM_HCU_USE_CUSTOM_QUANTIZATION_GEMM=0
@@ -208,6 +381,16 @@ vllm serve Qwen/Qwen3-VL-8B-Instruct \
   --trust-remote-code 
 ```
 
+### Qwen3-VL-8B-Instruct IFB K100_AI 1x vLLM 0.18-hotfix
+
+```bash
+export VLLM_HCU_USE_CUSTOM_QUANTIZATION_GEMM=0
+export VLLM_HCU_USE_CUSTOM_OPS=0
+export VLLM_USE_MODELSCOPE=1
+vllm serve Qwen/Qwen3-VL-8B-Instruct \
+  -tp 1 \
+  --trust-remote-code 
+```
 ### Qwen3-VL-8B-Thinking IFB BW1100 1x vLLM 0.18
 ```bash
 export VLLM_USE_MODELSCOPE=1
@@ -218,6 +401,16 @@ vllm serve Qwen/Qwen3-VL-8B-Thinking \
   --trust-remote-code 
 ```
 
+### Qwen3-VL-8B-Thinking IFB BW1100 1x vLLM 0.18-hotfix
+
+```bash
+export VLLM_HCU_USE_PD_SPLIT=1
+export VLLM_USE_MODELSCOPE=1
+vllm serve Qwen/Qwen3-VL-8B-Thinking \
+  -tp 1 \
+  --trust-remote-code \
+  --attention-backend FLASH_ATTN_CUSTOM
+```
 ### Qwen3-VL-8B-Thinking IFB BW1000 1x vLLM 0.18
 ```bash
 export VLLM_USE_MODELSCOPE=1
@@ -228,6 +421,16 @@ vllm serve Qwen/Qwen3-VL-8B-Thinking \
   --trust-remote-code 
 ```
 
+### Qwen3-VL-8B-Thinking IFB BW1000 1x vLLM 0.18-hotfix
+
+```bash
+export VLLM_HCU_USE_PD_SPLIT=1
+export VLLM_USE_MODELSCOPE=1
+vllm serve Qwen/Qwen3-VL-8B-Thinking \
+  -tp 1 \
+  --trust-remote-code \
+  --attention-backend FLASH_ATTN_CUSTOM
+```
 ### Qwen3-VL-8B-Thinking IFB K100_AI 1x vLLM 0.18
 ```bash
 export VLLM_HCU_USE_CUSTOM_QUANTIZATION_GEMM=0
@@ -238,6 +441,16 @@ vllm serve Qwen/Qwen3-VL-8B-Thinking \
   --trust-remote-code 
 ```
 
+### Qwen3-VL-8B-Thinking IFB K100_AI 1x vLLM 0.18-hotfix
+
+```bash
+export VLLM_HCU_USE_CUSTOM_QUANTIZATION_GEMM=0
+export VLLM_HCU_USE_CUSTOM_OPS=0
+export VLLM_USE_MODELSCOPE=1
+vllm serve Qwen/Qwen3-VL-8B-Thinking \
+  -tp 1 \
+  --trust-remote-code 
+```
 ### Qwen3-VL-30B-A3B-Instruct IFB BW1100 1x vLLM 0.18
 ```bash
 export VLLM_USE_MODELSCOPE=1
@@ -248,6 +461,16 @@ vllm serve Qwen/Qwen3-VL-30B-A3B-Instruct \
   --trust-remote-code 
 ```
 
+### Qwen3-VL-30B-A3B-Instruct IFB BW1100 1x vLLM 0.18-hotfix
+
+```bash
+export VLLM_HCU_USE_PD_SPLIT=1
+export VLLM_USE_MODELSCOPE=1
+vllm serve Qwen/Qwen3-VL-30B-A3B-Instruct \
+  -tp 1 \
+  --trust-remote-code \
+  --attention-backend FLASH_ATTN_CUSTOM
+```
 ### Qwen3-VL-30B-A3B-Instruct IFB BW1000 2x vLLM 0.18
 ```bash
 export VLLM_USE_MODELSCOPE=1
@@ -258,6 +481,16 @@ vllm serve Qwen/Qwen3-VL-30B-A3B-Instruct \
   --trust-remote-code 
 ```
 
+### Qwen3-VL-30B-A3B-Instruct IFB BW1000 2x vLLM 0.18-hotfix
+
+```bash
+export VLLM_HCU_USE_PD_SPLIT=1
+export VLLM_USE_MODELSCOPE=1
+vllm serve Qwen/Qwen3-VL-30B-A3B-Instruct \
+  -tp 2 \
+  --trust-remote-code \
+  --attention-backend FLASH_ATTN_CUSTOM
+```
 ### Qwen3-VL-30B-A3B-Instruct IFB K100_AI 2x vLLM 0.18
 ```bash
 export VLLM_HCU_USE_CUSTOM_QUANTIZATION_GEMM=0
@@ -268,6 +501,16 @@ vllm serve Qwen/Qwen3-VL-30B-A3B-Instruct \
   --trust-remote-code 
 ```
 
+### Qwen3-VL-30B-A3B-Instruct IFB K100_AI 2x vLLM 0.18-hotfix
+
+```bash
+export VLLM_HCU_USE_CUSTOM_QUANTIZATION_GEMM=0
+export VLLM_HCU_USE_CUSTOM_OPS=0
+export VLLM_USE_MODELSCOPE=1
+vllm serve Qwen/Qwen3-VL-30B-A3B-Instruct \
+  -tp 2 \
+  --trust-remote-code 
+```
 ### Qwen3-VL-30B-A3B-Thinking IFB BW1100 1x vLLM 0.18
 ```bash
 export VLLM_USE_MODELSCOPE=1
@@ -278,6 +521,16 @@ vllm serve Qwen/Qwen3-VL-30B-A3B-Thinking \
   --trust-remote-code 
 ```
 
+### Qwen3-VL-30B-A3B-Thinking IFB BW1100 1x vLLM 0.18-hotfix
+
+```bash
+export VLLM_HCU_USE_PD_SPLIT=1
+export VLLM_USE_MODELSCOPE=1
+vllm serve Qwen/Qwen3-VL-30B-A3B-Thinking \
+  -tp 1 \
+  --trust-remote-code \
+  --attention-backend FLASH_ATTN_CUSTOM
+```
 ### Qwen3-VL-30B-A3B-Thinking IFB BW1000 2x vLLM 0.18
 ```bash
 export VLLM_USE_MODELSCOPE=1
@@ -288,6 +541,16 @@ vllm serve Qwen/Qwen3-VL-30B-A3B-Thinking \
   --trust-remote-code 
 ```
 
+### Qwen3-VL-30B-A3B-Thinking IFB BW1000 2x vLLM 0.18-hotfix
+
+```bash
+export VLLM_HCU_USE_PD_SPLIT=1
+export VLLM_USE_MODELSCOPE=1
+vllm serve Qwen/Qwen3-VL-30B-A3B-Thinking \
+  -tp 2 \
+  --trust-remote-code \
+  --attention-backend FLASH_ATTN_CUSTOM
+```
 ### Qwen3-VL-30B-A3B-Thinking IFB K100_AI 2x vLLM 0.18
 ```bash
 export VLLM_HCU_USE_CUSTOM_QUANTIZATION_GEMM=0
@@ -298,6 +561,16 @@ vllm serve Qwen/Qwen3-VL-30B-A3B-Thinking \
   --trust-remote-code 
 ```
 
+### Qwen3-VL-30B-A3B-Thinking IFB K100_AI 2x vLLM 0.18-hotfix
+
+```bash
+export VLLM_HCU_USE_CUSTOM_QUANTIZATION_GEMM=0
+export VLLM_HCU_USE_CUSTOM_OPS=0
+export VLLM_USE_MODELSCOPE=1
+vllm serve Qwen/Qwen3-VL-30B-A3B-Thinking \
+  -tp 2 \
+  --trust-remote-code 
+```
 ### Qwen3-VL-32B-Instruct IFB BW1100 1x vLLM 0.18
 ```bash
 export VLLM_USE_MODELSCOPE=1
@@ -308,6 +581,16 @@ vllm serve Qwen/Qwen3-VL-32B-Instruct \
   --trust-remote-code 
 ```
 
+### Qwen3-VL-32B-Instruct IFB BW1100 1x vLLM 0.18-hotfix
+
+```bash
+export VLLM_HCU_USE_PD_SPLIT=1
+export VLLM_USE_MODELSCOPE=1
+vllm serve Qwen/Qwen3-VL-32B-Instruct \
+  -tp 1 \
+  --trust-remote-code \
+  --attention-backend FLASH_ATTN_CUSTOM
+```
 ### Qwen3-VL-32B-Instruct IFB BW1000 2x vLLM 0.18
 ```bash
 export VLLM_USE_MODELSCOPE=1
@@ -318,6 +601,16 @@ vllm serve Qwen/Qwen3-VL-32B-Instruct \
   --trust-remote-code 
 ```
 
+### Qwen3-VL-32B-Instruct IFB BW1000 2x vLLM 0.18-hotfix
+
+```bash
+export VLLM_HCU_USE_PD_SPLIT=1
+export VLLM_USE_MODELSCOPE=1
+vllm serve Qwen/Qwen3-VL-32B-Instruct \
+  -tp 2 \
+  --trust-remote-code \
+  --attention-backend FLASH_ATTN_CUSTOM
+```
 ### Qwen3-VL-32B-Instruct IFB K100_AI 2x vLLM 0.18
 ```bash
 export VLLM_HCU_USE_CUSTOM_QUANTIZATION_GEMM=0
@@ -328,6 +621,16 @@ vllm serve Qwen/Qwen3-VL-32B-Instruct \
   --trust-remote-code 
 ```
 
+### Qwen3-VL-32B-Instruct IFB K100_AI 2x vLLM 0.18-hotfix
+
+```bash
+export VLLM_HCU_USE_CUSTOM_QUANTIZATION_GEMM=0
+export VLLM_HCU_USE_CUSTOM_OPS=0
+export VLLM_USE_MODELSCOPE=1
+vllm serve Qwen/Qwen3-VL-32B-Instruct \
+  -tp 2 \
+  --trust-remote-code 
+```
 ### Qwen3-VL-235B-A22B-Instruct IFB BW1100 8x vLLM 0.18
 
 ```bash
@@ -339,6 +642,16 @@ vllm serve Qwen/Qwen3-VL-235B-A22B-Instruct \
   --trust-remote-code 
 ```
 
+### Qwen3-VL-235B-A22B-Instruct IFB BW1100 8x vLLM 0.18-hotfix
+
+```bash
+export VLLM_HCU_USE_PD_SPLIT=1
+export VLLM_USE_MODELSCOPE=1
+vllm serve Qwen/Qwen3-VL-235B-A22B-Instruct \
+  -tp 8 \
+  --trust-remote-code \
+  --attention-backend FLASH_ATTN_CUSTOM
+```
 ### Qwen3-VL-235B-A22B-Instruct IFB BW1000 16x vLLM 0.18
 ```bash
 export VLLM_USE_MODELSCOPE=1
@@ -348,6 +661,18 @@ vllm serve Qwen/Qwen3-VL-235B-A22B-Instruct \
   -tp 8 \
   -pp 2 \
   --trust-remote-code 
+```
+
+### Qwen3-VL-235B-A22B-Instruct IFB BW1000 16x vLLM 0.18-hotfix
+
+```bash
+export VLLM_HCU_USE_PD_SPLIT=1
+export VLLM_USE_MODELSCOPE=1
+vllm serve Qwen/Qwen3-VL-235B-A22B-Instruct \
+  -tp 8 \
+  -pp 2 \
+  --trust-remote-code \
+  --attention-backend FLASH_ATTN_CUSTOM
 ```
 ### Qwen3-VL-235B-A22B-Instruct IFB K100_AI 16x vLLM 0.18
 ```bash
@@ -360,6 +685,17 @@ vllm serve Qwen/Qwen3-VL-235B-A22B-Instruct \
   --trust-remote-code 
 ```
 
+### Qwen3-VL-235B-A22B-Instruct IFB K100_AI 16x vLLM 0.18-hotfix
+
+```bash
+export VLLM_HCU_USE_CUSTOM_QUANTIZATION_GEMM=0
+export VLLM_HCU_USE_CUSTOM_OPS=0
+export VLLM_USE_MODELSCOPE=1
+vllm serve Qwen/Qwen3-VL-235B-A22B-Instruct \
+  -tp 8 \
+  -pp 2 \
+  --trust-remote-code 
+```
 ### Qwen3-VL-235B-A22B-Thinking IFB BW1100 8x vLLM 0.18
 ```bash
 export VLLM_USE_MODELSCOPE=1
@@ -370,6 +706,16 @@ vllm serve Qwen/Qwen3-VL-235B-A22B-Thinking \
   --trust-remote-code 
 ```
 
+### Qwen3-VL-235B-A22B-Thinking IFB BW1100 8x vLLM 0.18-hotfix
+
+```bash
+export VLLM_HCU_USE_PD_SPLIT=1
+export VLLM_USE_MODELSCOPE=1
+vllm serve Qwen/Qwen3-VL-235B-A22B-Thinking \
+  -tp 8 \
+  --trust-remote-code \
+  --attention-backend FLASH_ATTN_CUSTOM
+```
 ### Qwen3-VL-235B-A22B-Thinking IFB BW1000 16x vLLM 0.18
 ```bash
 export VLLM_USE_MODELSCOPE=1
@@ -381,6 +727,17 @@ vllm serve Qwen/Qwen3-VL-235B-A22B-Thinking \
   --trust-remote-code 
 ```
 
+### Qwen3-VL-235B-A22B-Thinking IFB BW1000 16x vLLM 0.18-hotfix
+
+```bash
+export VLLM_HCU_USE_PD_SPLIT=1
+export VLLM_USE_MODELSCOPE=1
+vllm serve Qwen/Qwen3-VL-235B-A22B-Thinking \
+  -tp 8 \
+  -pp 2 \
+  --trust-remote-code \
+  --attention-backend FLASH_ATTN_CUSTOM
+```
 ### Qwen3-VL-235B-A22B-Thinking IFB K100_AI 16x vLLM 0.18
 ```bash
 export VLLM_HCU_USE_CUSTOM_QUANTIZATION_GEMM=0
@@ -392,6 +749,17 @@ vllm serve Qwen/Qwen3-VL-235B-A22B-Thinking \
   --trust-remote-code 
 ```
 
+### Qwen3-VL-235B-A22B-Thinking IFB K100_AI 16x vLLM 0.18-hotfix
+
+```bash
+export VLLM_HCU_USE_CUSTOM_QUANTIZATION_GEMM=0
+export VLLM_HCU_USE_CUSTOM_OPS=0
+export VLLM_USE_MODELSCOPE=1
+vllm serve Qwen/Qwen3-VL-235B-A22B-Thinking \
+  -tp 8 \
+  -pp 2 \
+  --trust-remote-code 
+```
 ## API 调用
 
 ### IFB

--- a/docs/model-deployment/vllm/qwen3.5.md
+++ b/docs/model-deployment/vllm/qwen3.5.md
@@ -9,37 +9,67 @@ Qwen3.5 是 Qwen3 系列的增强版本，在推理能力、代码生成、多�
 | 模型权重 | 量化方式 | vLLM 版本 | 推荐硬件 | 卡数 | 部署方式 | 启动命令 |
 | -------- | -------- | --------- | -------- | ---- | -------- | -------- |
 | [Qwen/Qwen3.5-4B](https://www.modelscope.cn/models/Qwen/Qwen3.5-4B)           | BF16      | 0.18 | BW1100  | 1 | IFB | [**`>_`**](#qwen35-4b-ifb-bw1100-1x-vllm-018)          |
+|  | BF16 | 0.18-hotfix | BW1100 | 1 | IFB | [**`>_`**](#qwen35-4b-ifb-bw1100-1x-vllm-018-hotfix) |
 |                                                                               | BF16      | 0.18 | BW1000  | 1 | IFB | [**`>_`**](#qwen35-4b-ifb-bw1000-1x-vllm-018)           |
+|                                                                               | BF16      | 0.18-hotfix | BW1000  | 1 | IFB | [**`>_`**](#qwen35-4b-ifb-bw1000-1x-vllm-018-hotfix) |
 |                                                                               | BF16      | 0.18 | K100_AI | 1 | IFB | [**`>_`**](#qwen35-4b-ifb-k100_ai-1x-vllm-018)           |
+|  | BF16 | 0.18-hotfix | K100_AI | 1 | IFB | [**`>_`**](#qwen35-4b-ifb-k100_ai-1x-vllm-018-hotfix) |
 | [Qwen/Qwen3.5-9B](https://www.modelscope.cn/models/Qwen/Qwen3.5-9B)           | BF16      | 0.18 | BW1100  | 1 | IFB | [**`>_`**](#qwen35-9b-ifb-bw1100-1x-vllm-018)          |
+|  | BF16 | 0.18-hotfix | BW1100 | 1 | IFB | [**`>_`**](#qwen35-9b-ifb-bw1100-1x-vllm-018-hotfix) |
 |                                                                               | BF16      | 0.18 | BW1000  | 1 | IFB | [**`>_`**](#qwen35-9b-ifb-bw1000-1x-vllm-018)           |
+|  | BF16 | 0.18-hotfix | BW1000 | 1 | IFB | [**`>_`**](#qwen35-9b-ifb-bw1000-1x-vllm-018-hotfix) |
 |                                                                               | BF16      | 0.18 | K100_AI | 1 | IFB | [**`>_`**](#qwen35-9b-ifb-k100_ai-1x-vllm-018)           |
+|  | BF16 | 0.18-hotfix | K100_AI | 1 | IFB | [**`>_`**](#qwen35-9b-ifb-k100_ai-1x-vllm-018-hotfix) |
 | [Qwen/Qwen3.5-27B](https://www.modelscope.cn/models/Qwen/Qwen3.5-27B)         | BF16      | 0.18 | BW1100  | 1 | IFB | [**`>_`**](#qwen35-27b-ifb-bw1100-1x-vllm-018)          |
+|  | BF16 | 0.18-hotfix | BW1100 | 1 | IFB | [**`>_`**](#qwen35-27b-ifb-bw1100-1x-vllm-018-hotfix) |
 |                                                                               | BF16      | 0.18 | BW1000  | 2 | IFB | [**`>_`**](#qwen35-27b-ifb-bw1000-2x-vllm-018)          |
+|  | BF16 | 0.18-hotfix | BW1000 | 2 | IFB | [**`>_`**](#qwen35-27b-ifb-bw1000-2x-vllm-018-hotfix) |
 |                                                                               | BF16      | 0.18 | K100_AI | 2 | IFB | [**`>_`**](#qwen35-27b-ifb-k100_ai-2x-vllm-018)          |
+|  | BF16 | 0.18-hotfix | K100_AI | 2 | IFB | [**`>_`**](#qwen35-27b-ifb-k100_ai-2x-vllm-018-hotfix) |
 | [hygon/Qwen3.5-27B-Channel-INT8-w8a8]() | INT8 W8A8 | 0.18 | BW1100  | 1 | IFB | [**`>_`**](#qwen35-27b-channel-int8-w8a8-ifb-bw1100-1x-vllm-018) |
+|  | INT8 W8A8 | 0.18-hotfix | BW1100 | 1 | IFB | [**`>_`**](#qwen35-27b-channel-int8-w8a8-ifb-bw1100-1x-vllm-018-hotfix) |
 |                                                                                              | INT8 W8A8 | 0.18 | BW1000  | 1 | IFB | [**`>_`**](#qwen35-27b-channel-int8-w8a8-ifb-bw1000-1x-vllm-018) |
+|  | INT8 W8A8 | 0.18-hotfix | BW1000 | 1 | IFB | [**`>_`**](#qwen35-27b-channel-int8-w8a8-ifb-bw1000-1x-vllm-018-hotfix) |
 |                                                                                              | INT8 W8A8 | 0.18 | K100_AI | 1 | IFB | [**`>_`**](#qwen35-27b-channel-int8-w8a8-ifb-k100_ai-1x-vllm-018) |
+|  | INT8 W8A8 | 0.18-hotfix | K100_AI | 1 | IFB | [**`>_`**](#qwen35-27b-channel-int8-w8a8-ifb-k100_ai-1x-vllm-018-hotfix) |
 | [Qwen/Qwen3.5-27B-W8A8-FP8](https://modelscope.cn/models/hygon/Qwen3.5-27B-Channel-FP8-w8a8) | FP8 W8A8  | 0.18 | BW1100  | 1 | IFB | [**`>_`**](#qwen35-27b-w8a8-fp8-ifb-bw1100-1x-vllm-018) |
 | [Qwen/Qwen3.5-35B-A3B](https://www.modelscope.cn/models/Qwen/Qwen3.5-35B-A3B) | BF16      | 0.18 | BW1100  | 1 | IFB | [**`>_`**](#qwen35-35b-a3b-ifb-bw1100-1x-vllm-018)     |
+|  | BF16 | 0.18-hotfix | BW1100 | 1 | IFB | [**`>_`**](#qwen35-35b-a3b-ifb-bw1100-1x-vllm-018-hotfix) |
 |                                                                               | BF16      | 0.18 | BW1000  | 2 | IFB | [**`>_`**](#qwen35-35b-a3b-ifb-bw1000-2x-vllm-018)      |
+|  | BF16 | 0.18-hotfix | BW1000 | 2 | IFB | [**`>_`**](#qwen35-35b-a3b-ifb-bw1000-2x-vllm-018-hotfix) |
 |                                                                               | BF16      | 0.18 | K100_AI | 2 | IFB | [**`>_`**](#qwen35-35b-a3b-ifb-k100_ai-2x-vllm-018)      |
+|  | BF16 | 0.18-hotfix | K100_AI | 2 | IFB | [**`>_`**](#qwen35-35b-a3b-ifb-k100_ai-2x-vllm-018-hotfix) |
 | [hygon/Qwen3.5-35B-A3B-Channel-INT8-w8a8](https://www.modelscope.cn/models/hygon/Qwen3.5-35B-A3B-Channel-INT8-w8a8) | INT8 W8A8 | 0.18 | BW1100  | 1 | IFB | [**`>_`**](#qwen35-35b-a3b-channel-int8-w8a8-ifb-bw1100-1x-vllm-018) |
+|  | INT8 W8A8 | 0.18-hotfix | BW1100 | 1 | IFB | [**`>_`**](#qwen35-35b-a3b-channel-int8-w8a8-ifb-bw1100-1x-vllm-018-hotfix) |
 |                                                                                              | INT8 W8A8 | 0.18 | BW1000  | 1 | IFB | [**`>_`**](#qwen35-35b-a3b-channel-int8-w8a8-ifb-bw1000-1x-vllm-018) |
+|  | INT8 W8A8 | 0.18-hotfix | BW1000 | 1 | IFB | [**`>_`**](#qwen35-35b-a3b-channel-int8-w8a8-ifb-bw1000-1x-vllm-018-hotfix) |
 |                                                                                              | INT8 W8A8 | 0.18 | K100_AI | 1 | IFB | [**`>_`**](#qwen35-35b-a3b-channel-int8-w8a8-ifb-k100_ai-1x-vllm-018) |
+|  | INT8 W8A8 | 0.18-hotfix | K100_AI | 1 | IFB | [**`>_`**](#qwen35-35b-a3b-channel-int8-w8a8-ifb-k100_ai-1x-vllm-018-hotfix) |
 | [hygon/Qwen3.5-35B-A3B-Channel-FP8-w8a8](https://www.modelscope.cn/models/hygon/Qwen3.5-35B-A3B-Channel-FP8-w8a8)       | FP8 W8A8  | 0.18 | BW1100  | 1 | IFB | [**`>_`**](#qwen35-35b-a3b-channel-fp8-w8a8-ifb-bw1100-1x-vllm-018) |
+|  | FP8 W8A8 | 0.18-hotfix | BW1100 | 1 | IFB | [**`>_`**](#qwen35-35b-a3b-channel-fp8-w8a8-ifb-bw1100-1x-vllm-018-hotfix) |
 | [Qwen/Qwen3.5-122B-A10B](https://www.modelscope.cn/models/Qwen/Qwen3.5-122B-A10B) | BF16   | 0.18 | BW1100  | 4 | IFB | [**`>_`**](#qwen35-122b-a10b-ifb-bw1100-4x-vllm-018)  |
+|  | BF16 | 0.18-hotfix | BW1100 | 4 | IFB | [**`>_`**](#qwen35-122b-a10b-ifb-bw1100-4x-vllm-018-hotfix) |
 |                                                                                  | BF16   | 0.18 | BW1000  | 8 | IFB | [**`>_`**](#qwen35-122b-a10b-ifb-bw1000-8x-vllm-018)   |
+|  | BF16 | 0.18-hotfix | BW1000 | 8 | IFB | [**`>_`**](#qwen35-122b-a10b-ifb-bw1000-8x-vllm-018-hotfix) |
 |                                                                                  | BF16   | 0.18 | K100_AI | 8 | IFB | [**`>_`**](#qwen35-122b-a10b-ifb-k100_ai-8x-vllm-018)   |
+|  | BF16 | 0.18-hotfix | K100_AI | 8 | IFB | [**`>_`**](#qwen35-122b-a10b-ifb-k100_ai-8x-vllm-018-hotfix) |
 | [Qwen/Qwen3.5-122B-A10B-AWQ](https://www.modelscope.cn/models/tclf90/Qwen3.5-122B-A10B-AWQ) | AWQ | 0.18 | K100_AI | 4 | IFB | [**`>_`**](#qwen35-122b-a10b-awq-ifb-k100_ai-4x-vllm-018) |
 | [Qwen/Qwen3.5-122B-A10B-W8A8-INT8](https://www.modelscope.cn/models/Qwen/Qwen3.5-122B-A10B-W8A8-INT8) | INT8 W8A8 | 0.18 | BW1100  | 2 | IFB | [**`>_`**](#qwen35-122b-a10b-w8a8-int8-ifb-bw1100-2x-vllm-018) |
+|  | INT8 W8A8 | 0.18-hotfix | BW1100 | 2 | IFB | [**`>_`**](#qwen35-122b-a10b-w8a8-int8-ifb-bw1100-2x-vllm-018-hotfix) |
 |                                                                                               | INT8 W8A8 | 0.18 | BW1000  | 4 | IFB | [**`>_`**](#qwen35-122b-a10b-w8a8-int8-ifb-bw1000-4x-vllm-018) |
+|  | INT8 W8A8 | 0.18-hotfix | BW1000 | 4 | IFB | [**`>_`**](#qwen35-122b-a10b-w8a8-int8-ifb-bw1000-4x-vllm-018-hotfix) |
 |                                                                                               | INT8 W8A8 | 0.18 | K100_AI | 4 | IFB | [**`>_`**](#qwen35-122b-a10b-w8a8-int8-ifb-k100_ai-4x-vllm-018) |
+|  | INT8 W8A8 | 0.18-hotfix | K100_AI | 4 | IFB | [**`>_`**](#qwen35-122b-a10b-w8a8-int8-ifb-k100_ai-4x-vllm-018-hotfix) |
 | [hygon/Qwen3.5-122B-A10B-Channel-FP8-w8a8](https://www.modelscope.cn/models/hygon/Qwen3.5-122B-A10B-Channel-FP8-w8a8)    | FP8 W8A8  | 0.18 | BW1100  | 2 | IFB | [**`>_`**](#qwen35-122b-a10b-channel-fp8-w8a8-ifb-bw1100-2x-vllm-018) |
+|  | FP8 W8A8 | 0.18-hotfix | BW1100 | 2 | IFB | [**`>_`**](#qwen35-122b-a10b-channel-fp8-w8a8-ifb-bw1100-2x-vllm-018-hotfix) |
 | [Qwen/Qwen3.5-397B-A17B-W8A8-INT8](https://modelscope.cn/models/hygon/Qwen3.5-397B-A17B-Channel-INT8-w8a8) | INT8 W8A8 | 0.18 | BW1100  | 8 | IFB | [**`>_`**](#qwen35-397b-a17b-w8a8-int8-ifb-bw1100-8x-vllm-018) |
+|  | INT8 W8A8 | 0.18-hotfix | BW1100 | 8 | IFB | [**`>_`**](#qwen35-397b-a17b-w8a8-int8-ifb-bw1100-8x-vllm-018-hotfix) |
 |                                                                                                | INT8 W8A8 | 0.18 | BW1000  | 8 | IFB | [**`>_`**](#qwen35-397b-a17b-w8a8-int8-ifb-bw1000-8x-vllm-018) |
+|  | INT8 W8A8 | 0.18-hotfix | BW1000 | 8 | IFB | [**`>_`**](#qwen35-397b-a17b-w8a8-int8-ifb-bw1000-8x-vllm-018-hotfix) |
 |                                                                                                | INT8 W8A8 | 0.18 | K100_AI | 8 | IFB | [**`>_`**](#qwen35-397b-a17b-w8a8-int8-ifb-k100_ai-8x-vllm-018) |
+|  | INT8 W8A8 | 0.18-hotfix | K100_AI | 8 | IFB | [**`>_`**](#qwen35-397b-a17b-w8a8-int8-ifb-k100_ai-8x-vllm-018-hotfix) |
 | [hygon/Qwen3.5-397B-A17B-Channel-FP8](https://www.modelscope.cn/models/hygon/Qwen3.5-397B-A17B-Channel-FP8) | FP8 W8A8 | 0.18 | BW1100  | 4 | IFB | [**`>_`**](#qwen35-397b-a17b-channel-fp8-ifb-bw1100-4x-vllm-018) |
+|  | FP8 W8A8 | 0.18-hotfix | BW1100 | 4 | IFB | [**`>_`**](#qwen35-397b-a17b-channel-fp8-ifb-bw1100-4x-vllm-018-hotfix) |
 
 ## 启动命令
 
@@ -57,6 +87,19 @@ vllm serve Qwen/Qwen3.5-4B \
   --speculative-config.num_speculative_tokens 3
 ```
 
+### Qwen3.5-4B IFB BW1100 1x vLLM 0.18-hotfix
+
+```bash
+export VLLM_HCU_USE_PD_SPLIT=1
+
+vllm serve Qwen/Qwen3.5-4B \
+  -tp 1 \
+  --trust-remote-code \
+  --max-num-batched-tokens 10240 \
+  --speculative-config.method mtp \
+  --speculative-config.num_speculative_tokens 3 \
+  --attention-backend FLASH_ATTN_CUSTOM
+```
 ### Qwen3.5-4B IFB BW1000 1x vLLM 0.18
 
 ```bash
@@ -69,6 +112,19 @@ vllm serve Qwen/Qwen3.5-4B \
   --max-num-batched-tokens 10240 \
   --speculative-config.method mtp \
   --speculative-config.num_speculative_tokens 3
+```
+
+### Qwen3.5-4B IFB BW1000 1x vLLM 0.18-hotfix
+
+```bash
+export VLLM_HCU_USE_PD_SPLIT=1
+vllm serve Qwen/Qwen3.5-4B \
+  -tp 1 \
+  --trust-remote-code \
+  --max-num-batched-tokens 10240 \
+  --speculative-config.method mtp \
+  --speculative-config.num_speculative_tokens 3 \
+  --attention-backend FLASH_ATTN_CUSTOM
 ```
 
 ### Qwen3.5-4B IFB K100_AI 1x vLLM 0.18
@@ -85,6 +141,19 @@ vllm serve Qwen/Qwen3.5-4B \
   --speculative-config.num_speculative_tokens 3
 ```
 
+### Qwen3.5-4B IFB K100_AI 1x vLLM 0.18-hotfix
+
+```bash
+export VLLM_HCU_USE_CUSTOM_QUANTIZATION_GEMM=0
+export VLLM_HCU_USE_CUSTOM_OPS=0
+
+vllm serve Qwen/Qwen3.5-4B \
+  -tp 1 \
+  --trust-remote-code \
+  --max-num-batched-tokens 10240 \
+  --speculative-config.method mtp \
+  --speculative-config.num_speculative_tokens 3
+```
 ### Qwen3.5-9B IFB BW1100 1x vLLM 0.18
 
 ```bash
@@ -99,6 +168,19 @@ vllm serve Qwen/Qwen3.5-9B \
   --speculative-config.num_speculative_tokens 3
 ```
 
+### Qwen3.5-9B IFB BW1100 1x vLLM 0.18-hotfix
+
+```bash
+export VLLM_HCU_USE_PD_SPLIT=1
+
+vllm serve Qwen/Qwen3.5-9B \
+  -tp 1 \
+  --trust-remote-code \
+  --max-num-batched-tokens 10240 \
+  --speculative-config.method mtp \
+  --speculative-config.num_speculative_tokens 3 \
+  --attention-backend FLASH_ATTN_CUSTOM
+```
 ### Qwen3.5-9B IFB BW1000 1x vLLM 0.18
 
 ```bash
@@ -113,6 +195,19 @@ vllm serve Qwen/Qwen3.5-9B \
   --speculative-config.num_speculative_tokens 3
 ```
 
+### Qwen3.5-9B IFB BW1000 1x vLLM 0.18-hotfix
+
+```bash
+export VLLM_HCU_USE_PD_SPLIT=1
+
+vllm serve Qwen/Qwen3.5-9B \
+  -tp 1 \
+  --trust-remote-code \
+  --max-num-batched-tokens 10240 \
+  --speculative-config.method mtp \
+  --speculative-config.num_speculative_tokens 3 \
+  --attention-backend FLASH_ATTN_CUSTOM
+```
 ### Qwen3.5-9B IFB K100_AI 1x vLLM 0.18
 
 ```bash
@@ -127,6 +222,19 @@ vllm serve Qwen/Qwen3.5-9B \
   --speculative-config.num_speculative_tokens 3
 ```
 
+### Qwen3.5-9B IFB K100_AI 1x vLLM 0.18-hotfix
+
+```bash
+export VLLM_HCU_USE_CUSTOM_QUANTIZATION_GEMM=0
+export VLLM_HCU_USE_CUSTOM_OPS=0
+
+vllm serve Qwen/Qwen3.5-9B \
+  -tp 1 \
+  --trust-remote-code \
+  --max-num-batched-tokens 10240 \
+  --speculative-config.method mtp \
+  --speculative-config.num_speculative_tokens 3
+```
 ### Qwen3.5-27B IFB BW1100 1x vLLM 0.18
 
 ```bash
@@ -141,6 +249,19 @@ vllm serve Qwen/Qwen3.5-27B \
   --speculative-config.num_speculative_tokens 3
 ```
 
+### Qwen3.5-27B IFB BW1100 1x vLLM 0.18-hotfix
+
+```bash
+export VLLM_HCU_USE_PD_SPLIT=1
+
+vllm serve Qwen/Qwen3.5-27B \
+  -tp 1 \
+  --trust-remote-code \
+  --max-num-batched-tokens 10240 \
+  --speculative-config.method mtp \
+  --speculative-config.num_speculative_tokens 3 \
+  --attention-backend FLASH_ATTN_CUSTOM
+```
 ### Qwen3.5-27B IFB BW1000 2x vLLM 0.18
 
 ```bash
@@ -155,6 +276,19 @@ vllm serve Qwen/Qwen3.5-27B \
   --speculative-config.num_speculative_tokens 3
 ```
 
+### Qwen3.5-27B IFB BW1000 2x vLLM 0.18-hotfix
+
+```bash
+export VLLM_HCU_USE_PD_SPLIT=1
+
+vllm serve Qwen/Qwen3.5-27B \
+  -tp 2 \
+  --trust-remote-code \
+  --max-num-batched-tokens 10240 \
+  --speculative-config.method mtp \
+  --speculative-config.num_speculative_tokens 3 \
+  --attention-backend FLASH_ATTN_CUSTOM
+```
 ### Qwen3.5-27B IFB K100_AI 2x vLLM 0.18
 
 ```bash
@@ -169,6 +303,19 @@ vllm serve Qwen/Qwen3.5-27B \
   --speculative-config.num_speculative_tokens 3
 ```
 
+### Qwen3.5-27B IFB K100_AI 2x vLLM 0.18-hotfix
+
+```bash
+export VLLM_HCU_USE_CUSTOM_QUANTIZATION_GEMM=0
+export VLLM_HCU_USE_CUSTOM_OPS=0
+
+vllm serve Qwen/Qwen3.5-27B \
+  -tp 2 \
+  --trust-remote-code \
+  --max-num-batched-tokens 10240 \
+  --speculative-config.method mtp \
+  --speculative-config.num_speculative_tokens 3
+```
 ### Qwen3.5-27B-Channel-INT8-w8a8 IFB BW1100 1x vLLM 0.18
 
 ```bash
@@ -185,6 +332,21 @@ vllm serve hygon/Qwen3.5-27B-Channel-INT8-w8a8 \
   --speculative-config.quantization "slimquant_marlin"
 ```
 
+### Qwen3.5-27B-Channel-INT8-w8a8 IFB BW1100 1x vLLM 0.18-hotfix
+
+```bash
+export VLLM_HCU_USE_PD_SPLIT=1
+
+vllm serve hygon/Qwen3.5-27B-Channel-INT8-w8a8 \
+  -tp 1 \
+  --trust-remote-code \
+  --max-num-batched-tokens 10240 \
+  -q slimquant_marlin \
+  --speculative-config.method mtp \
+  --speculative-config.num_speculative_tokens 3 \
+  --speculative-config.quantization "slimquant_marlin" \
+  --attention-backend FLASH_ATTN_CUSTOM
+```
 ### Qwen3.5-27B-Channel-INT8-w8a8 IFB BW1000 1x vLLM 0.18
 
 ```bash
@@ -201,6 +363,21 @@ vllm serve hygon/Qwen3.5-27B-Channel-INT8-w8a8 \
   --speculative-config.quantization "slimquant_marlin"
 ```
 
+### Qwen3.5-27B-Channel-INT8-w8a8 IFB BW1000 1x vLLM 0.18-hotfix
+
+```bash
+export VLLM_HCU_USE_PD_SPLIT=1
+
+vllm serve hygon/Qwen3.5-27B-Channel-INT8-w8a8 \
+  -tp 1 \
+  --trust-remote-code \
+  --max-num-batched-tokens 10240 \
+  -q slimquant_marlin \
+  --speculative-config.method mtp \
+  --speculative-config.num_speculative_tokens 3 \
+  --speculative-config.quantization "slimquant_marlin" \
+  --attention-backend FLASH_ATTN_CUSTOM
+```
 ### Qwen3.5-27B-Channel-INT8-w8a8 IFB K100_AI 1x vLLM 0.18
 
 ```bash
@@ -215,6 +392,19 @@ vllm serve hygon/Qwen3.5-27B-Channel-INT8-w8a8 \
   --speculative-config.num_speculative_tokens 3 
 ```
 
+### Qwen3.5-27B-Channel-INT8-w8a8 IFB K100_AI 1x vLLM 0.18-hotfix
+
+```bash
+export VLLM_HCU_USE_CUSTOM_QUANTIZATION_GEMM=0
+export VLLM_HCU_USE_CUSTOM_OPS=0
+
+vllm serve hygon/Qwen3.5-27B-Channel-INT8-w8a8 \
+  -tp 1 \
+  --trust-remote-code \
+  --max-num-batched-tokens 10240 \
+  --speculative-config.method mtp \
+  --speculative-config.num_speculative_tokens 3 
+```
 ### Qwen3.5-35B-A3B IFB BW1100 1x vLLM 0.18
 
 ```bash
@@ -232,6 +422,19 @@ vllm serve Qwen/Qwen3.5-35B-A3B \
   --speculative-config.num_speculative_tokens 3
 ```
 
+### Qwen3.5-35B-A3B IFB BW1100 1x vLLM 0.18-hotfix
+
+```bash
+export VLLM_HCU_USE_PD_SPLIT=1
+vllm serve Qwen/Qwen3.5-35B-A3B \
+  -tp 1 \
+  --trust-remote-code \
+  --max-num-batched-tokens 10240 \
+  --speculative-config.method mtp \
+  --speculative-config.num_speculative_tokens 3 \
+  --attention-backend FLASH_ATTN_CUSTOM \
+  --moe-backend aiter
+```
 ### Qwen3.5-35B-A3B IFB BW1000 2x vLLM 0.18
 
 ```bash
@@ -249,6 +452,19 @@ vllm serve Qwen/Qwen3.5-35B-A3B \
   --speculative-config.num_speculative_tokens 3
 ```
 
+### Qwen3.5-35B-A3B IFB BW1000 2x vLLM 0.18-hotfix
+
+```bash
+export VLLM_HCU_USE_PD_SPLIT=1
+vllm serve Qwen/Qwen3.5-35B-A3B \
+  -tp 2 \
+  --trust-remote-code \
+  --max-num-batched-tokens 10240 \
+  --speculative-config.method mtp \
+  --speculative-config.num_speculative_tokens 3 \
+  --attention-backend FLASH_ATTN_CUSTOM \
+  --moe-backend aiter
+```
 ### Qwen3.5-35B-A3B IFB K100_AI 2x vLLM 0.18
 
 ```bash
@@ -263,6 +479,19 @@ vllm serve Qwen/Qwen3.5-35B-A3B \
   --speculative-config.num_speculative_tokens 3
 ```
 
+### Qwen3.5-35B-A3B IFB K100_AI 2x vLLM 0.18-hotfix
+
+```bash
+export VLLM_HCU_USE_CUSTOM_QUANTIZATION_GEMM=0
+export VLLM_HCU_USE_CUSTOM_OPS=0
+
+vllm serve Qwen/Qwen3.5-35B-A3B \
+  -tp 2 \
+  --trust-remote-code \
+  --max-num-batched-tokens 10240 \
+  --speculative-config.method mtp \
+  --speculative-config.num_speculative_tokens 3
+```
 ### Qwen3.5-35B-A3B-Channel-INT8-w8a8 IFB BW1100 1x vLLM 0.18
 
 ```bash
@@ -279,6 +508,21 @@ vllm serve hygon/Qwen3.5-35B-A3B-Channel-INT8-w8a8 \
   --speculative-config.quantization "slimquant_marlin"
 ```
 
+### Qwen3.5-35B-A3B-Channel-INT8-w8a8 IFB BW1100 1x vLLM 0.18-hotfix
+
+```bash
+export VLLM_HCU_USE_PD_SPLIT=1
+
+vllm serve hygon/Qwen3.5-35B-A3B-Channel-INT8-w8a8 \
+  -tp 1 \
+  --trust-remote-code \
+  --max-num-batched-tokens 10240 \
+  -q slimquant_marlin \
+  --speculative-config.method mtp \
+  --speculative-config.num_speculative_tokens 3 \
+  --speculative-config.quantization "slimquant_marlin" \
+  --attention-backend FLASH_ATTN_CUSTOM
+```
 ### Qwen3.5-35B-A3B-Channel-INT8-w8a8 IFB BW1000 1x vLLM 0.18
 
 ```bash
@@ -295,6 +539,21 @@ vllm serve hygon/Qwen3.5-35B-A3B-Channel-INT8-w8a8 \
   --speculative-config.quantization "slimquant_marlin"
 ```
 
+### Qwen3.5-35B-A3B-Channel-INT8-w8a8 IFB BW1000 1x vLLM 0.18-hotfix
+
+```bash
+export VLLM_HCU_USE_PD_SPLIT=1
+
+vllm serve hygon/Qwen3.5-35B-A3B-Channel-INT8-w8a8 \
+  -tp 1 \
+  --trust-remote-code \
+  --max-num-batched-tokens 10240 \
+  -q slimquant_marlin \
+  --speculative-config.method mtp \
+  --speculative-config.num_speculative_tokens 3 \
+  --speculative-config.quantization "slimquant_marlin" \
+  --attention-backend FLASH_ATTN_CUSTOM
+```
 ### Qwen3.5-35B-A3B-Channel-INT8-w8a8 IFB K100_AI 1x vLLM 0.18
 
 ```bash
@@ -309,6 +568,19 @@ vllm serve hygon/Qwen3.5-35B-A3B-Channel-INT8-w8a8 \
   --speculative-config.num_speculative_tokens 3
 ```
 
+### Qwen3.5-35B-A3B-Channel-INT8-w8a8 IFB K100_AI 1x vLLM 0.18-hotfix
+
+```bash
+export VLLM_HCU_USE_CUSTOM_QUANTIZATION_GEMM=0
+export VLLM_HCU_USE_CUSTOM_OPS=0
+
+vllm serve hygon/Qwen3.5-35B-A3B-Channel-INT8-w8a8 \
+  -tp 1 \
+  --trust-remote-code \
+  --max-num-batched-tokens 10240 \
+  --speculative-config.method mtp \
+  --speculative-config.num_speculative_tokens 3
+```
 ### Qwen3.5-35B-A3B-Channel-FP8-w8a8 IFB BW1100 1x vLLM 0.18
 
 ```bash
@@ -325,6 +597,21 @@ vllm serve hygon/Qwen3.5-35B-A3B-Channel-FP8-w8a8 \
   --speculative-config.quantization "slimquant_marlin"
 ```
 
+### Qwen3.5-35B-A3B-Channel-FP8-w8a8 IFB BW1100 1x vLLM 0.18-hotfix
+
+```bash
+export VLLM_HCU_USE_PD_SPLIT=1
+
+vllm serve hygon/Qwen3.5-35B-A3B-Channel-FP8-w8a8 \
+  -tp 1 \
+  --trust-remote-code \
+  --max-num-batched-tokens 10240 \
+  -q slimquant_marlin \
+  --speculative-config.method mtp \
+  --speculative-config.num_speculative_tokens 3 \
+  --speculative-config.quantization "slimquant_marlin" \
+  --attention-backend FLASH_ATTN_CUSTOM
+```
 ### Qwen3.5-122B-A10B IFB BW1100 4x vLLM 0.18
 
 ```bash
@@ -342,6 +629,19 @@ vllm serve Qwen/Qwen3.5-122B-A10B \
   --speculative-config.num_speculative_tokens 3
 ```
 
+### Qwen3.5-122B-A10B IFB BW1100 4x vLLM 0.18-hotfix
+
+```bash
+export VLLM_HCU_USE_PD_SPLIT=1
+vllm serve Qwen/Qwen3.5-122B-A10B \
+  -tp 4 \
+  --trust-remote-code \
+  --max-num-batched-tokens 10240 \
+  --speculative-config.method mtp \
+  --speculative-config.num_speculative_tokens 3 \
+  --attention-backend FLASH_ATTN_CUSTOM \
+  --moe-backend aiter
+```
 ### Qwen3.5-122B-A10B IFB BW1000 8x vLLM 0.18
 
 ```bash
@@ -359,6 +659,19 @@ vllm serve Qwen/Qwen3.5-122B-A10B \
   --speculative-config.num_speculative_tokens 3
 ```
 
+### Qwen3.5-122B-A10B IFB BW1000 8x vLLM 0.18-hotfix
+
+```bash
+export VLLM_HCU_USE_PD_SPLIT=1
+vllm serve Qwen/Qwen3.5-122B-A10B \
+  -tp 8 \
+  --trust-remote-code \
+  --max-num-batched-tokens 10240 \
+  --speculative-config.method mtp \
+  --speculative-config.num_speculative_tokens 3 \
+  --attention-backend FLASH_ATTN_CUSTOM \
+  --moe-backend aiter
+```
 ### Qwen3.5-122B-A10B IFB K100_AI 8x vLLM 0.18
 
 ```bash
@@ -373,6 +686,19 @@ vllm serve Qwen/Qwen3.5-122B-A10B \
   --speculative-config.num_speculative_tokens 3
 ```
 
+### Qwen3.5-122B-A10B IFB K100_AI 8x vLLM 0.18-hotfix
+
+```bash
+export VLLM_HCU_USE_CUSTOM_QUANTIZATION_GEMM=0
+export VLLM_HCU_USE_CUSTOM_OPS=0
+
+vllm serve Qwen/Qwen3.5-122B-A10B \
+  -tp 8 \
+  --trust-remote-code \
+  --max-num-batched-tokens 10240 \
+  --speculative-config.method mtp \
+  --speculative-config.num_speculative_tokens 3
+```
 ### Qwen3.5-122B-A10B-W8A8-INT8 IFB BW1100 2x vLLM 0.18
 
 ```bash
@@ -389,6 +715,21 @@ vllm serve Qwen/Qwen3.5-122B-A10B-W8A8-INT8 \
   --speculative-config.quantization "slimquant_marlin"
 ```
 
+### Qwen3.5-122B-A10B-W8A8-INT8 IFB BW1100 2x vLLM 0.18-hotfix
+
+```bash
+export VLLM_HCU_USE_PD_SPLIT=1
+
+vllm serve Qwen/Qwen3.5-122B-A10B-W8A8-INT8 \
+  -tp 2 \
+  --trust-remote-code \
+  --max-num-batched-tokens 10240 \
+  -q slimquant_marlin \
+  --speculative-config.method mtp \
+  --speculative-config.num_speculative_tokens 3 \
+  --speculative-config.quantization "slimquant_marlin" \
+  --attention-backend FLASH_ATTN_CUSTOM
+```
 ### Qwen3.5-122B-A10B-W8A8-INT8 IFB BW1000 4x vLLM 0.18
 
 ```bash
@@ -405,6 +746,21 @@ vllm serve Qwen/Qwen3.5-122B-A10B-W8A8-INT8 \
   --speculative-config.quantization "slimquant_marlin"
 ```
 
+### Qwen3.5-122B-A10B-W8A8-INT8 IFB BW1000 4x vLLM 0.18-hotfix
+
+```bash
+export VLLM_HCU_USE_PD_SPLIT=1
+
+vllm serve Qwen/Qwen3.5-122B-A10B-W8A8-INT8 \
+  -tp 4 \
+  --trust-remote-code \
+  --max-num-batched-tokens 10240 \
+  -q slimquant_marlin \
+  --speculative-config.method mtp \
+  --speculative-config.num_speculative_tokens 3 \
+  --speculative-config.quantization "slimquant_marlin" \
+  --attention-backend FLASH_ATTN_CUSTOM
+```
 ### Qwen3.5-122B-A10B-W8A8-INT8 IFB K100_AI 4x vLLM 0.18
 
 ```bash
@@ -419,6 +775,19 @@ vllm serve Qwen/Qwen3.5-122B-A10B-W8A8-INT8 \
   --speculative-config.num_speculative_tokens 3 
 ```
 
+### Qwen3.5-122B-A10B-W8A8-INT8 IFB K100_AI 4x vLLM 0.18-hotfix
+
+```bash
+export VLLM_HCU_USE_CUSTOM_QUANTIZATION_GEMM=0
+export VLLM_HCU_USE_CUSTOM_OPS=0
+
+vllm serve Qwen/Qwen3.5-122B-A10B-W8A8-INT8 \
+  -tp 4 \
+  --trust-remote-code \
+  --max-num-batched-tokens 10240 \
+  --speculative-config.method mtp \
+  --speculative-config.num_speculative_tokens 3 
+```
 ### Qwen3.5-122B-A10B-Channel-FP8-w8a8 IFB BW1100 2x vLLM 0.18
 
 ```bash
@@ -435,6 +804,21 @@ vllm serve hygon/Qwen3.5-122B-A10B-Channel-FP8-w8a8 \
   --speculative-config.quantization "slimquant_marlin"
 ```
 
+### Qwen3.5-122B-A10B-Channel-FP8-w8a8 IFB BW1100 2x vLLM 0.18-hotfix
+
+```bash
+export VLLM_HCU_USE_PD_SPLIT=1
+
+vllm serve hygon/Qwen3.5-122B-A10B-Channel-FP8-w8a8 \
+  -tp 4 \
+  --trust-remote-code \
+  --max-num-batched-tokens 10240 \
+  -q slimquant_marlin \
+  --speculative-config.method mtp \
+  --speculative-config.num_speculative_tokens 3 \
+  --speculative-config.quantization "slimquant_marlin" \
+  --attention-backend FLASH_ATTN_CUSTOM
+```
 ### Qwen3.5-397B-A17B-W8A8-INT8 IFB BW1100 8x vLLM 0.18
 
 ```bash
@@ -451,6 +835,21 @@ vllm serve Qwen/Qwen3.5-397B-A17B-W8A8-INT8 \
   --speculative-config.quantization "slimquant_marlin"
 ```
 
+### Qwen3.5-397B-A17B-W8A8-INT8 IFB BW1100 8x vLLM 0.18-hotfix
+
+```bash
+export VLLM_HCU_USE_PD_SPLIT=1
+
+vllm serve Qwen/Qwen3.5-397B-A17B-W8A8-INT8 \
+  -tp 8 \
+  --trust-remote-code \
+  --max-num-batched-tokens 10240 \
+  -q slimquant_marlin \
+  --speculative-config.method mtp \
+  --speculative-config.num_speculative_tokens 3 \
+  --speculative-config.quantization "slimquant_marlin" \
+  --attention-backend FLASH_ATTN_CUSTOM
+```
 ### Qwen3.5-397B-A17B-W8A8-INT8 IFB BW1000 8x vLLM 0.18
 
 ```bash
@@ -467,6 +866,21 @@ vllm serve Qwen/Qwen3.5-397B-A17B-W8A8-INT8 \
   --speculative-config.quantization "slimquant_marlin"
 ```
 
+### Qwen3.5-397B-A17B-W8A8-INT8 IFB BW1000 8x vLLM 0.18-hotfix
+
+```bash
+export VLLM_HCU_USE_PD_SPLIT=1
+
+vllm serve Qwen/Qwen3.5-397B-A17B-W8A8-INT8 \
+  -tp 8 \
+  --trust-remote-code \
+  --max-num-batched-tokens 10240 \
+  -q slimquant_marlin \
+  --speculative-config.method mtp \
+  --speculative-config.num_speculative_tokens 3 \
+  --speculative-config.quantization "slimquant_marlin" \
+  --attention-backend FLASH_ATTN_CUSTOM
+```
 ### Qwen3.5-397B-A17B-W8A8-INT8 IFB K100_AI 8x vLLM 0.18
 
 ```bash
@@ -481,6 +895,19 @@ vllm serve Qwen/Qwen3.5-397B-A17B-W8A8-INT8 \
   --speculative-config.num_speculative_tokens 3 
 ```
 
+### Qwen3.5-397B-A17B-W8A8-INT8 IFB K100_AI 8x vLLM 0.18-hotfix
+
+```bash
+export VLLM_HCU_USE_CUSTOM_QUANTIZATION_GEMM=0
+export VLLM_HCU_USE_CUSTOM_OPS=0
+
+vllm serve Qwen/Qwen3.5-397B-A17B-W8A8-INT8 \
+  -tp 8 \
+  --trust-remote-code \
+  --max-num-batched-tokens 10240 \
+  --speculative-config.method mtp \
+  --speculative-config.num_speculative_tokens 3 
+```
 ### Qwen3.5-397B-A17B-Channel-FP8 IFB BW1100 4x vLLM 0.18
 
 ```bash
@@ -497,6 +924,21 @@ vllm serve hygon/Qwen3.5-397B-A17B-Channel-FP8 \
   --speculative-config.quantization "slimquant_marlin"
 ```
 
+### Qwen3.5-397B-A17B-Channel-FP8 IFB BW1100 4x vLLM 0.18-hotfix
+
+```bash
+export VLLM_HCU_USE_PD_SPLIT=1
+
+vllm serve hygon/Qwen3.5-397B-A17B-Channel-FP8 \
+  -tp 4 \
+  --trust-remote-code \
+  --max-num-batched-tokens 10240 \
+  -q slimquant_marlin \
+  --speculative-config.method mtp \
+  --speculative-config.num_speculative_tokens 3 \
+  --speculative-config.quantization "slimquant_marlin" \
+  --attention-backend FLASH_ATTN_CUSTOM
+```
 ## API 调用
 
 ### IFB

--- a/docs/model-deployment/vllm/qwen3.6.md
+++ b/docs/model-deployment/vllm/qwen3.6.md
@@ -9,11 +9,17 @@ Qwen3.6 模型相较于 Qwen3.5 模型，**在智能体编程能力、推理速�
 | 模型权重 | 量化方式 | vLLM 版本 | 推荐硬件 | 卡数 | 部署方式 | 启动命令 |
 | -------- | -------- | --------- | -------- | ---- | -------- | -------- |
 | [Qwen/Qwen3.6-27B](https://www.modelscope.cn/models/Qwen/Qwen3.6-27B) | BF16 | 0.18 | BW1100  | 1 | IFB | [**`>_`**](#qwen36-27b-ifb-bw1100-1x-vllm-018) |
+|  | BF16 | 0.18-hotfix | BW1100 | 1 | IFB | [**`>_`**](#qwen36-27b-ifb-bw1100-1x-vllm-018-hotfix) |
 |                                                                  | BF16 | 0.18 | BW1000  | 2 | IFB | [**`>_`**](#qwen36-27b-ifb-bw1000-2x-vllm-018) |
+|  | BF16 | 0.18-hotfix | BW1000 | 2 | IFB | [**`>_`**](#qwen36-27b-ifb-bw1000-2x-vllm-018-hotfix) |
 |                                                                  | BF16 | 0.18 | K100_AI | 2 | IFB | [**`>_`**](#qwen36-27b-ifb-k100_ai-2x-vllm-018) |
+|  | BF16 | 0.18-hotfix | K100_AI | 2 | IFB | [**`>_`**](#qwen36-27b-ifb-k100_ai-2x-vllm-018-hotfix) |
 | [Qwen/Qwen3.6-35B-A3B](https://www.modelscope.cn/models/Qwen/Qwen3.6-35B-A3B) | BF16 | 0.18 | BW1100  | 1 | IFB | [**`>_`**](#qwen36-35b-a3b-ifb-bw1100-1x-vllm-018) |
+|  | BF16 | 0.18-hotfix | BW1100 | 1 | IFB | [**`>_`**](#qwen36-35b-a3b-ifb-bw1100-1x-vllm-018-hotfix) |
 |                                                                         | BF16 | 0.18 | BW1000  | 2 | IFB | [**`>_`**](#qwen36-35b-a3b-ifb-bw1000-2x-vllm-018) |
+|  | BF16 | 0.18-hotfix | BW1000 | 2 | IFB | [**`>_`**](#qwen36-35b-a3b-ifb-bw1000-2x-vllm-018-hotfix) |
 |                                                                         | BF16 | 0.18 | K100_AI | 2 | IFB | [**`>_`**](#qwen36-35b-a3b-ifb-k100_ai-2x-vllm-018) |
+|  | BF16 | 0.18-hotfix | K100_AI | 2 | IFB | [**`>_`**](#qwen36-35b-a3b-ifb-k100_ai-2x-vllm-018-hotfix) |
 
 ## 启动命令
 
@@ -31,6 +37,19 @@ vllm serve Qwen/Qwen3.6-27B \
   --speculative-config.num_speculative_tokens 3
 ```
 
+### Qwen3.6-27B IFB BW1100 1x vLLM 0.18-hotfix
+
+```bash
+export VLLM_HCU_USE_PD_SPLIT=1
+
+vllm serve Qwen/Qwen3.6-27B \
+  -tp 1 \
+  --trust-remote-code \
+  --max-num-batched-tokens 10240 \
+  --speculative-config.method mtp \
+  --speculative-config.num_speculative_tokens 3 \
+  --attention-backend FLASH_ATTN_CUSTOM
+```
 ### Qwen3.6-27B IFB BW1000 2x vLLM 0.18
 
 ```bash
@@ -45,6 +64,19 @@ vllm serve Qwen/Qwen3.6-27B \
   --speculative-config.num_speculative_tokens 3
 ```
 
+### Qwen3.6-27B IFB BW1000 2x vLLM 0.18-hotfix
+
+```bash
+export VLLM_HCU_USE_PD_SPLIT=1
+
+vllm serve Qwen/Qwen3.6-27B \
+  -tp 2 \
+  --trust-remote-code \
+  --max-num-batched-tokens 10240 \
+  --speculative-config.method mtp \
+  --speculative-config.num_speculative_tokens 3 \
+  --attention-backend FLASH_ATTN_CUSTOM
+```
 ### Qwen3.6-27B IFB K100_AI 2x vLLM 0.18
 
 ```bash
@@ -59,6 +91,19 @@ vllm serve Qwen/Qwen3.6-27B \
   --speculative-config.num_speculative_tokens 3
 ```
 
+### Qwen3.6-27B IFB K100_AI 2x vLLM 0.18-hotfix
+
+```bash
+export VLLM_HCU_USE_CUSTOM_QUANTIZATION_GEMM=0
+export VLLM_HCU_USE_CUSTOM_OPS=0
+
+vllm serve Qwen/Qwen3.6-27B \
+  -tp 2 \
+  --trust-remote-code \
+  --max-num-batched-tokens 10240 \
+  --speculative-config.method mtp \
+  --speculative-config.num_speculative_tokens 3
+```
 ### Qwen3.6-35B-A3B IFB BW1100 1x vLLM 0.18
 
 ```bash
@@ -76,6 +121,19 @@ vllm serve Qwen/Qwen3.6-35B-A3B \
   --speculative-config.num_speculative_tokens 3
 ```
 
+### Qwen3.6-35B-A3B IFB BW1100 1x vLLM 0.18-hotfix
+
+```bash
+export VLLM_HCU_USE_PD_SPLIT=1
+vllm serve Qwen/Qwen3.6-35B-A3B \
+  -tp 1 \
+  --trust-remote-code \
+  --max-num-batched-tokens 10240 \
+  --speculative-config.method mtp \
+  --speculative-config.num_speculative_tokens 3 \
+  --attention-backend FLASH_ATTN_CUSTOM \
+  --moe-backend aiter
+```
 ### Qwen3.6-35B-A3B IFB BW1000 2x vLLM 0.18
 
 ```bash
@@ -93,6 +151,19 @@ vllm serve Qwen/Qwen3.6-35B-A3B \
   --speculative-config.num_speculative_tokens 3
 ```
 
+### Qwen3.6-35B-A3B IFB BW1000 2x vLLM 0.18-hotfix
+
+```bash
+export VLLM_HCU_USE_PD_SPLIT=1
+vllm serve Qwen/Qwen3.6-35B-A3B \
+  -tp 2 \
+  --trust-remote-code \
+  --max-num-batched-tokens 10240 \
+  --speculative-config.method mtp \
+  --speculative-config.num_speculative_tokens 3 \
+  --attention-backend FLASH_ATTN_CUSTOM \
+  --moe-backend aiter
+```
 ### Qwen3.6-35B-A3B IFB K100_AI 2x vLLM 0.18
 
 ```bash
@@ -107,6 +178,19 @@ vllm serve Qwen/Qwen3.6-35B-A3B \
   --speculative-config.num_speculative_tokens 3
 ```
 
+### Qwen3.6-35B-A3B IFB K100_AI 2x vLLM 0.18-hotfix
+
+```bash
+export VLLM_HCU_USE_CUSTOM_QUANTIZATION_GEMM=0
+export VLLM_HCU_USE_CUSTOM_OPS=0
+
+vllm serve Qwen/Qwen3.6-35B-A3B \
+  -tp 2 \
+  --trust-remote-code \
+  --max-num-batched-tokens 10240 \
+  --speculative-config.method mtp \
+  --speculative-config.num_speculative_tokens 3
+```
 ## API 调用
 
 ### IFB

--- a/docs/model-deployment/vllm/qwen3.md
+++ b/docs/model-deployment/vllm/qwen3.md
@@ -9,84 +9,118 @@ Qwen3 是阿里通义千问第三代大语言模型，支持 0.6B ~ 235B 多种�
 | 模型权重 | 量化方式 | vLLM 版本 | 推荐硬件 | 卡数 | 部署方式 | 启动命令 |
 | -------- | -------- | --------- | -------- | ---- | -------- | -------- |
 | [Qwen/Qwen3-0.6B](https://www.modelscope.cn/models/Qwen/Qwen3-0.6B)           | BF16 | 0.18 | BW1100  | 1 | IFB | [**`>_`**](#qwen3-06b-ifb-bw1100-1x-vllm-018)           |
+|  | BF16 | 0.18-hotfix | BW1100 | 1 | IFB | [**`>_`**](#qwen3-06b-ifb-bw1100-1x-vllm-018-hotfix) |
 |                                                                               | BF16 | 0.18 | BW1000  | 1 | IFB | [**`>_`**](#qwen3-06b-ifb-bw1000-1x-vllm-018)           |
+|  | BF16 | 0.18-hotfix | BW1000 | 1 | IFB | [**`>_`**](#qwen3-06b-ifb-bw1000-1x-vllm-018-hotfix) |
 |                                                                               | BF16 | 0.18 | K100_AI | 1 | IFB | [**`>_`**](#qwen3-06b-ifb-k100_ai-1x-vllm-018)          |
+|  | BF16 | 0.18-hotfix | K100_AI | 1 | IFB | [**`>_`**](#qwen3-06b-ifb-k100_ai-1x-vllm-018-hotfix) |
 |                                                                               | BF16 | 0.15 | BW1100  | 1   | IFB | [**`>_`**](#qwen3-06b-ifb-bw1100-1x-vllm-015) |
 |                                                                               | BF16 | 0.15 | BW1000  | 1 | IFB | [**`>_`**](#qwen3-06b-ifb-bw1000-1x-vllm-015)           |
 |                                                                               | BF16 | 0.15 | K100_AI | 1   | IFB | [**`>_`**](#qwen3-06b-ifb-k100_ai-1x-vllm-015) |
 | [Qwen/Qwen3-1.7B](https://www.modelscope.cn/models/Qwen/Qwen3-1.7B)           | BF16 | 0.18 | BW1100  | 1 | IFB | [**`>_`**](#qwen3-17b-ifb-bw1100-1x-vllm-018)           |
+|  | BF16 | 0.18-hotfix | BW1100 | 1 | IFB | [**`>_`**](#qwen3-17b-ifb-bw1100-1x-vllm-018-hotfix) |
 |                                                                               | BF16 | 0.18 | BW1000  | 1 | IFB | [**`>_`**](#qwen3-17b-ifb-bw1000-1x-vllm-018)           |
+|  | BF16 | 0.18-hotfix | BW1000 | 1 | IFB | [**`>_`**](#qwen3-17b-ifb-bw1000-1x-vllm-018-hotfix) |
 |                                                                               | BF16 | 0.18 | K100_AI | 1 | IFB | [**`>_`**](#qwen3-17b-ifb-k100_ai-1x-vllm-018)          |
+|  | BF16 | 0.18-hotfix | K100_AI | 1 | IFB | [**`>_`**](#qwen3-17b-ifb-k100_ai-1x-vllm-018-hotfix) |
 |                                                                               | BF16 | 0.15 | BW1100  | 1   | IFB | [**`>_`**](#qwen3-17b-ifb-bw1100-1x-vllm-015) |
 |                                                                               | BF16 | 0.15 | BW1000  | 1 | IFB | [**`>_`**](#qwen3-17b-ifb-bw1000-1x-vllm-015)           |
 |                                                                               | BF16 | 0.15 | K100_AI | 1   | IFB | [**`>_`**](#qwen3-17b-ifb-k100_ai-1x-vllm-015) |
 | [Qwen/Qwen3-4B](https://www.modelscope.cn/models/Qwen/Qwen3-4B)               | BF16 | 0.18 | BW1100  | 1 | IFB | [**`>_`**](#qwen3-4b-ifb-bw1100-1x-vllm-018)            |
+|  | BF16 | 0.18-hotfix | BW1100 | 1 | IFB | [**`>_`**](#qwen3-4b-ifb-bw1100-1x-vllm-018-hotfix) |
 |                                                                               | BF16 | 0.18 | BW1000  | 1 | IFB | [**`>_`**](#qwen3-4b-ifb-bw1000-1x-vllm-018)            |
+|  | BF16 | 0.18-hotfix | BW1000 | 1 | IFB | [**`>_`**](#qwen3-4b-ifb-bw1000-1x-vllm-018-hotfix) |
 |                                                                               | BF16 | 0.18 | K100_AI | 1 | IFB | [**`>_`**](#qwen3-4b-ifb-k100_ai-1x-vllm-018)           |
+|  | BF16 | 0.18-hotfix | K100_AI | 1 | IFB | [**`>_`**](#qwen3-4b-ifb-k100_ai-1x-vllm-018-hotfix) |
 |                                                                               | BF16 | 0.15 | BW1100  | 1   | IFB | [**`>_`**](#qwen3-4b-ifb-bw1100-1x-vllm-015) |
 |                                                                               | BF16 | 0.15 | BW1000  | 1 | IFB | [**`>_`**](#qwen3-4b-ifb-bw1000-1x-vllm-015)            |
 |                                                                               | BF16 | 0.15 | K100_AI | 1   | IFB | [**`>_`**](#qwen3-4b-ifb-k100_ai-1x-vllm-015) |
 | [Qwen/Qwen3-4B-Channel-INT8-w8a8](https://www.modelscope.cn/models/hygon/Qwen3-4B-Channel-INT8-w8a8) | INT8 W8A8 | 0.18 | BW1100 | 1 | IFB | [**`>_`**](#qwen3-4b-channel-int8-w8a8-ifb-bw1100-1x-vllm-018) |
+|  | INT8 W8A8 | 0.18-hotfix | BW1100 | 1 | IFB | [**`>_`**](#qwen3-4b-channel-int8-w8a8-ifb-bw1100-1x-vllm-018-hotfix) |
 |                                                                               | INT8 W8A8 | 0.18 | BW1000 | 1 | IFB | [**`>_`**](#qwen3-4b-channel-int8-w8a8-ifb-bw1000-1x-vllm-018) |
+|  | INT8 W8A8 | 0.18-hotfix | BW1000 | 1 | IFB | [**`>_`**](#qwen3-4b-channel-int8-w8a8-ifb-bw1000-1x-vllm-018-hotfix) |
 |                                                                               | INT8 W8A8 | 0.18 | K100_AI | 1 | IFB | [**`>_`**](#qwen3-4b-channel-int8-w8a8-ifb-k100_ai-1x-vllm-018) |
 |                                                                               | INT8 W8A8 | 0.15 | BW1100 | 1 | IFB | [**`>_`**](#qwen3-4b-channel-int8-w8a8-ifb-bw1100-1x-vllm-015) |
 |                                                                               | INT8 W8A8 | 0.15 | BW1000 | 1 | IFB | [**`>_`**](#qwen3-4b-channel-int8-w8a8-ifb-bw1000-1x-vllm-015) |
 |                                                                               | INT8 W8A8 | 0.15 | K100_AI | 1 | IFB | [**`>_`**](#qwen3-4b-channel-int8-w8a8-ifb-k100_ai-1x-vllm-015) |
 | [Qwen/Qwen3-8B](https://www.modelscope.cn/models/Qwen/Qwen3-8B)               | BF16 | 0.18 | BW1100  | 1 | IFB | [**`>_`**](#qwen3-8b-ifb-bw1100-1x-vllm-018)            |
+|  | BF16 | 0.18-hotfix | BW1100 | 1 | IFB | [**`>_`**](#qwen3-8b-ifb-bw1100-1x-vllm-018-hotfix) |
 |                                                                               | BF16 | 0.18 | BW1000  | 1 | IFB | [**`>_`**](#qwen3-8b-ifb-bw1000-1x-vllm-018)            |
+|  | BF16 | 0.18-hotfix | BW1000 | 1 | IFB | [**`>_`**](#qwen3-8b-ifb-bw1000-1x-vllm-018-hotfix) |
 |                                                                               | BF16 | 0.18 | K100_AI | 1 | IFB | [**`>_`**](#qwen3-8b-ifb-k100_ai-1x-vllm-018)           |
+|  | BF16 | 0.18-hotfix | K100_AI | 1 | IFB | [**`>_`**](#qwen3-8b-ifb-k100_ai-1x-vllm-018-hotfix) |
 |                                                                               | BF16 | 0.15 | BW1100  | 1   | IFB | [**`>_`**](#qwen3-8b-ifb-bw1100-1x-vllm-015) |
 |                                                                               | BF16 | 0.15 | BW1000  | 1 | IFB | [**`>_`**](#qwen3-8b-ifb-bw1000-1x-vllm-015)            |
 |                                                                               | BF16 | 0.15 | K100_AI | 1   | IFB | [**`>_`**](#qwen3-8b-ifb-k100_ai-1x-vllm-015) |
 | [Qwen/Qwen3-8B-Channel-INT8-w8a8](https://www.modelscope.cn/models/hygon/Qwen3-8B-Channel-INT8-w8a8) | INT8 W8A8 | 0.18 | BW1100 | 1 | IFB | [**`>_`**](#qwen3-8b-channel-int8-w8a8-ifb-bw1100-1x-vllm-018) |
+|  | INT8 W8A8 | 0.18-hotfix | BW1100 | 1 | IFB | [**`>_`**](#qwen3-8b-channel-int8-w8a8-ifb-bw1100-1x-vllm-018-hotfix) |
 |                                                                               | INT8 W8A8 | 0.18 | BW1000 | 1 | IFB | [**`>_`**](#qwen3-8b-channel-int8-w8a8-ifb-bw1000-1x-vllm-018) |
+|  | INT8 W8A8 | 0.18-hotfix | BW1000 | 1 | IFB | [**`>_`**](#qwen3-8b-channel-int8-w8a8-ifb-bw1000-1x-vllm-018-hotfix) |
 |                                                                               | INT8 W8A8 | 0.18 | K100_AI | 1 | IFB | [**`>_`**](#qwen3-8b-channel-int8-w8a8-ifb-k100_ai-1x-vllm-018) |
 |                                                                               | INT8 W8A8 | 0.15 | BW1100 | 1 | IFB | [**`>_`**](#qwen3-8b-channel-int8-w8a8-ifb-bw1100-1x-vllm-015) |
 |                                                                               | INT8 W8A8 | 0.15 | BW1000 | 1 | IFB | [**`>_`**](#qwen3-8b-channel-int8-w8a8-ifb-bw1000-1x-vllm-015) |
 |                                                                               | INT8 W8A8 | 0.15 | K100_AI | 1 | IFB | [**`>_`**](#qwen3-8b-channel-int8-w8a8-ifb-k100_ai-1x-vllm-015) |
 | [Qwen/Qwen3-14B](https://www.modelscope.cn/models/Qwen/Qwen3-14B)             | BF16 | 0.18 | BW1100  | 1 | IFB | [**`>_`**](#qwen3-14b-ifb-bw1100-1x-vllm-018)           |
+|  | BF16 | 0.18-hotfix | BW1100 | 1 | IFB | [**`>_`**](#qwen3-14b-ifb-bw1100-1x-vllm-018-hotfix) |
 |                                                                               | BF16 | 0.18 | BW1000  | 1 | IFB | [**`>_`**](#qwen3-14b-ifb-bw1000-1x-vllm-018)           |
+|  | BF16 | 0.18-hotfix | BW1000 | 1 | IFB | [**`>_`**](#qwen3-14b-ifb-bw1000-1x-vllm-018-hotfix) |
 |                                                                               | BF16 | 0.18 | K100_AI | 1 | IFB | [**`>_`**](#qwen3-14b-ifb-k100_ai-1x-vllm-018)          |
+|  | BF16 | 0.18-hotfix | K100_AI | 1 | IFB | [**`>_`**](#qwen3-14b-ifb-k100_ai-1x-vllm-018-hotfix) |
 |                                                                               | BF16 | 0.15 | BW1100  | 1   | IFB | [**`>_`**](#qwen3-14b-ifb-bw1100-1x-vllm-015) |
 |                                                                               | BF16 | 0.15 | BW1000  | 1 | IFB | [**`>_`**](#qwen3-14b-ifb-bw1000-1x-vllm-015)           |
 |                                                                               | BF16 | 0.15 | K100_AI | 1   | IFB | [**`>_`**](#qwen3-14b-ifb-k100_ai-1x-vllm-015) |
 | [Qwen/Qwen3-14B-Channel-INT8-w8a8](https://www.modelscope.cn/models/hygon/Qwen3-14B-Channel-INT8-w8a8) | INT8 W8A8 | 0.18 | BW1100 | 1 | IFB | [**`>_`**](#qwen3-14b-channel-int8-w8a8-ifb-bw1100-1x-vllm-018) |
+|  | INT8 W8A8 | 0.18-hotfix | BW1100 | 1 | IFB | [**`>_`**](#qwen3-14b-channel-int8-w8a8-ifb-bw1100-1x-vllm-018-hotfix) |
 |                                                                               | INT8 W8A8 | 0.18 | BW1000 | 1 | IFB | [**`>_`**](#qwen3-14b-channel-int8-w8a8-ifb-bw1000-1x-vllm-018) |
+|  | INT8 W8A8 | 0.18-hotfix | BW1000 | 1 | IFB | [**`>_`**](#qwen3-14b-channel-int8-w8a8-ifb-bw1000-1x-vllm-018-hotfix) |
 |                                                                               | INT8 W8A8 | 0.18 | K100_AI | 1 | IFB | [**`>_`**](#qwen3-14b-channel-int8-w8a8-ifb-k100_ai-1x-vllm-018) |
 |                                                                               | INT8 W8A8 | 0.15 | BW1100 | 1 | IFB | [**`>_`**](#qwen3-14b-channel-int8-w8a8-ifb-bw1100-1x-vllm-015) |
 |                                                                               | INT8 W8A8 | 0.15 | BW1000 | 1 | IFB | [**`>_`**](#qwen3-14b-channel-int8-w8a8-ifb-bw1000-1x-vllm-015) |
 |                                                                               | INT8 W8A8 | 0.15 | K100_AI | 1 | IFB | [**`>_`**](#qwen3-14b-channel-int8-w8a8-ifb-k100_ai-1x-vllm-015) |
 | [Qwen/Qwen3-32B](https://www.modelscope.cn/models/Qwen/Qwen3-32B)             | BF16 | 0.18 | BW1100  | 1 | IFB | [**`>_`**](#qwen3-32b-ifb-bw1100-1x-vllm-018)           |
+|  | BF16 | 0.18-hotfix | BW1100 | 1 | IFB | [**`>_`**](#qwen3-32b-ifb-bw1100-1x-vllm-018-hotfix) |
 |                                                                               | BF16 | 0.18 | BW1000  | 2 | IFB | [**`>_`**](#qwen3-32b-ifb-bw1000-2x-vllm-018)           |
+|  | BF16 | 0.18-hotfix | BW1000 | 2 | IFB | [**`>_`**](#qwen3-32b-ifb-bw1000-2x-vllm-018-hotfix) |
 |                                                                               | BF16 | 0.18 | K100_AI | 2 | IFB | [**`>_`**](#qwen3-32b-ifb-k100_ai-2x-vllm-018)          |
+|  | BF16 | 0.18-hotfix | K100_AI | 2 | IFB | [**`>_`**](#qwen3-32b-ifb-k100_ai-2x-vllm-018-hotfix) |
 |                                                                               | BF16 | 0.15 | BW1100  | 1 | IFB | [**`>_`**](#qwen3-32b-ifb-bw1100-1x-vllm-015)           |
 |                                                                               | BF16 | 0.15 | BW1000  | 2   | IFB | [**`>_`**](#qwen3-32b-ifb-bw1000-2x-vllm-015) |
 |                                                                               | BF16 | 0.15 | K100_AI | 2   | IFB | [**`>_`**](#qwen3-32b-ifb-k100_ai-2x-vllm-015) |
 | [Qwen/Qwen3-30B-A3B-Instruct-2507](https://www.modelscope.cn/models/Qwen/Qwen3-30B-A3B-Instruct-2507) | BF16 | 0.18 | BW1100 | 1 | IFB | [**`>_`**](#qwen3-30b-a3b-instruct-2507-ifb-bw1100-1x-vllm-018) |
+|  | BF16 | 0.18-hotfix | BW1100 | 1 | IFB | [**`>_`**](#qwen3-30b-a3b-instruct-2507-ifb-bw1100-1x-vllm-018-hotfix) |
 |                                                                               | BF16 | 0.18 | BW1000 | 2 | IFB | [**`>_`**](#qwen3-30b-a3b-instruct-2507-ifb-bw1000-2x-vllm-018) |
+|  | BF16 | 0.18-hotfix | BW1000 | 2 | IFB | [**`>_`**](#qwen3-30b-a3b-instruct-2507-ifb-bw1000-2x-vllm-018-hotfix) |
 |                                                                               | BF16 | 0.18 | K100_AI | 2 | IFB | [**`>_`**](#qwen3-30b-a3b-instruct-2507-ifb-k100_ai-2x-vllm-018) |
+|  | BF16 | 0.18-hotfix | K100_AI | 2 | IFB | [**`>_`**](#qwen3-30b-a3b-instruct-2507-ifb-k100_ai-2x-vllm-018-hotfix) |
 |                                                                               | BF16 | 0.15 | BW1100  | 1 | IFB | [**`>_`**](#qwen3-30b-a3b-instruct-2507-ifb-bw1100-1x-vllm-015) |
 |                                                                               | BF16 | 0.15 | BW1000  | 2 | IFB | [**`>_`**](#qwen3-30b-a3b-instruct-2507-ifb-bw1000-2x-vllm-015) |
 |                                                                               | BF16 | 0.15 | K100_AI | 2   | IFB | [**`>_`**](#qwen3-30b-a3b-instruct-2507-ifb-k100_ai-2x-vllm-015) |
 | [Qwen/Qwen3-30B-A3B-Channel-INT8-w8a8](https://www.modelscope.cn/models/hygon/Qwen3-30B-A3B-Channel-INT8-w8a8) | INT8 W8A8 | 0.18 | BW1100 | 1 | IFB | [**`>_`**](#qwen3-30b-a3b-instruct-2507-w8a8-int8-ifb-bw1100-1x-vllm-018) |
+|  | INT8 W8A8 | 0.18-hotfix | BW1100 | 1 | IFB | [**`>_`**](#qwen3-30b-a3b-instruct-2507-w8a8-int8-ifb-bw1100-1x-vllm-018-hotfix) |
 |                                                                               | INT8 W8A8 | 0.18 | BW1000 | 1 | IFB | [**`>_`**](#qwen3-30b-a3b-instruct-2507-w8a8-int8-ifb-bw1000-1x-vllm-018) |
+|  | INT8 W8A8 | 0.18-hotfix | BW1000 | 1 | IFB | [**`>_`**](#qwen3-30b-a3b-instruct-2507-w8a8-int8-ifb-bw1000-1x-vllm-018-hotfix) |
 |                                                                               | INT8 W8A8 | 0.18 | K100_AI | 1 | IFB | [**`>_`**](#qwen3-30b-a3b-instruct-2507-w8a8-int8-ifb-k100_ai-1x-vllm-018) |
 |                                                                               | INT8 W8A8 | 0.15 | BW1100 | 1 | IFB | [**`>_`**](#qwen3-30b-a3b-instruct-2507-w8a8-int8-ifb-bw1100-1x-vllm-015) |
 |                                                                               | INT8 W8A8 | 0.15 | BW1000 | 1 | IFB | [**`>_`**](#qwen3-30b-a3b-instruct-2507-w8a8-int8-ifb-bw1000-1x-vllm-015) |
 |                                                                               | INT8 W8A8 | 0.15 | K100_AI | 1 | IFB | [**`>_`**](#qwen3-30b-a3b-instruct-2507-w8a8-int8-ifb-k100_ai-1x-vllm-015) |
 | [Qwen/Qwen3-235B-A22B-Instruct-2507](https://www.modelscope.cn/models/Qwen/Qwen3-235B-A22B-Instruct-2507) | BF16 | 0.18 | BW1100 | 4 | IFB | [**`>_`**](#qwen3-235b-a22b-instruct-2507-ifb-bw1100-4x-vllm-018) |
+|  | BF16 | 0.18-hotfix | BW1100 | 4 | IFB | [**`>_`**](#qwen3-235b-a22b-instruct-2507-ifb-bw1100-4x-vllm-018-hotfix) |
 |                                                                               | BF16 | 0.18 | BW1000 | 8 | IFB | [**`>_`**](#qwen3-235b-a22b-instruct-2507-ifb-bw1000-8x-vllm-018) |
+|  | BF16 | 0.18-hotfix | BW1000 | 8 | IFB | [**`>_`**](#qwen3-235b-a22b-instruct-2507-ifb-bw1000-8x-vllm-018-hotfix) |
 |                                                                               | BF16 | 0.18 | K100_AI | 8 | IFB | [**`>_`**](#qwen3-235b-a22b-instruct-2507-ifb-k100_ai-8x-vllm-018) |
 |                                                                               | BF16 | 0.15 | BW1100  | 4 | IFB | [**`>_`**](#qwen3-235b-a22b-instruct-2507-ifb-bw1100-4x-vllm-015) |
 |                                                                               | BF16 | 0.15 | BW1000  | 8 | IFB | [**`>_`**](#qwen3-235b-a22b-instruct-2507-ifb-bw1000-8x-vllm-015) |
 |                                                                               | BF16 | 0.15 | K100_AI | 8 | IFB | [**`>_`**](#qwen3-235b-a22b-instruct-2507-ifb-k100_ai-8x-vllm-015) |
 | [Qwen/Qwen3-235B-A22B-Channel-INT8-w8a8](https://www.modelscope.cn/models/hygon/Qwen3-235B-A22B-Channel-INT8-w8a8) | INT8 W8A8 | 0.18 | BW1100 | 2 | IFB | [**`>_`**](#qwen3-235b-a22b-channel-int8-w8a8-ifb-bw1100-2x-vllm-018) |
+|  | INT8 W8A8 | 0.18-hotfix | BW1100 | 2 | IFB | [**`>_`**](#qwen3-235b-a22b-channel-int8-w8a8-ifb-bw1100-2x-vllm-018-hotfix) |
 |                                                                               | INT8 W8A8 | 0.18 | BW1000 | 4 | IFB | [**`>_`**](#qwen3-235b-a22b-channel-int8-w8a8-ifb-bw1000-4x-vllm-018) |
+|  | INT8 W8A8 | 0.18-hotfix | BW1000 | 4 | IFB | [**`>_`**](#qwen3-235b-a22b-channel-int8-w8a8-ifb-bw1000-4x-vllm-018-hotfix) |
 |                                                                               | INT8 W8A8 | 0.18 | K100_AI | 4 | IFB | [**`>_`**](#qwen3-235b-a22b-channel-int8-w8a8-ifb-k100_ai-4x-vllm-018) |
 |                                                                               | INT8 W8A8 | 0.15 | BW1100 | 4 | IFB | [**`>_`**](#qwen3-235b-a22b-channel-int8-w8a8-ifb-bw1100-4x-vllm-015) |
 |                                                                               | INT8 W8A8 | 0.15 | BW1000 | 4 | IFB | [**`>_`**](#qwen3-235b-a22b-channel-int8-w8a8-ifb-bw1000-4x-vllm-015) |
 |                                                                               | INT8 W8A8 | 0.15 | K100_AI | 4 | IFB | [**`>_`**](#qwen3-235b-a22b-channel-int8-w8a8-ifb-k100_ai-4x-vllm-015) |
 | [Qwen/Qwen3-235B-A22B-FP8-Channel](https://www.modelscope.cn/models/hygon/Qwen3-235B-A22B-W8A8) | FP8 | 0.18 | BW1100 | 4 | IFB | [**`>_`**](#qwen3-235b-a22b-fp8-channelwise-ifb-bw1100-4x-vllm-018) |
+|  | FP8 | 0.18-hotfix | BW1100 | 4 | IFB | [**`>_`**](#qwen3-235b-a22b-fp8-channelwise-ifb-bw1100-4x-vllm-018-hotfix) |
 |                                                                               | FP8  | 0.15 | BW1100 | 4 | IFB | [**`>_`**](#qwen3-235b-a22b-fp8-channelwise-ifb-bw1100-4x-vllm-015) |
 
 
@@ -104,6 +138,17 @@ vllm serve Qwen/Qwen3-0.6B \
   --kv-cache-dtype fp8_e4m3
 ```
 
+### Qwen3-0.6B IFB BW1100 1x vLLM 0.18-hotfix
+
+```bash
+export VLLM_HCU_USE_PD_SPLIT=1
+
+vllm serve Qwen/Qwen3-0.6B \
+  -tp 1 \
+  --trust-remote-code \
+  --kv-cache-dtype fp8_e4m3 \
+  --attention-backend FLASH_ATTN_CUSTOM
+```
 ### Qwen3-0.6B IFB BW1000 1x vLLM 0.18
 
 ```bash
@@ -116,6 +161,17 @@ vllm serve Qwen/Qwen3-0.6B \
   --kv-cache-dtype fp8_e5m2 
 ```
 
+### Qwen3-0.6B IFB BW1000 1x vLLM 0.18-hotfix
+
+```bash
+export VLLM_HCU_USE_PD_SPLIT=1
+
+vllm serve Qwen/Qwen3-0.6B \
+  -tp 1 \
+  --trust-remote-code \
+  --kv-cache-dtype fp8_e5m2 \
+  --attention-backend FLASH_ATTN_CUSTOM
+```
 ### Qwen3-0.6B IFB K100_AI 1x vLLM 0.18
 
 ```bash
@@ -127,6 +183,15 @@ vllm serve Qwen/Qwen3-0.6B \
   --trust-remote-code 
 ```
 
+### Qwen3-0.6B IFB K100_AI 1x vLLM 0.18-hotfix
+
+```bash
+
+vllm serve Qwen/Qwen3-0.6B \
+  -tp 1 \
+  --trust-remote-code \
+  --attention-backend FLASH_ATTN_CUSTOM
+```
 ### Qwen3-0.6B IFB BW1100 1x vLLM 0.15
 
 ### Qwen3-0.6B IFB BW1000 1x vLLM 0.15
@@ -157,6 +222,17 @@ vllm serve Qwen/Qwen3-1.7B \
   --kv-cache-dtype fp8_e4m3 
 ```
 
+### Qwen3-1.7B IFB BW1100 1x vLLM 0.18-hotfix
+
+```bash
+export VLLM_HCU_USE_PD_SPLIT=1
+
+vllm serve Qwen/Qwen3-1.7B \
+  -tp 1 \
+  --trust-remote-code \
+  --kv-cache-dtype fp8_e4m3 \
+  --attention-backend FLASH_ATTN_CUSTOM
+```
 ### Qwen3-1.7B IFB BW1000 1x vLLM 0.18
 ```bash
 export VLLM_HCU_USE_PD_SPLIT=1
@@ -168,6 +244,17 @@ vllm serve Qwen/Qwen3-1.7B \
   --kv-cache-dtype fp8_e5m2 
 ```
 
+### Qwen3-1.7B IFB BW1000 1x vLLM 0.18-hotfix
+
+```bash
+export VLLM_HCU_USE_PD_SPLIT=1
+
+vllm serve Qwen/Qwen3-1.7B \
+  -tp 1 \
+  --trust-remote-code \
+  --kv-cache-dtype fp8_e5m2 \
+  --attention-backend FLASH_ATTN_CUSTOM
+```
 ### Qwen3-1.7B IFB K100_AI 1x vLLM 0.18
 ```bash
 export VLLM_HCU_USE_CUSTOM_QUANTIZATION_GEMM=0
@@ -178,6 +265,16 @@ vllm serve Qwen/Qwen3-1.7B \
   --trust-remote-code
 ```
 
+### Qwen3-1.7B IFB K100_AI 1x vLLM 0.18-hotfix
+
+```bash
+export VLLM_HCU_USE_CUSTOM_QUANTIZATION_GEMM=0
+export VLLM_HCU_USE_CUSTOM_OPS=0
+
+vllm serve Qwen/Qwen3-1.7B \
+  -tp 1 \
+  --trust-remote-code
+```
 ### Qwen3-1.7B IFB BW1100 1x vLLM 0.15
 
 ### Qwen3-1.7B IFB BW1000 1x vLLM 0.15
@@ -200,6 +297,18 @@ vllm serve Qwen/Qwen3-4B \
   --max-num-batched-tokens 10240
 ```
 
+### Qwen3-4B IFB BW1100 1x vLLM 0.18-hotfix
+
+```bash
+export VLLM_HCU_USE_PD_SPLIT=1
+
+vllm serve Qwen/Qwen3-4B \
+  -tp 1 \
+  --trust-remote-code \
+  --kv-cache-dtype fp8_e4m3 \
+  --max-num-batched-tokens 10240 \
+  --attention-backend FLASH_ATTN_CUSTOM
+```
 ### Qwen3-4B IFB BW1000 1x vLLM 0.18
 ```bash
 export VLLM_HCU_USE_PD_SPLIT=1
@@ -212,6 +321,18 @@ vllm serve Qwen/Qwen3-4B \
   --max-num-batched-tokens 10240
 ```
 
+### Qwen3-4B IFB BW1000 1x vLLM 0.18-hotfix
+
+```bash
+export VLLM_HCU_USE_PD_SPLIT=1
+
+vllm serve Qwen/Qwen3-4B \
+  -tp 1 \
+  --trust-remote-code \
+  --kv-cache-dtype fp8_e5m2 \
+  --max-num-batched-tokens 10240 \
+  --attention-backend FLASH_ATTN_CUSTOM
+```
 ### Qwen3-4B IFB K100_AI 1x vLLM 0.18
 ```bash
 export VLLM_HCU_USE_CUSTOM_QUANTIZATION_GEMM=0
@@ -223,6 +344,17 @@ vllm serve Qwen/Qwen3-4B \
   --max-num-batched-tokens 10240 
 ```
 
+### Qwen3-4B IFB K100_AI 1x vLLM 0.18-hotfix
+
+```bash
+export VLLM_HCU_USE_CUSTOM_QUANTIZATION_GEMM=0
+export VLLM_HCU_USE_CUSTOM_OPS=0
+
+vllm serve Qwen/Qwen3-4B \
+  -tp 1 \
+  --trust-remote-code \
+  --max-num-batched-tokens 10240 
+```
 ### Qwen3-4B IFB BW1100 1x vLLM 0.15
 
 ### Qwen3-4B IFB BW1000 1x vLLM 0.15
@@ -240,6 +372,18 @@ vllm serve Qwen/Qwen3-4B-Channel-INT8-w8a8 \
   --q slimquant_marlin
 ```
 
+### Qwen3-4B-Channel-INT8-w8a8 IFB BW1100 1x vLLM 0.18-hotfix
+
+```bash
+export VLLM_HCU_USE_PD_SPLIT=1
+
+vllm serve Qwen/Qwen3-4B-Channel-INT8-w8a8 \
+  -tp  1 \
+  --trust-remote-code \
+  --max-num-batched-tokens 10240 \
+  --q slimquant_marlin \
+  --attention-backend FLASH_ATTN_CUSTOM
+```
 ### Qwen3-4B-Channel-INT8-w8a8 IFB BW1000 1x vLLM 0.18
 ```bash
 export VLLM_HCU_USE_CUSTOM_FLASH_ATTN=1
@@ -251,7 +395,18 @@ vllm serve Qwen/Qwen3-4B-Channel-INT8-w8a8 \
   --q slimquant_marlin
 ```
 
+### Qwen3-4B-Channel-INT8-w8a8 IFB BW1000 1x vLLM 0.18-hotfix
 
+```bash
+export VLLM_HCU_USE_PD_SPLIT=1
+
+vllm serve Qwen/Qwen3-4B-Channel-INT8-w8a8 \
+  -tp  1 \
+  --trust-remote-code \
+  --max-num-batched-tokens 10240 \
+  --q slimquant_marlin \
+  --attention-backend FLASH_ATTN_CUSTOM
+```
 ### Qwen3-4B-Channel-INT8-w8a8 IFB K100_AI 1x vLLM 0.18
 
 ### Qwen3-4B-Channel-INT8-w8a8 IFB BW1100 1x vLLM 0.15
@@ -272,6 +427,18 @@ vllm serve Qwen/Qwen3-8B \
   --max-num-batched-tokens 10240
 ```
 
+### Qwen3-8B IFB BW1100 1x vLLM 0.18-hotfix
+
+```bash
+export VLLM_HCU_USE_PD_SPLIT=1
+
+vllm serve Qwen/Qwen3-8B \
+  -tp 1 \
+  --trust-remote-code \
+  --kv-cache-dtype fp8_e4m3 \
+  --max-num-batched-tokens 10240 \
+  --attention-backend FLASH_ATTN_CUSTOM
+```
 ### Qwen3-8B IFB BW1000 1x vLLM 0.18
 ```bash
 export VLLM_HCU_USE_PD_SPLIT=1
@@ -284,6 +451,18 @@ vllm serve Qwen/Qwen3-8B \
   --max-num-batched-tokens 10240 
 ```
 
+### Qwen3-8B IFB BW1000 1x vLLM 0.18-hotfix
+
+```bash
+export VLLM_HCU_USE_PD_SPLIT=1
+
+vllm serve Qwen/Qwen3-8B \
+  -tp 1 \
+  --trust-remote-code \
+  --kv-cache-dtype fp8_e5m2 \
+  --max-num-batched-tokens 10240 \
+  --attention-backend FLASH_ATTN_CUSTOM
+```
 ### Qwen3-8B IFB K100_AI 1x vLLM 0.18
 ```bash
 export VLLM_HCU_USE_CUSTOM_QUANTIZATION_GEMM=0
@@ -295,6 +474,17 @@ vllm serve Qwen/Qwen3-8B \
   --max-num-batched-tokens 10240 
 ```
 
+### Qwen3-8B IFB K100_AI 1x vLLM 0.18-hotfix
+
+```bash
+export VLLM_HCU_USE_CUSTOM_QUANTIZATION_GEMM=0
+export VLLM_HCU_USE_CUSTOM_OPS=0
+
+vllm serve Qwen/Qwen3-8B \
+  -tp 1 \
+  --trust-remote-code \
+  --max-num-batched-tokens 10240 
+```
 ### Qwen3-8B IFB BW1100 1x vLLM 0.15
 
 ### Qwen3-8B IFB BW1000 1x vLLM 0.15
@@ -312,6 +502,18 @@ vllm serve Qwen/Qwen3-8B-Channel-INT8-w8a8 \
   --q slimquant_marlin
 ```
 
+### Qwen3-8B-Channel-INT8-w8a8 IFB BW1100 1x vLLM 0.18-hotfix
+
+```bash
+export VLLM_HCU_USE_PD_SPLIT=1
+
+vllm serve Qwen/Qwen3-8B-Channel-INT8-w8a8 \
+  -tp  1 \
+  --trust-remote-code \
+  --max-num-batched-tokens 10240 \
+  --q slimquant_marlin \
+  --attention-backend FLASH_ATTN_CUSTOM
+```
 ### Qwen3-8B-Channel-INT8-w8a8 IFB BW1000 1x vLLM 0.18
 ```bash
 export VLLM_HCU_USE_CUSTOM_FLASH_ATTN=1
@@ -323,6 +525,18 @@ vllm serve Qwen/Qwen3-8B-Channel-INT8-w8a8 \
   --q slimquant_marlin
 ```
 
+### Qwen3-8B-Channel-INT8-w8a8 IFB BW1000 1x vLLM 0.18-hotfix
+
+```bash
+export VLLM_HCU_USE_PD_SPLIT=1
+
+vllm serve Qwen/Qwen3-8B-Channel-INT8-w8a8 \
+  -tp  1 \
+  --trust-remote-code \
+  --max-num-batched-tokens 10240 \
+  --q slimquant_marlin \
+  --attention-backend FLASH_ATTN_CUSTOM
+```
 ### Qwen3-8B-Channel-INT8-w8a8 IFB K100_AI 1x vLLM 0.18
 
 ### Qwen3-8B-Channel-INT8-w8a8 IFB BW1100 1x vLLM 0.15
@@ -343,6 +557,18 @@ vllm serve Qwen/Qwen3-14B \
   --max-num-batched-tokens 10240
 ```
 
+### Qwen3-14B IFB BW1100 1x vLLM 0.18-hotfix
+
+```bash
+export VLLM_HCU_USE_PD_SPLIT=1
+
+vllm serve Qwen/Qwen3-14B \
+  -tp 1 \
+  --trust-remote-code \
+  --kv-cache-dtype fp8_e4m3 \
+  --max-num-batched-tokens 10240 \
+  --attention-backend FLASH_ATTN_CUSTOM
+```
 ### Qwen3-14B IFB BW1000 1x vLLM 0.18
 ```bash
 export VLLM_HCU_USE_PD_SPLIT=1
@@ -355,6 +581,18 @@ vllm serve Qwen/Qwen3-14B \
   --max-num-batched-tokens 10240
 ```
 
+### Qwen3-14B IFB BW1000 1x vLLM 0.18-hotfix
+
+```bash
+export VLLM_HCU_USE_PD_SPLIT=1
+
+vllm serve Qwen/Qwen3-14B \
+  -tp 1 \
+  --trust-remote-code \
+  --kv-cache-dtype fp8_e5m2 \
+  --max-num-batched-tokens 10240 \
+  --attention-backend FLASH_ATTN_CUSTOM
+```
 ### Qwen3-14B IFB K100_AI 1x vLLM 0.18
 ```bash
 export VLLM_HCU_USE_CUSTOM_QUANTIZATION_GEMM=0
@@ -366,6 +604,17 @@ vllm serve Qwen/Qwen3-14B \
   --max-num-batched-tokens 10240 
 ```
 
+### Qwen3-14B IFB K100_AI 1x vLLM 0.18-hotfix
+
+```bash
+export VLLM_HCU_USE_CUSTOM_QUANTIZATION_GEMM=0
+export VLLM_HCU_USE_CUSTOM_OPS=0
+
+vllm serve Qwen/Qwen3-14B \
+  -tp 1 \
+  --trust-remote-code \
+  --max-num-batched-tokens 10240 
+```
 ### Qwen3-14B IFB BW1100 1x vLLM 0.15
 
 ### Qwen3-14B IFB BW1000 1x vLLM 0.15
@@ -383,6 +632,18 @@ vllm serve Qwen/Qwen3-14B-Channel-INT8-w8a8 \
   --q slimquant_marlin
 ```
 
+### Qwen3-14B-Channel-INT8-w8a8 IFB BW1100 1x vLLM 0.18-hotfix
+
+```bash
+export VLLM_HCU_USE_PD_SPLIT=1
+
+vllm serve Qwen/Qwen3-14B-Channel-INT8-w8a8 \
+  -tp  1 \
+  --trust-remote-code \
+  --max-num-batched-tokens 10240 \
+  --q slimquant_marlin \
+  --attention-backend FLASH_ATTN_CUSTOM
+```
 ### Qwen3-14B-Channel-INT8-w8a8 IFB BW1000 1x vLLM 0.18
 ```bash
 export VLLM_HCU_USE_CUSTOM_FLASH_ATTN=1
@@ -392,8 +653,20 @@ vllm serve Qwen/Qwen3-14B-Channel-INT8-w8a8 \
   --trust-remote-code \
   --max-num-batched-tokens 10240 \
   --q slimquant_marlin
-``` 
+```
 
+### Qwen3-14B-Channel-INT8-w8a8 IFB BW1000 1x vLLM 0.18-hotfix
+
+```bash
+export VLLM_HCU_USE_PD_SPLIT=1
+
+vllm serve Qwen/Qwen3-14B-Channel-INT8-w8a8 \
+  -tp  1 \
+  --trust-remote-code \
+  --max-num-batched-tokens 10240 \
+  --q slimquant_marlin \
+  --attention-backend FLASH_ATTN_CUSTOM
+```
 ### Qwen3-14B-Channel-INT8-w8a8 IFB K100_AI 1x vLLM 0.18
 
 ### Qwen3-14B-Channel-INT8-w8a8 IFB BW1100 1x vLLM 0.15
@@ -414,6 +687,18 @@ vllm serve Qwen/Qwen3-32B \
   --max-num-batched-tokens 10240
 ```
 
+### Qwen3-32B IFB BW1100 1x vLLM 0.18-hotfix
+
+```bash
+export VLLM_HCU_USE_PD_SPLIT=1
+
+vllm serve Qwen/Qwen3-32B \
+  -tp 1 \
+  --trust-remote-code \
+  --kv-cache-dtype fp8_e4m3 \
+  --max-num-batched-tokens 10240 \
+  --attention-backend FLASH_ATTN_CUSTOM
+```
 ### Qwen3-32B IFB BW1000 2x vLLM 0.18
 ```bash
 export VLLM_HCU_USE_PD_SPLIT=1
@@ -426,6 +711,18 @@ vllm serve Qwen/Qwen3-32B \
   --max-num-batched-tokens 10240
 ```
 
+### Qwen3-32B IFB BW1000 2x vLLM 0.18-hotfix
+
+```bash
+export VLLM_HCU_USE_PD_SPLIT=1
+
+vllm serve Qwen/Qwen3-32B \
+  -tp 2 \
+  --trust-remote-code \
+  --kv-cache-dtype fp8_e5m2 \
+  --max-num-batched-tokens 10240 \
+  --attention-backend FLASH_ATTN_CUSTOM
+```
 ### Qwen3-32B IFB K100_AI 2x vLLM 0.18
 
 ```bash
@@ -438,6 +735,17 @@ vllm serve Qwen/Qwen3-32B \
   --max-num-batched-tokens 10240 
 ```
 
+### Qwen3-32B IFB K100_AI 2x vLLM 0.18-hotfix
+
+```bash
+export VLLM_HCU_USE_CUSTOM_QUANTIZATION_GEMM=0
+export VLLM_HCU_USE_CUSTOM_OPS=0
+
+vllm serve Qwen/Qwen3-32B \
+  -tp 2 \
+  --trust-remote-code \
+  --max-num-batched-tokens 10240 
+```
 ### Qwen3-32B IFB BW1100 1x vLLM 0.15
 
 ### Qwen3-32B IFB BW1000 2x vLLM 0.15
@@ -457,6 +765,17 @@ vllm serve Qwen/Qwen3-30B-A3B-Instruct-2507 \
   --max-num-batched-tokens 10240 
 ```
 
+### Qwen3-30B-A3B-Instruct-2507 IFB BW1100 1x vLLM 0.18-hotfix
+
+```bash
+export VLLM_HCU_USE_PD_SPLIT=1
+vllm serve Qwen/Qwen3-30B-A3B-Instruct-2507 \
+  -tp 1 \
+  --trust-remote-code \
+  --max-num-batched-tokens 10240 \
+  --attention-backend FLASH_ATTN_CUSTOM \
+  --moe-backend aiter
+```
 ### Qwen3-30B-A3B-Instruct-2507 IFB BW1000 2x vLLM 0.18
 ```bash
 export VLLM_HCU_USE_PD_SPLIT=1
@@ -470,6 +789,17 @@ vllm serve Qwen/Qwen3-30B-A3B-Instruct-2507 \
   --max-num-batched-tokens 10240 
 ```
 
+### Qwen3-30B-A3B-Instruct-2507 IFB BW1000 2x vLLM 0.18-hotfix
+
+```bash
+export VLLM_HCU_USE_PD_SPLIT=1
+vllm serve Qwen/Qwen3-30B-A3B-Instruct-2507 \
+  -tp 2 \
+  --trust-remote-code \
+  --max-num-batched-tokens 10240 \
+  --attention-backend FLASH_ATTN_CUSTOM \
+  --moe-backend aiter
+```
 ### Qwen3-30B-A3B-Instruct-2507 IFB K100_AI 2x vLLM 0.18
 ```bash
 export VLLM_HCU_USE_CUSTOM_QUANTIZATION_GEMM=0
@@ -481,6 +811,17 @@ vllm serve Qwen/Qwen3-30B-A3B-Instruct-2507 \
   --max-num-batched-tokens 10240 
 ```
 
+### Qwen3-30B-A3B-Instruct-2507 IFB K100_AI 2x vLLM 0.18-hotfix
+
+```bash
+export VLLM_HCU_USE_CUSTOM_QUANTIZATION_GEMM=0
+export VLLM_HCU_USE_CUSTOM_OPS=0
+
+vllm serve Qwen/Qwen3-30B-A3B-Instruct-2507 \
+  -tp 2 \
+  --trust-remote-code \
+  --max-num-batched-tokens 10240 
+```
 ### Qwen3-30B-A3B-Instruct-2507 IFB BW1100 1x vLLM 0.15
 
 ### Qwen3-30B-A3B-Instruct-2507 IFB BW1000 2x vLLM 0.15
@@ -510,7 +851,18 @@ vllm serve Qwen/Qwen3-30B-A3B-Instruct-2507-W8A8 \
   --q slimquant_marlin
 ```
 
+### Qwen3-30B-A3B-Instruct-2507-W8A8-INT8 IFB BW1100 1x vLLM 0.18-hotfix
 
+```bash
+export VLLM_HCU_USE_PD_SPLIT=1
+
+vllm serve Qwen/Qwen3-30B-A3B-Instruct-2507-W8A8 \
+  -tp  1 \
+  --trust-remote-code \
+  --max-num-batched-tokens 10240 \
+  --q slimquant_marlin \
+  --attention-backend FLASH_ATTN_CUSTOM
+```
 ### Qwen3-30B-A3B-Instruct-2507-W8A8-INT8 IFB BW1000 1x vLLM 0.18
 
 ```bash
@@ -524,7 +876,18 @@ vllm serve Qwen/Qwen3-30B-A3B-Instruct-2507-W8A8 \
   --q slimquant_marlin 
 ```
 
+### Qwen3-30B-A3B-Instruct-2507-W8A8-INT8 IFB BW1000 1x vLLM 0.18-hotfix
 
+```bash
+export VLLM_HCU_USE_PD_SPLIT=1
+
+vllm serve Qwen/Qwen3-30B-A3B-Instruct-2507-W8A8 \
+  -tp 1 \
+  --trust-remote-code \
+  --max-num-batched-tokens 10240 \
+  --q slimquant_marlin \
+  --attention-backend FLASH_ATTN_CUSTOM
+```
 ### Qwen3-30B-A3B-Instruct-2507-W8A8-INT8 IFB K100_AI 1x vLLM 0.18
 
 ### Qwen3-30B-A3B-Instruct-2507-W8A8-INT8 IFB BW1100 1x vLLM 0.15
@@ -546,6 +909,17 @@ vllm serve Qwen/Qwen3-235B-A22B-Instruct-2507 \
   --max-num-batched-tokens 10240 
 ```
 
+### Qwen3-235B-A22B-Instruct-2507 IFB BW1100 4x vLLM 0.18-hotfix
+
+```bash
+export VLLM_HCU_USE_PD_SPLIT=1
+vllm serve Qwen/Qwen3-235B-A22B-Instruct-2507 \
+  -tp 4 \
+  --trust-remote-code \
+  --max-num-batched-tokens 10240 \
+  --attention-backend FLASH_ATTN_CUSTOM \
+  --moe-backend aiter
+```
 ### Qwen3-235B-A22B-Instruct-2507 IFB BW1000 8x vLLM 0.18
 
 ```bash
@@ -561,7 +935,18 @@ vllm serve Qwen/Qwen3-235B-A22B-Instruct-2507 \
   --gpu-memory-utilization 0.95
 ```
 
+### Qwen3-235B-A22B-Instruct-2507 IFB BW1000 8x vLLM 0.18-hotfix
 
+```bash
+export VLLM_HCU_USE_PD_SPLIT=1
+vllm serve Qwen/Qwen3-235B-A22B-Instruct-2507 \
+  -tp 8 \
+  --trust-remote-code \
+  --max-num-batched-tokens 10240 \
+  --gpu-memory-utilization 0.95 \
+  --attention-backend FLASH_ATTN_CUSTOM \
+  --moe-backend aiter
+```
 ### Qwen3-235B-A22B-Instruct-2507 IFB K100_AI 8x vLLM 0.18
 
 <!-- TODO: 启动命令待补充 -->
@@ -617,10 +1002,23 @@ vllm serve Qwen/Qwen3-235B-A22B-Channel-INT8-w8a8  \
   --q slimquant_marlin \
   --max-model-len 40960 \
   --gpu-memory-utilization 0.95
-
 ```
 
+### Qwen3-235B-A22B-Channel-INT8-w8a8 IFB BW1100 2x vLLM 0.18-hotfix
 
+```bash
+export VLLM_HCU_USE_PD_SPLIT=1
+
+vllm serve Qwen/Qwen3-235B-A22B-Channel-INT8-w8a8  \
+  -tp  2 \
+  --trust-remote-code \
+  --max-num-batched-tokens 10240 \
+  --q slimquant_marlin \
+  --max-model-len 40960 \
+  --gpu-memory-utilization 0.95 \
+  --attention-backend FLASH_ATTN_CUSTOM
+
+```
 ### Qwen3-235B-A22B-Channel-INT8-w8a8 IFB BW1000 4x vLLM 0.18
 ```bash
 export VLLM_HCU_USE_CUSTOM_FLASH_ATTN=1
@@ -634,6 +1032,20 @@ vllm serve Qwen/Qwen3-235B-A22B-Channel-INT8-w8a8 \
   --gpu-memory-utilization 0.95
 ```
 
+### Qwen3-235B-A22B-Channel-INT8-w8a8 IFB BW1000 4x vLLM 0.18-hotfix
+
+```bash
+export VLLM_HCU_USE_PD_SPLIT=1
+
+vllm serve Qwen/Qwen3-235B-A22B-Channel-INT8-w8a8 \
+  -tp  4 \
+  --trust-remote-code \
+  --max-num-batched-tokens 10240 \
+  --q slimquant_marlin \
+  --max-model-len 40960 \
+  --gpu-memory-utilization 0.95 \
+  --attention-backend FLASH_ATTN_CUSTOM
+```
 ### Qwen3-235B-A22B-Channel-INT8-w8a8 IFB K100_AI 4x vLLM 0.18
 
 ### Qwen3-235B-A22B-Channel-INT8-w8a8 IFB BW1100 2x vLLM 0.15
@@ -653,6 +1065,17 @@ vllm serve Qwen/Qwen3-235B-A22B-FP8-Channelwise \
   --max-num-batched-tokens 10240 
 ```
 
+### Qwen3-235B-A22B-FP8-Channelwise IFB BW1100 4x vLLM 0.18-hotfix
+
+```bash
+export VLLM_HCU_USE_PD_SPLIT=1
+
+vllm serve Qwen/Qwen3-235B-A22B-FP8-Channelwise \
+  -tp 4 \
+  --trust-remote-code \
+  --max-num-batched-tokens 10240 \
+  --attention-backend FLASH_ATTN_CUSTOM
+```
 ### Qwen3-235B-A22B-FP8-Channelwise IFB BW1100 4x vLLM 0.15
 ```bash
 export VLLM_USE_LIGHTOP=1
@@ -673,7 +1096,6 @@ vllm serve Qwen/Qwen3-235B-A22B-FP8-Channelwise \
   --disable-cascade-attn \
   -cc '{"pass_config": {"fuse_act_quant": false}, "custom_ops": ["all"]}'
 ```
-
 
 
 


### PR DESCRIPTION
## 背景

vLLM 0.18 相关模型部署文档目前的启动命令基于 `0.18.1-ubuntu22.04-dtk26.04-py3.10` 镜像，其中若干环境变量在 hotfix 镜像中已由框架内置并暴露为 CLI 参数，需要在文档中体现两种镜像下的启动方式差异。

## 变更内容

对以下 8 个 vLLM 模型部署文档进行同类改造：

- `docs/model-deployment/vllm/qwen2.md`
- `docs/model-deployment/vllm/qwen2-vl.md`
- `docs/model-deployment/vllm/qwen2.5-vl.md`
- `docs/model-deployment/vllm/qwen3.md`
- `docs/model-deployment/vllm/qwen3-vl.md`
- `docs/model-deployment/vllm/qwen3.5.md`
- `docs/model-deployment/vllm/qwen3.6.md`
- `docs/model-deployment/vllm/kimi-k2.5.md`

### 具体改动

- 为每一个 vLLM 0.18 启动命令代码块的首行加入注释：`# 0.18.1-ubuntu22.04-dtk26.04-py3.10 镜像`
- 在原命令之后新增 `# hotfix 镜像` 段落，把以下环境变量替换为等价 CLI 参数：
  - `VLLM_HCU_USE_FLASH_ATTN=1` → `--attention-backend FLASH_ATTN_CLASSIC`（qwen3.5、qwen3.6）
  - `VLLM_HCU_USE_CUSTOM_FLASH_ATTN=1` → `--attention-backend FLASH_ATTN_CUSTOM`（qwen2、qwen2-vl、qwen2.5-vl、qwen3、qwen3-vl）
  - `VLLM_ROCM_USE_AITER=1` + `VLLM_ROCM_USE_AITER_MOE=1` → `--moe-backend aiter`（qwen3、qwen3.5、qwen3.6 MoE）
  - `VLLM_HCU_USE_AITER_W4A16_MOE=1` → `--moe-backend aiter`（kimi-k2.5）
- hotfix 变体一并移除 `VLLM_HCU_USE_PD_SPLIT`、`VLLM_HCU_USE_CUSTOM_TOPK_TOPP_SAMPLER` 等在新镜像下不再需要的环境变量。
- K100_AI 硬件上的 hotfix 变体保留原有环境变量与命令，仅补上 hotfix 段落。
- vLLM 0.15 相关章节与其他非 0.18 内容保持原样，未做改动。

## 影响范围

- 只涉及文档 (`docs/model-deployment/vllm/*.md`)，无代码/构建配置变更。
- 原有 0.18 启动命令保留可读性，用户可根据实际镜像版本二选一。

## 自测清单

- [x] 每个文件的表格锚点、章节标题、命令缩进未破坏。
- [x] hotfix 变体命令仍是可直接复制粘贴执行的合法 `vllm serve` 命令。
- [x] 0.15 与非 vLLM 部分未被改动。