### PR TITLE
docs/vllm/qwen: 为 0.18-hotfix BW1100/BW1000 命令添加 --kv-cache-dtype

### DIFF
--- a/docs/model-deployment/vllm/qwen2-vl.md
+++ b/docs/model-deployment/vllm/qwen2-vl.md
@@ -44,6 +44,7 @@ vllm serve Qwen/Qwen2-VL-2B \
     --chat-template-content-format openai \
     --chat-template qwen2_vl_openai_chat_template.jinja \
     --allowed-local-media-path /path-to/VL_data/ \
+    --kv-cache-dtype fp8_e4m3 \
     --attention-backend FLASH_ATTN_CUSTOM
 ```
 ### Qwen2-VL-2B IFB BW1000 1x vLLM 0.18
@@ -73,6 +74,7 @@ vllm serve Qwen/Qwen2-VL-2B \
     --chat-template-content-format openai \
     --chat-template qwen2_vl_openai_chat_template.jinja \
     --allowed-local-media-path /path-to/VL_data/ \
+    --kv-cache-dtype fp8_e5m2 \
     --attention-backend FLASH_ATTN_CUSTOM
 ```
 ### Qwen2-VL-2B IFB K100_AI 1x vLLM 0.18

--- a/docs/model-deployment/vllm/qwen2.5-vl.md
+++ b/docs/model-deployment/vllm/qwen2.5-vl.md
@@ -38,6 +38,7 @@ vllm serve Qwen/Qwen2.5-VL-32B-Instruct \
     -tp 2 \
     --trust-remote-code \
     --allowed-local-media-path /path-to/VL_data/ \
+    --kv-cache-dtype fp8_e5m2 \
     --attention-backend FLASH_ATTN_CUSTOM
 ```
 ### Qwen2.5-VL-32B-Instruct IFB BW1100 1x vLLM 0.18
@@ -64,6 +65,7 @@ vllm serve Qwen/Qwen2.5-VL-32B-Instruct \
     --enable-chunked-prefill \
     --max-model-len 32768 \
     --allowed-local-media-path /path-to/VL_data/ \
+    --kv-cache-dtype fp8_e4m3 \
     --attention-backend FLASH_ATTN_CUSTOM
 ```
 ### Qwen2.5-VL-32B-Instruct IFB K100_AI 4x vLLM 0.18

--- a/docs/model-deployment/vllm/qwen2.md
+++ b/docs/model-deployment/vllm/qwen2.md
@@ -61,6 +61,7 @@ export VLLM_USE_MODELSCOPE=1
 vllm serve Qwen/Qwen2-0.5B-Instruct \
   -tp 1 \
   --trust-remote-code \
+  --kv-cache-dtype fp8_e4m3 \
   --attention-backend FLASH_ATTN_CUSTOM
 ```
 ### Qwen2-0.5B-Instruct IFB BW1000 1x vLLM 0.18
@@ -83,6 +84,7 @@ export VLLM_USE_MODELSCOPE=1
 vllm serve Qwen/Qwen2-0.5B-Instruct \
   -tp 1 \
   --trust-remote-code \
+  --kv-cache-dtype fp8_e5m2 \
   --attention-backend FLASH_ATTN_CUSTOM
 ```
 ### Qwen2-0.5B-Instruct IFB K100_AI 1x vLLM 0.18
@@ -128,6 +130,7 @@ export VLLM_USE_MODELSCOPE=1
 vllm serve Qwen/Qwen2-1.5B-Instruct \
   -tp 1 \
   --trust-remote-code \
+  --kv-cache-dtype fp8_e4m3 \
   --attention-backend FLASH_ATTN_CUSTOM
 ```
 ### Qwen2-1.5B-Instruct IFB BW1000 1x vLLM 0.18
@@ -150,6 +153,7 @@ export VLLM_USE_MODELSCOPE=1
 vllm serve Qwen/Qwen2-1.5B-Instruct \
   -tp 1 \
   --trust-remote-code \
+  --kv-cache-dtype fp8_e5m2 \
   --attention-backend FLASH_ATTN_CUSTOM
 ```
 ### Qwen2-1.5B-Instruct IFB K100_AI 1x vLLM 0.18
@@ -195,6 +199,7 @@ export VLLM_USE_MODELSCOPE=1
 vllm serve Qwen/Qwen2-7B-Instruct \
   -tp 1 \
   --trust-remote-code \
+  --kv-cache-dtype fp8_e4m3 \
   --attention-backend FLASH_ATTN_CUSTOM
 ```
 ### Qwen2-7B-Instruct IFB BW1000 1x vLLM 0.18
@@ -217,6 +222,7 @@ export VLLM_USE_MODELSCOPE=1
 vllm serve Qwen/Qwen2-7B-Instruct \
   -tp 1 \
   --trust-remote-code \
+  --kv-cache-dtype fp8_e5m2 \
   --attention-backend FLASH_ATTN_CUSTOM
 ```
 ### Qwen2-7B-Instruct IFB K100_AI 1x vLLM 0.18
@@ -262,6 +268,7 @@ export VLLM_USE_MODELSCOPE=1
 vllm serve Qwen/Qwen2-57B-A14B-Instruct \
   -tp 2 \
   --trust-remote-code \
+  --kv-cache-dtype fp8_e4m3 \
   --attention-backend FLASH_ATTN_CUSTOM
 ```
 ### Qwen2-57B-A14B-Instruct IFB BW1000 4x vLLM 0.18
@@ -284,6 +291,7 @@ export VLLM_USE_MODELSCOPE=1
 vllm serve Qwen/Qwen2-57B-A14B-Instruct \
   -tp 4 \
   --trust-remote-code \
+  --kv-cache-dtype fp8_e5m2 \
   --attention-backend FLASH_ATTN_CUSTOM
 ```
 ### Qwen2-57B-A14B-Instruct IFB K100_AI 4x vLLM 0.18
@@ -329,6 +337,7 @@ export VLLM_USE_MODELSCOPE=1
 vllm serve Qwen/Qwen2-72B-Instruct \
   -tp 2 \
   --trust-remote-code \
+  --kv-cache-dtype fp8_e4m3 \
   --attention-backend FLASH_ATTN_CUSTOM
 ```
 ### Qwen2-72B-Instruct IFB BW1000 4x vLLM 0.18
@@ -351,6 +360,7 @@ export VLLM_USE_MODELSCOPE=1
 vllm serve Qwen/Qwen2-72B-Instruct \
   -tp 4 \
   --trust-remote-code \
+  --kv-cache-dtype fp8_e5m2 \
   --attention-backend FLASH_ATTN_CUSTOM
 ```
 ### Qwen2-72B-Instruct IFB K100_AI 4x vLLM 0.18

--- a/docs/model-deployment/vllm/qwen3-vl.md
+++ b/docs/model-deployment/vllm/qwen3-vl.md
@@ -109,6 +109,7 @@ export VLLM_USE_MODELSCOPE=1
 vllm serve Qwen/Qwen3-VL-2B-Instruct \
   -tp 1 \
   --trust-remote-code \
+  --kv-cache-dtype fp8_e4m3 \
   --attention-backend FLASH_ATTN_CUSTOM
 ```
 ### Qwen3-VL-2B-Instruct IFB BW1000 1x vLLM 0.18
@@ -129,6 +130,7 @@ export VLLM_USE_MODELSCOPE=1
 vllm serve Qwen/Qwen3-VL-2B-Instruct \
   -tp 1 \
   --trust-remote-code \
+  --kv-cache-dtype fp8_e5m2 \
   --attention-backend FLASH_ATTN_CUSTOM
 ```
 ### Qwen3-VL-2B-Instruct IFB K100_AI 1x vLLM 0.18
@@ -169,6 +171,7 @@ export VLLM_USE_MODELSCOPE=1
 vllm serve Qwen/Qwen3-VL-2B-Thinking \
   -tp 1 \
   --trust-remote-code \
+  --kv-cache-dtype fp8_e4m3 \
   --attention-backend FLASH_ATTN_CUSTOM
 ```
 ### Qwen3-VL-2B-Thinking IFB BW1000 1x vLLM 0.18
@@ -189,6 +192,7 @@ export VLLM_USE_MODELSCOPE=1
 vllm serve Qwen/Qwen3-VL-2B-Thinking \
   -tp 1 \
   --trust-remote-code \
+  --kv-cache-dtype fp8_e5m2 \
   --attention-backend FLASH_ATTN_CUSTOM
 ```
 ### Qwen3-VL-2B-Thinking IFB K100_AI 1x vLLM 0.18
@@ -229,6 +233,7 @@ export VLLM_USE_MODELSCOPE=1
 vllm serve Qwen/Qwen3-VL-4B-Instruct \
   -tp 1 \
   --trust-remote-code \
+  --kv-cache-dtype fp8_e4m3 \
   --attention-backend FLASH_ATTN_CUSTOM
 ```
 ### Qwen3-VL-4B-Instruct IFB BW1000 1x vLLM 0.18
@@ -249,6 +254,7 @@ export VLLM_USE_MODELSCOPE=1
 vllm serve Qwen/Qwen3-VL-4B-Instruct \
   -tp 1 \
   --trust-remote-code \
+  --kv-cache-dtype fp8_e5m2 \
   --attention-backend FLASH_ATTN_CUSTOM
 ```
 ### Qwen3-VL-4B-Instruct IFB K100_AI 1x vLLM 0.18
@@ -289,6 +295,7 @@ export VLLM_USE_MODELSCOPE=1
 vllm serve Qwen/Qwen3-VL-4B-Thinking \
   -tp 1 \
   --trust-remote-code \
+  --kv-cache-dtype fp8_e4m3 \
   --attention-backend FLASH_ATTN_CUSTOM
 ```
 ### Qwen3-VL-4B-Thinking IFB BW1000 1x vLLM 0.18
@@ -309,6 +316,7 @@ export VLLM_USE_MODELSCOPE=1
 vllm serve Qwen/Qwen3-VL-4B-Thinking \
   -tp 1 \
   --trust-remote-code \
+  --kv-cache-dtype fp8_e5m2 \
   --attention-backend FLASH_ATTN_CUSTOM
 ```
 ### Qwen3-VL-4B-Thinking IFB K100_AI 1x vLLM 0.18
@@ -349,6 +357,7 @@ export VLLM_USE_MODELSCOPE=1
 vllm serve Qwen/Qwen3-VL-8B-Instruct \
   -tp 1 \
   --trust-remote-code \
+  --kv-cache-dtype fp8_e4m3 \
   --attention-backend FLASH_ATTN_CUSTOM
 ```
 ### Qwen3-VL-8B-Instruct IFB BW1000 1x vLLM 0.18
@@ -369,6 +378,7 @@ export VLLM_USE_MODELSCOPE=1
 vllm serve Qwen/Qwen3-VL-8B-Instruct \
   -tp 1 \
   --trust-remote-code \
+  --kv-cache-dtype fp8_e5m2 \
   --attention-backend FLASH_ATTN_CUSTOM
 ```
 ### Qwen3-VL-8B-Instruct IFB K100_AI 1x vLLM 0.18
@@ -409,6 +419,7 @@ export VLLM_USE_MODELSCOPE=1
 vllm serve Qwen/Qwen3-VL-8B-Thinking \
   -tp 1 \
   --trust-remote-code \
+  --kv-cache-dtype fp8_e4m3 \
   --attention-backend FLASH_ATTN_CUSTOM
 ```
 ### Qwen3-VL-8B-Thinking IFB BW1000 1x vLLM 0.18
@@ -429,6 +440,7 @@ export VLLM_USE_MODELSCOPE=1
 vllm serve Qwen/Qwen3-VL-8B-Thinking \
   -tp 1 \
   --trust-remote-code \
+  --kv-cache-dtype fp8_e5m2 \
   --attention-backend FLASH_ATTN_CUSTOM
 ```
 ### Qwen3-VL-8B-Thinking IFB K100_AI 1x vLLM 0.18
@@ -469,6 +481,7 @@ export VLLM_USE_MODELSCOPE=1
 vllm serve Qwen/Qwen3-VL-30B-A3B-Instruct \
   -tp 1 \
   --trust-remote-code \
+  --kv-cache-dtype fp8_e4m3 \
   --attention-backend FLASH_ATTN_CUSTOM
 ```
 ### Qwen3-VL-30B-A3B-Instruct IFB BW1000 2x vLLM 0.18
@@ -489,6 +502,7 @@ export VLLM_USE_MODELSCOPE=1
 vllm serve Qwen/Qwen3-VL-30B-A3B-Instruct \
   -tp 2 \
   --trust-remote-code \
+  --kv-cache-dtype fp8_e5m2 \
   --attention-backend FLASH_ATTN_CUSTOM
 ```
 ### Qwen3-VL-30B-A3B-Instruct IFB K100_AI 2x vLLM 0.18
@@ -529,6 +543,7 @@ export VLLM_USE_MODELSCOPE=1
 vllm serve Qwen/Qwen3-VL-30B-A3B-Thinking \
   -tp 1 \
   --trust-remote-code \
+  --kv-cache-dtype fp8_e4m3 \
   --attention-backend FLASH_ATTN_CUSTOM
 ```
 ### Qwen3-VL-30B-A3B-Thinking IFB BW1000 2x vLLM 0.18
@@ -549,6 +564,7 @@ export VLLM_USE_MODELSCOPE=1
 vllm serve Qwen/Qwen3-VL-30B-A3B-Thinking \
   -tp 2 \
   --trust-remote-code \
+  --kv-cache-dtype fp8_e5m2 \
   --attention-backend FLASH_ATTN_CUSTOM
 ```
 ### Qwen3-VL-30B-A3B-Thinking IFB K100_AI 2x vLLM 0.18
@@ -589,6 +605,7 @@ export VLLM_USE_MODELSCOPE=1
 vllm serve Qwen/Qwen3-VL-32B-Instruct \
   -tp 1 \
   --trust-remote-code \
+  --kv-cache-dtype fp8_e4m3 \
   --attention-backend FLASH_ATTN_CUSTOM
 ```
 ### Qwen3-VL-32B-Instruct IFB BW1000 2x vLLM 0.18
@@ -609,6 +626,7 @@ export VLLM_USE_MODELSCOPE=1
 vllm serve Qwen/Qwen3-VL-32B-Instruct \
   -tp 2 \
   --trust-remote-code \
+  --kv-cache-dtype fp8_e5m2 \
   --attention-backend FLASH_ATTN_CUSTOM
 ```
 ### Qwen3-VL-32B-Instruct IFB K100_AI 2x vLLM 0.18
@@ -650,6 +668,7 @@ export VLLM_USE_MODELSCOPE=1
 vllm serve Qwen/Qwen3-VL-235B-A22B-Instruct \
   -tp 8 \
   --trust-remote-code \
+  --kv-cache-dtype fp8_e4m3 \
   --attention-backend FLASH_ATTN_CUSTOM
 ```
 ### Qwen3-VL-235B-A22B-Instruct IFB BW1000 16x vLLM 0.18
@@ -672,6 +691,7 @@ vllm serve Qwen/Qwen3-VL-235B-A22B-Instruct \
   -tp 8 \
   -pp 2 \
   --trust-remote-code \
+  --kv-cache-dtype fp8_e5m2 \
   --attention-backend FLASH_ATTN_CUSTOM
 ```
 ### Qwen3-VL-235B-A22B-Instruct IFB K100_AI 16x vLLM 0.18
@@ -714,6 +734,7 @@ export VLLM_USE_MODELSCOPE=1
 vllm serve Qwen/Qwen3-VL-235B-A22B-Thinking \
   -tp 8 \
   --trust-remote-code \
+  --kv-cache-dtype fp8_e4m3 \
   --attention-backend FLASH_ATTN_CUSTOM
 ```
 ### Qwen3-VL-235B-A22B-Thinking IFB BW1000 16x vLLM 0.18
@@ -736,6 +757,7 @@ vllm serve Qwen/Qwen3-VL-235B-A22B-Thinking \
   -tp 8 \
   -pp 2 \
   --trust-remote-code \
+  --kv-cache-dtype fp8_e5m2 \
   --attention-backend FLASH_ATTN_CUSTOM
 ```
 ### Qwen3-VL-235B-A22B-Thinking IFB K100_AI 16x vLLM 0.18

--- a/docs/model-deployment/vllm/qwen3.5.md
+++ b/docs/model-deployment/vllm/qwen3.5.md
@@ -98,6 +98,7 @@ vllm serve Qwen/Qwen3.5-4B \
   --max-num-batched-tokens 10240 \
   --speculative-config.method mtp \
   --speculative-config.num_speculative_tokens 3 \
+  --kv-cache-dtype fp8_e4m3 \
   --attention-backend FLASH_ATTN_CUSTOM
 ```
 ### Qwen3.5-4B IFB BW1000 1x vLLM 0.18
@@ -124,6 +125,7 @@ vllm serve Qwen/Qwen3.5-4B \
   --max-num-batched-tokens 10240 \
   --speculative-config.method mtp \
   --speculative-config.num_speculative_tokens 3 \
+  --kv-cache-dtype fp8_e5m2 \
   --attention-backend FLASH_ATTN_CUSTOM
 ```
 
@@ -179,6 +181,7 @@ vllm serve Qwen/Qwen3.5-9B \
   --max-num-batched-tokens 10240 \
   --speculative-config.method mtp \
   --speculative-config.num_speculative_tokens 3 \
+  --kv-cache-dtype fp8_e4m3 \
   --attention-backend FLASH_ATTN_CUSTOM
 ```
 ### Qwen3.5-9B IFB BW1000 1x vLLM 0.18
@@ -206,6 +209,7 @@ vllm serve Qwen/Qwen3.5-9B \
   --max-num-batched-tokens 10240 \
   --speculative-config.method mtp \
   --speculative-config.num_speculative_tokens 3 \
+  --kv-cache-dtype fp8_e5m2 \
   --attention-backend FLASH_ATTN_CUSTOM
 ```
 ### Qwen3.5-9B IFB K100_AI 1x vLLM 0.18
@@ -260,6 +264,7 @@ vllm serve Qwen/Qwen3.5-27B \
   --max-num-batched-tokens 10240 \
   --speculative-config.method mtp \
   --speculative-config.num_speculative_tokens 3 \
+  --kv-cache-dtype fp8_e4m3 \
   --attention-backend FLASH_ATTN_CUSTOM
 ```
 ### Qwen3.5-27B IFB BW1000 2x vLLM 0.18
@@ -287,6 +292,7 @@ vllm serve Qwen/Qwen3.5-27B \
   --max-num-batched-tokens 10240 \
   --speculative-config.method mtp \
   --speculative-config.num_speculative_tokens 3 \
+  --kv-cache-dtype fp8_e5m2 \
   --attention-backend FLASH_ATTN_CUSTOM
 ```
 ### Qwen3.5-27B IFB K100_AI 2x vLLM 0.18
@@ -345,6 +351,7 @@ vllm serve hygon/Qwen3.5-27B-Channel-INT8-w8a8 \
   --speculative-config.method mtp \
   --speculative-config.num_speculative_tokens 3 \
   --speculative-config.quantization "slimquant_marlin" \
+  --kv-cache-dtype fp8_e4m3 \
   --attention-backend FLASH_ATTN_CUSTOM
 ```
 ### Qwen3.5-27B-Channel-INT8-w8a8 IFB BW1000 1x vLLM 0.18
@@ -376,6 +383,7 @@ vllm serve hygon/Qwen3.5-27B-Channel-INT8-w8a8 \
   --speculative-config.method mtp \
   --speculative-config.num_speculative_tokens 3 \
   --speculative-config.quantization "slimquant_marlin" \
+  --kv-cache-dtype fp8_e5m2 \
   --attention-backend FLASH_ATTN_CUSTOM
 ```
 ### Qwen3.5-27B-Channel-INT8-w8a8 IFB K100_AI 1x vLLM 0.18
@@ -432,6 +440,7 @@ vllm serve Qwen/Qwen3.5-35B-A3B \
   --max-num-batched-tokens 10240 \
   --speculative-config.method mtp \
   --speculative-config.num_speculative_tokens 3 \
+  --kv-cache-dtype fp8_e4m3 \
   --attention-backend FLASH_ATTN_CUSTOM \
   --moe-backend aiter
 ```
@@ -462,6 +471,7 @@ vllm serve Qwen/Qwen3.5-35B-A3B \
   --max-num-batched-tokens 10240 \
   --speculative-config.method mtp \
   --speculative-config.num_speculative_tokens 3 \
+  --kv-cache-dtype fp8_e5m2 \
   --attention-backend FLASH_ATTN_CUSTOM \
   --moe-backend aiter
 ```
@@ -521,6 +531,7 @@ vllm serve hygon/Qwen3.5-35B-A3B-Channel-INT8-w8a8 \
   --speculative-config.method mtp \
   --speculative-config.num_speculative_tokens 3 \
   --speculative-config.quantization "slimquant_marlin" \
+  --kv-cache-dtype fp8_e4m3 \
   --attention-backend FLASH_ATTN_CUSTOM
 ```
 ### Qwen3.5-35B-A3B-Channel-INT8-w8a8 IFB BW1000 1x vLLM 0.18
@@ -552,6 +563,7 @@ vllm serve hygon/Qwen3.5-35B-A3B-Channel-INT8-w8a8 \
   --speculative-config.method mtp \
   --speculative-config.num_speculative_tokens 3 \
   --speculative-config.quantization "slimquant_marlin" \
+  --kv-cache-dtype fp8_e5m2 \
   --attention-backend FLASH_ATTN_CUSTOM
 ```
 ### Qwen3.5-35B-A3B-Channel-INT8-w8a8 IFB K100_AI 1x vLLM 0.18
@@ -610,6 +622,7 @@ vllm serve hygon/Qwen3.5-35B-A3B-Channel-FP8-w8a8 \
   --speculative-config.method mtp \
   --speculative-config.num_speculative_tokens 3 \
   --speculative-config.quantization "slimquant_marlin" \
+  --kv-cache-dtype fp8_e4m3 \
   --attention-backend FLASH_ATTN_CUSTOM
 ```
 ### Qwen3.5-122B-A10B IFB BW1100 4x vLLM 0.18
@@ -639,6 +652,7 @@ vllm serve Qwen/Qwen3.5-122B-A10B \
   --max-num-batched-tokens 10240 \
   --speculative-config.method mtp \
   --speculative-config.num_speculative_tokens 3 \
+  --kv-cache-dtype fp8_e4m3 \
   --attention-backend FLASH_ATTN_CUSTOM \
   --moe-backend aiter
 ```
@@ -669,6 +683,7 @@ vllm serve Qwen/Qwen3.5-122B-A10B \
   --max-num-batched-tokens 10240 \
   --speculative-config.method mtp \
   --speculative-config.num_speculative_tokens 3 \
+  --kv-cache-dtype fp8_e5m2 \
   --attention-backend FLASH_ATTN_CUSTOM \
   --moe-backend aiter
 ```
@@ -728,6 +743,7 @@ vllm serve Qwen/Qwen3.5-122B-A10B-W8A8-INT8 \
   --speculative-config.method mtp \
   --speculative-config.num_speculative_tokens 3 \
   --speculative-config.quantization "slimquant_marlin" \
+  --kv-cache-dtype fp8_e4m3 \
   --attention-backend FLASH_ATTN_CUSTOM
 ```
 ### Qwen3.5-122B-A10B-W8A8-INT8 IFB BW1000 4x vLLM 0.18
@@ -759,6 +775,7 @@ vllm serve Qwen/Qwen3.5-122B-A10B-W8A8-INT8 \
   --speculative-config.method mtp \
   --speculative-config.num_speculative_tokens 3 \
   --speculative-config.quantization "slimquant_marlin" \
+  --kv-cache-dtype fp8_e5m2 \
   --attention-backend FLASH_ATTN_CUSTOM
 ```
 ### Qwen3.5-122B-A10B-W8A8-INT8 IFB K100_AI 4x vLLM 0.18
@@ -817,6 +834,7 @@ vllm serve hygon/Qwen3.5-122B-A10B-Channel-FP8-w8a8 \
   --speculative-config.method mtp \
   --speculative-config.num_speculative_tokens 3 \
   --speculative-config.quantization "slimquant_marlin" \
+  --kv-cache-dtype fp8_e4m3 \
   --attention-backend FLASH_ATTN_CUSTOM
 ```
 ### Qwen3.5-397B-A17B-W8A8-INT8 IFB BW1100 8x vLLM 0.18
@@ -848,6 +866,7 @@ vllm serve Qwen/Qwen3.5-397B-A17B-W8A8-INT8 \
   --speculative-config.method mtp \
   --speculative-config.num_speculative_tokens 3 \
   --speculative-config.quantization "slimquant_marlin" \
+  --kv-cache-dtype fp8_e4m3 \
   --attention-backend FLASH_ATTN_CUSTOM
 ```
 ### Qwen3.5-397B-A17B-W8A8-INT8 IFB BW1000 8x vLLM 0.18
@@ -879,6 +898,7 @@ vllm serve Qwen/Qwen3.5-397B-A17B-W8A8-INT8 \
   --speculative-config.method mtp \
   --speculative-config.num_speculative_tokens 3 \
   --speculative-config.quantization "slimquant_marlin" \
+  --kv-cache-dtype fp8_e5m2 \
   --attention-backend FLASH_ATTN_CUSTOM
 ```
 ### Qwen3.5-397B-A17B-W8A8-INT8 IFB K100_AI 8x vLLM 0.18
@@ -937,6 +957,7 @@ vllm serve hygon/Qwen3.5-397B-A17B-Channel-FP8 \
   --speculative-config.method mtp \
   --speculative-config.num_speculative_tokens 3 \
   --speculative-config.quantization "slimquant_marlin" \
+  --kv-cache-dtype fp8_e4m3 \
   --attention-backend FLASH_ATTN_CUSTOM
 ```
 ## API 调用

--- a/docs/model-deployment/vllm/qwen3.6.md
+++ b/docs/model-deployment/vllm/qwen3.6.md
@@ -48,6 +48,7 @@ vllm serve Qwen/Qwen3.6-27B \
   --max-num-batched-tokens 10240 \
   --speculative-config.method mtp \
   --speculative-config.num_speculative_tokens 3 \
+  --kv-cache-dtype fp8_e4m3 \
   --attention-backend FLASH_ATTN_CUSTOM
 ```
 ### Qwen3.6-27B IFB BW1000 2x vLLM 0.18
@@ -75,6 +76,7 @@ vllm serve Qwen/Qwen3.6-27B \
   --max-num-batched-tokens 10240 \
   --speculative-config.method mtp \
   --speculative-config.num_speculative_tokens 3 \
+  --kv-cache-dtype fp8_e5m2 \
   --attention-backend FLASH_ATTN_CUSTOM
 ```
 ### Qwen3.6-27B IFB K100_AI 2x vLLM 0.18
@@ -131,6 +133,7 @@ vllm serve Qwen/Qwen3.6-35B-A3B \
   --max-num-batched-tokens 10240 \
   --speculative-config.method mtp \
   --speculative-config.num_speculative_tokens 3 \
+  --kv-cache-dtype fp8_e4m3 \
   --attention-backend FLASH_ATTN_CUSTOM \
   --moe-backend aiter
 ```
@@ -161,6 +164,7 @@ vllm serve Qwen/Qwen3.6-35B-A3B \
   --max-num-batched-tokens 10240 \
   --speculative-config.method mtp \
   --speculative-config.num_speculative_tokens 3 \
+  --kv-cache-dtype fp8_e5m2 \
   --attention-backend FLASH_ATTN_CUSTOM \
   --moe-backend aiter
 ```

--- a/docs/model-deployment/vllm/qwen3.md
+++ b/docs/model-deployment/vllm/qwen3.md
@@ -382,6 +382,7 @@ vllm serve Qwen/Qwen3-4B-Channel-INT8-w8a8 \
   --trust-remote-code \
   --max-num-batched-tokens 10240 \
   --q slimquant_marlin \
+  --kv-cache-dtype fp8_e4m3 \
   --attention-backend FLASH_ATTN_CUSTOM
 ```
 ### Qwen3-4B-Channel-INT8-w8a8 IFB BW1000 1x vLLM 0.18
@@ -405,6 +406,7 @@ vllm serve Qwen/Qwen3-4B-Channel-INT8-w8a8 \
   --trust-remote-code \
   --max-num-batched-tokens 10240 \
   --q slimquant_marlin \
+  --kv-cache-dtype fp8_e5m2 \
   --attention-backend FLASH_ATTN_CUSTOM
 ```
 ### Qwen3-4B-Channel-INT8-w8a8 IFB K100_AI 1x vLLM 0.18
@@ -512,6 +514,7 @@ vllm serve Qwen/Qwen3-8B-Channel-INT8-w8a8 \
   --trust-remote-code \
   --max-num-batched-tokens 10240 \
   --q slimquant_marlin \
+  --kv-cache-dtype fp8_e4m3 \
   --attention-backend FLASH_ATTN_CUSTOM
 ```
 ### Qwen3-8B-Channel-INT8-w8a8 IFB BW1000 1x vLLM 0.18
@@ -535,6 +538,7 @@ vllm serve Qwen/Qwen3-8B-Channel-INT8-w8a8 \
   --trust-remote-code \
   --max-num-batched-tokens 10240 \
   --q slimquant_marlin \
+  --kv-cache-dtype fp8_e5m2 \
   --attention-backend FLASH_ATTN_CUSTOM
 ```
 ### Qwen3-8B-Channel-INT8-w8a8 IFB K100_AI 1x vLLM 0.18
@@ -642,6 +646,7 @@ vllm serve Qwen/Qwen3-14B-Channel-INT8-w8a8 \
   --trust-remote-code \
   --max-num-batched-tokens 10240 \
   --q slimquant_marlin \
+  --kv-cache-dtype fp8_e4m3 \
   --attention-backend FLASH_ATTN_CUSTOM
 ```
 ### Qwen3-14B-Channel-INT8-w8a8 IFB BW1000 1x vLLM 0.18
@@ -665,6 +670,7 @@ vllm serve Qwen/Qwen3-14B-Channel-INT8-w8a8 \
   --trust-remote-code \
   --max-num-batched-tokens 10240 \
   --q slimquant_marlin \
+  --kv-cache-dtype fp8_e5m2 \
   --attention-backend FLASH_ATTN_CUSTOM
 ```
 ### Qwen3-14B-Channel-INT8-w8a8 IFB K100_AI 1x vLLM 0.18
@@ -773,6 +779,7 @@ vllm serve Qwen/Qwen3-30B-A3B-Instruct-2507 \
   -tp 1 \
   --trust-remote-code \
   --max-num-batched-tokens 10240 \
+  --kv-cache-dtype fp8_e4m3 \
   --attention-backend FLASH_ATTN_CUSTOM \
   --moe-backend aiter
 ```
@@ -797,6 +804,7 @@ vllm serve Qwen/Qwen3-30B-A3B-Instruct-2507 \
   -tp 2 \
   --trust-remote-code \
   --max-num-batched-tokens 10240 \
+  --kv-cache-dtype fp8_e5m2 \
   --attention-backend FLASH_ATTN_CUSTOM \
   --moe-backend aiter
 ```
@@ -861,6 +869,7 @@ vllm serve Qwen/Qwen3-30B-A3B-Instruct-2507-W8A8 \
   --trust-remote-code \
   --max-num-batched-tokens 10240 \
   --q slimquant_marlin \
+  --kv-cache-dtype fp8_e4m3 \
   --attention-backend FLASH_ATTN_CUSTOM
 ```
 ### Qwen3-30B-A3B-Instruct-2507-W8A8-INT8 IFB BW1000 1x vLLM 0.18
@@ -886,6 +895,7 @@ vllm serve Qwen/Qwen3-30B-A3B-Instruct-2507-W8A8 \
   --trust-remote-code \
   --max-num-batched-tokens 10240 \
   --q slimquant_marlin \
+  --kv-cache-dtype fp8_e5m2 \
   --attention-backend FLASH_ATTN_CUSTOM
 ```
 ### Qwen3-30B-A3B-Instruct-2507-W8A8-INT8 IFB K100_AI 1x vLLM 0.18
@@ -917,6 +927,7 @@ vllm serve Qwen/Qwen3-235B-A22B-Instruct-2507 \
   -tp 4 \
   --trust-remote-code \
   --max-num-batched-tokens 10240 \
+  --kv-cache-dtype fp8_e4m3 \
   --attention-backend FLASH_ATTN_CUSTOM \
   --moe-backend aiter
 ```
@@ -944,6 +955,7 @@ vllm serve Qwen/Qwen3-235B-A22B-Instruct-2507 \
   --trust-remote-code \
   --max-num-batched-tokens 10240 \
   --gpu-memory-utilization 0.95 \
+  --kv-cache-dtype fp8_e5m2 \
   --attention-backend FLASH_ATTN_CUSTOM \
   --moe-backend aiter
 ```
@@ -1016,6 +1028,7 @@ vllm serve Qwen/Qwen3-235B-A22B-Channel-INT8-w8a8  \
   --q slimquant_marlin \
   --max-model-len 40960 \
   --gpu-memory-utilization 0.95 \
+  --kv-cache-dtype fp8_e4m3 \
   --attention-backend FLASH_ATTN_CUSTOM
 
 ```
@@ -1044,6 +1057,7 @@ vllm serve Qwen/Qwen3-235B-A22B-Channel-INT8-w8a8 \
   --q slimquant_marlin \
   --max-model-len 40960 \
   --gpu-memory-utilization 0.95 \
+  --kv-cache-dtype fp8_e5m2 \
   --attention-backend FLASH_ATTN_CUSTOM
 ```
 ### Qwen3-235B-A22B-Channel-INT8-w8a8 IFB K100_AI 4x vLLM 0.18
@@ -1074,6 +1088,7 @@ vllm serve Qwen/Qwen3-235B-A22B-FP8-Channelwise \
   -tp 4 \
   --trust-remote-code \
   --max-num-batched-tokens 10240 \
+  --kv-cache-dtype fp8_e4m3 \
   --attention-backend FLASH_ATTN_CUSTOM
 ```
 ### Qwen3-235B-A22B-FP8-Channelwise IFB BW1100 4x vLLM 0.15


### PR DESCRIPTION
## Summary

- BW1100 的 `0.18-hotfix` 启动命令统一添加 `--kv-cache-dtype fp8_e4m3`
- BW1000 的 `0.18-hotfix` 启动命令统一添加 `--kv-cache-dtype fp8_e5m2`
- K100_AI、非 hotfix 版本命令不做改动

涉及文件：`qwen2.md`、`qwen2-vl.md`、`qwen2.5-vl.md`、`qwen3.md`、`qwen3-vl.md`、`qwen3.5.md`、`qwen3.6.md`，共 7 个文件、76 行新增。

## Test plan

- [ ] 检查每个 Qwen 文档的 BW1100 0.18-hotfix 小节：命令含 `--kv-cache-dtype fp8_e4m3`
- [ ] 检查每个 Qwen 文档的 BW1000 0.18-hotfix 小节：命令含 `--kv-cache-dtype fp8_e5m2`
- [ ] 确认 K100_AI 和非 hotfix 小节未被修改

🤖 Generated with Claude Code