### PR TITLE
docs: update qwen hotfix vLLM flags

### DIFF
--- a/docs/model-deployment/vllm/qwen2-vl.md
+++ b/docs/model-deployment/vllm/qwen2-vl.md
@@ -74,7 +74,6 @@ vllm serve Qwen/Qwen2-VL-2B \
     --chat-template-content-format openai \
     --chat-template qwen2_vl_openai_chat_template.jinja \
     --allowed-local-media-path /path-to/VL_data/ \
-    --kv-cache-dtype fp8_e5m2 \
     --attention-backend FLASH_ATTN_CUSTOM
 ```
 ### Qwen2-VL-2B IFB K100_AI 1x vLLM 0.18

--- a/docs/model-deployment/vllm/qwen2.5-vl.md
+++ b/docs/model-deployment/vllm/qwen2.5-vl.md
@@ -38,7 +38,6 @@ vllm serve Qwen/Qwen2.5-VL-32B-Instruct \
     -tp 2 \
     --trust-remote-code \
     --allowed-local-media-path /path-to/VL_data/ \
-    --kv-cache-dtype fp8_e5m2 \
     --attention-backend FLASH_ATTN_CUSTOM
 ```
 ### Qwen2.5-VL-32B-Instruct IFB BW1100 1x vLLM 0.18

--- a/docs/model-deployment/vllm/qwen2.md
+++ b/docs/model-deployment/vllm/qwen2.md
@@ -84,7 +84,6 @@ export VLLM_USE_MODELSCOPE=1
 vllm serve Qwen/Qwen2-0.5B-Instruct \
   -tp 1 \
   --trust-remote-code \
-  --kv-cache-dtype fp8_e5m2 \
   --attention-backend FLASH_ATTN_CUSTOM
 ```
 ### Qwen2-0.5B-Instruct IFB K100_AI 1x vLLM 0.18
@@ -153,7 +152,6 @@ export VLLM_USE_MODELSCOPE=1
 vllm serve Qwen/Qwen2-1.5B-Instruct \
   -tp 1 \
   --trust-remote-code \
-  --kv-cache-dtype fp8_e5m2 \
   --attention-backend FLASH_ATTN_CUSTOM
 ```
 ### Qwen2-1.5B-Instruct IFB K100_AI 1x vLLM 0.18
@@ -222,7 +220,6 @@ export VLLM_USE_MODELSCOPE=1
 vllm serve Qwen/Qwen2-7B-Instruct \
   -tp 1 \
   --trust-remote-code \
-  --kv-cache-dtype fp8_e5m2 \
   --attention-backend FLASH_ATTN_CUSTOM
 ```
 ### Qwen2-7B-Instruct IFB K100_AI 1x vLLM 0.18
@@ -291,7 +288,6 @@ export VLLM_USE_MODELSCOPE=1
 vllm serve Qwen/Qwen2-57B-A14B-Instruct \
   -tp 4 \
   --trust-remote-code \
-  --kv-cache-dtype fp8_e5m2 \
   --attention-backend FLASH_ATTN_CUSTOM
 ```
 ### Qwen2-57B-A14B-Instruct IFB K100_AI 4x vLLM 0.18
@@ -360,7 +356,6 @@ export VLLM_USE_MODELSCOPE=1
 vllm serve Qwen/Qwen2-72B-Instruct \
   -tp 4 \
   --trust-remote-code \
-  --kv-cache-dtype fp8_e5m2 \
   --attention-backend FLASH_ATTN_CUSTOM
 ```
 ### Qwen2-72B-Instruct IFB K100_AI 4x vLLM 0.18

--- a/docs/model-deployment/vllm/qwen3-vl.md
+++ b/docs/model-deployment/vllm/qwen3-vl.md
@@ -130,7 +130,6 @@ export VLLM_USE_MODELSCOPE=1
 vllm serve Qwen/Qwen3-VL-2B-Instruct \
   -tp 1 \
   --trust-remote-code \
-  --kv-cache-dtype fp8_e5m2 \
   --attention-backend FLASH_ATTN_CUSTOM
 ```
 ### Qwen3-VL-2B-Instruct IFB K100_AI 1x vLLM 0.18
@@ -192,7 +191,6 @@ export VLLM_USE_MODELSCOPE=1
 vllm serve Qwen/Qwen3-VL-2B-Thinking \
   -tp 1 \
   --trust-remote-code \
-  --kv-cache-dtype fp8_e5m2 \
   --attention-backend FLASH_ATTN_CUSTOM
 ```
 ### Qwen3-VL-2B-Thinking IFB K100_AI 1x vLLM 0.18
@@ -254,7 +252,6 @@ export VLLM_USE_MODELSCOPE=1
 vllm serve Qwen/Qwen3-VL-4B-Instruct \
   -tp 1 \
   --trust-remote-code \
-  --kv-cache-dtype fp8_e5m2 \
   --attention-backend FLASH_ATTN_CUSTOM
 ```
 ### Qwen3-VL-4B-Instruct IFB K100_AI 1x vLLM 0.18
@@ -316,7 +313,6 @@ export VLLM_USE_MODELSCOPE=1
 vllm serve Qwen/Qwen3-VL-4B-Thinking \
   -tp 1 \
   --trust-remote-code \
-  --kv-cache-dtype fp8_e5m2 \
   --attention-backend FLASH_ATTN_CUSTOM
 ```
 ### Qwen3-VL-4B-Thinking IFB K100_AI 1x vLLM 0.18
@@ -378,7 +374,6 @@ export VLLM_USE_MODELSCOPE=1
 vllm serve Qwen/Qwen3-VL-8B-Instruct \
   -tp 1 \
   --trust-remote-code \
-  --kv-cache-dtype fp8_e5m2 \
   --attention-backend FLASH_ATTN_CUSTOM
 ```
 ### Qwen3-VL-8B-Instruct IFB K100_AI 1x vLLM 0.18
@@ -440,7 +435,6 @@ export VLLM_USE_MODELSCOPE=1
 vllm serve Qwen/Qwen3-VL-8B-Thinking \
   -tp 1 \
   --trust-remote-code \
-  --kv-cache-dtype fp8_e5m2 \
   --attention-backend FLASH_ATTN_CUSTOM
 ```
 ### Qwen3-VL-8B-Thinking IFB K100_AI 1x vLLM 0.18
@@ -502,7 +496,6 @@ export VLLM_USE_MODELSCOPE=1
 vllm serve Qwen/Qwen3-VL-30B-A3B-Instruct \
   -tp 2 \
   --trust-remote-code \
-  --kv-cache-dtype fp8_e5m2 \
   --attention-backend FLASH_ATTN_CUSTOM
 ```
 ### Qwen3-VL-30B-A3B-Instruct IFB K100_AI 2x vLLM 0.18
@@ -564,7 +557,6 @@ export VLLM_USE_MODELSCOPE=1
 vllm serve Qwen/Qwen3-VL-30B-A3B-Thinking \
   -tp 2 \
   --trust-remote-code \
-  --kv-cache-dtype fp8_e5m2 \
   --attention-backend FLASH_ATTN_CUSTOM
 ```
 ### Qwen3-VL-30B-A3B-Thinking IFB K100_AI 2x vLLM 0.18
@@ -626,7 +618,6 @@ export VLLM_USE_MODELSCOPE=1
 vllm serve Qwen/Qwen3-VL-32B-Instruct \
   -tp 2 \
   --trust-remote-code \
-  --kv-cache-dtype fp8_e5m2 \
   --attention-backend FLASH_ATTN_CUSTOM
 ```
 ### Qwen3-VL-32B-Instruct IFB K100_AI 2x vLLM 0.18
@@ -691,7 +682,6 @@ vllm serve Qwen/Qwen3-VL-235B-A22B-Instruct \
   -tp 8 \
   -pp 2 \
   --trust-remote-code \
-  --kv-cache-dtype fp8_e5m2 \
   --attention-backend FLASH_ATTN_CUSTOM
 ```
 ### Qwen3-VL-235B-A22B-Instruct IFB K100_AI 16x vLLM 0.18
@@ -757,7 +747,6 @@ vllm serve Qwen/Qwen3-VL-235B-A22B-Thinking \
   -tp 8 \
   -pp 2 \
   --trust-remote-code \
-  --kv-cache-dtype fp8_e5m2 \
   --attention-backend FLASH_ATTN_CUSTOM
 ```
 ### Qwen3-VL-235B-A22B-Thinking IFB K100_AI 16x vLLM 0.18

--- a/docs/model-deployment/vllm/qwen3.5.md
+++ b/docs/model-deployment/vllm/qwen3.5.md
@@ -90,8 +90,6 @@ vllm serve Qwen/Qwen3.5-4B \
 ### Qwen3.5-4B IFB BW1100 1x vLLM 0.18-hotfix
 
 ```bash
-export VLLM_HCU_USE_PD_SPLIT=1
-
 vllm serve Qwen/Qwen3.5-4B \
   -tp 1 \
   --trust-remote-code \
@@ -118,14 +116,12 @@ vllm serve Qwen/Qwen3.5-4B \
 ### Qwen3.5-4B IFB BW1000 1x vLLM 0.18-hotfix
 
 ```bash
-export VLLM_HCU_USE_PD_SPLIT=1
 vllm serve Qwen/Qwen3.5-4B \
   -tp 1 \
   --trust-remote-code \
   --max-num-batched-tokens 10240 \
   --speculative-config.method mtp \
   --speculative-config.num_speculative_tokens 3 \
-  --kv-cache-dtype fp8_e5m2 \
   --attention-backend FLASH_ATTN_CUSTOM
 ```
 
@@ -173,8 +169,6 @@ vllm serve Qwen/Qwen3.5-9B \
 ### Qwen3.5-9B IFB BW1100 1x vLLM 0.18-hotfix
 
 ```bash
-export VLLM_HCU_USE_PD_SPLIT=1
-
 vllm serve Qwen/Qwen3.5-9B \
   -tp 1 \
   --trust-remote-code \
@@ -201,15 +195,12 @@ vllm serve Qwen/Qwen3.5-9B \
 ### Qwen3.5-9B IFB BW1000 1x vLLM 0.18-hotfix
 
 ```bash
-export VLLM_HCU_USE_PD_SPLIT=1
-
 vllm serve Qwen/Qwen3.5-9B \
   -tp 1 \
   --trust-remote-code \
   --max-num-batched-tokens 10240 \
   --speculative-config.method mtp \
   --speculative-config.num_speculative_tokens 3 \
-  --kv-cache-dtype fp8_e5m2 \
   --attention-backend FLASH_ATTN_CUSTOM
 ```
 ### Qwen3.5-9B IFB K100_AI 1x vLLM 0.18
@@ -256,8 +247,6 @@ vllm serve Qwen/Qwen3.5-27B \
 ### Qwen3.5-27B IFB BW1100 1x vLLM 0.18-hotfix
 
 ```bash
-export VLLM_HCU_USE_PD_SPLIT=1
-
 vllm serve Qwen/Qwen3.5-27B \
   -tp 1 \
   --trust-remote-code \
@@ -284,15 +273,12 @@ vllm serve Qwen/Qwen3.5-27B \
 ### Qwen3.5-27B IFB BW1000 2x vLLM 0.18-hotfix
 
 ```bash
-export VLLM_HCU_USE_PD_SPLIT=1
-
 vllm serve Qwen/Qwen3.5-27B \
   -tp 2 \
   --trust-remote-code \
   --max-num-batched-tokens 10240 \
   --speculative-config.method mtp \
   --speculative-config.num_speculative_tokens 3 \
-  --kv-cache-dtype fp8_e5m2 \
   --attention-backend FLASH_ATTN_CUSTOM
 ```
 ### Qwen3.5-27B IFB K100_AI 2x vLLM 0.18
@@ -341,8 +327,6 @@ vllm serve hygon/Qwen3.5-27B-Channel-INT8-w8a8 \
 ### Qwen3.5-27B-Channel-INT8-w8a8 IFB BW1100 1x vLLM 0.18-hotfix
 
 ```bash
-export VLLM_HCU_USE_PD_SPLIT=1
-
 vllm serve hygon/Qwen3.5-27B-Channel-INT8-w8a8 \
   -tp 1 \
   --trust-remote-code \
@@ -373,8 +357,6 @@ vllm serve hygon/Qwen3.5-27B-Channel-INT8-w8a8 \
 ### Qwen3.5-27B-Channel-INT8-w8a8 IFB BW1000 1x vLLM 0.18-hotfix
 
 ```bash
-export VLLM_HCU_USE_PD_SPLIT=1
-
 vllm serve hygon/Qwen3.5-27B-Channel-INT8-w8a8 \
   -tp 1 \
   --trust-remote-code \
@@ -383,7 +365,6 @@ vllm serve hygon/Qwen3.5-27B-Channel-INT8-w8a8 \
   --speculative-config.method mtp \
   --speculative-config.num_speculative_tokens 3 \
   --speculative-config.quantization "slimquant_marlin" \
-  --kv-cache-dtype fp8_e5m2 \
   --attention-backend FLASH_ATTN_CUSTOM
 ```
 ### Qwen3.5-27B-Channel-INT8-w8a8 IFB K100_AI 1x vLLM 0.18
@@ -433,7 +414,6 @@ vllm serve Qwen/Qwen3.5-35B-A3B \
 ### Qwen3.5-35B-A3B IFB BW1100 1x vLLM 0.18-hotfix
 
 ```bash
-export VLLM_HCU_USE_PD_SPLIT=1
 vllm serve Qwen/Qwen3.5-35B-A3B \
   -tp 1 \
   --trust-remote-code \
@@ -464,14 +444,12 @@ vllm serve Qwen/Qwen3.5-35B-A3B \
 ### Qwen3.5-35B-A3B IFB BW1000 2x vLLM 0.18-hotfix
 
 ```bash
-export VLLM_HCU_USE_PD_SPLIT=1
 vllm serve Qwen/Qwen3.5-35B-A3B \
   -tp 2 \
   --trust-remote-code \
   --max-num-batched-tokens 10240 \
   --speculative-config.method mtp \
   --speculative-config.num_speculative_tokens 3 \
-  --kv-cache-dtype fp8_e5m2 \
   --attention-backend FLASH_ATTN_CUSTOM \
   --moe-backend aiter
 ```
@@ -521,8 +499,6 @@ vllm serve hygon/Qwen3.5-35B-A3B-Channel-INT8-w8a8 \
 ### Qwen3.5-35B-A3B-Channel-INT8-w8a8 IFB BW1100 1x vLLM 0.18-hotfix
 
 ```bash
-export VLLM_HCU_USE_PD_SPLIT=1
-
 vllm serve hygon/Qwen3.5-35B-A3B-Channel-INT8-w8a8 \
   -tp 1 \
   --trust-remote-code \
@@ -553,8 +529,6 @@ vllm serve hygon/Qwen3.5-35B-A3B-Channel-INT8-w8a8 \
 ### Qwen3.5-35B-A3B-Channel-INT8-w8a8 IFB BW1000 1x vLLM 0.18-hotfix
 
 ```bash
-export VLLM_HCU_USE_PD_SPLIT=1
-
 vllm serve hygon/Qwen3.5-35B-A3B-Channel-INT8-w8a8 \
   -tp 1 \
   --trust-remote-code \
@@ -563,7 +537,6 @@ vllm serve hygon/Qwen3.5-35B-A3B-Channel-INT8-w8a8 \
   --speculative-config.method mtp \
   --speculative-config.num_speculative_tokens 3 \
   --speculative-config.quantization "slimquant_marlin" \
-  --kv-cache-dtype fp8_e5m2 \
   --attention-backend FLASH_ATTN_CUSTOM
 ```
 ### Qwen3.5-35B-A3B-Channel-INT8-w8a8 IFB K100_AI 1x vLLM 0.18
@@ -612,8 +585,6 @@ vllm serve hygon/Qwen3.5-35B-A3B-Channel-FP8-w8a8 \
 ### Qwen3.5-35B-A3B-Channel-FP8-w8a8 IFB BW1100 1x vLLM 0.18-hotfix
 
 ```bash
-export VLLM_HCU_USE_PD_SPLIT=1
-
 vllm serve hygon/Qwen3.5-35B-A3B-Channel-FP8-w8a8 \
   -tp 1 \
   --trust-remote-code \
@@ -645,7 +616,6 @@ vllm serve Qwen/Qwen3.5-122B-A10B \
 ### Qwen3.5-122B-A10B IFB BW1100 4x vLLM 0.18-hotfix
 
 ```bash
-export VLLM_HCU_USE_PD_SPLIT=1
 vllm serve Qwen/Qwen3.5-122B-A10B \
   -tp 4 \
   --trust-remote-code \
@@ -676,14 +646,12 @@ vllm serve Qwen/Qwen3.5-122B-A10B \
 ### Qwen3.5-122B-A10B IFB BW1000 8x vLLM 0.18-hotfix
 
 ```bash
-export VLLM_HCU_USE_PD_SPLIT=1
 vllm serve Qwen/Qwen3.5-122B-A10B \
   -tp 8 \
   --trust-remote-code \
   --max-num-batched-tokens 10240 \
   --speculative-config.method mtp \
   --speculative-config.num_speculative_tokens 3 \
-  --kv-cache-dtype fp8_e5m2 \
   --attention-backend FLASH_ATTN_CUSTOM \
   --moe-backend aiter
 ```
@@ -733,8 +701,6 @@ vllm serve Qwen/Qwen3.5-122B-A10B-W8A8-INT8 \
 ### Qwen3.5-122B-A10B-W8A8-INT8 IFB BW1100 2x vLLM 0.18-hotfix
 
 ```bash
-export VLLM_HCU_USE_PD_SPLIT=1
-
 vllm serve Qwen/Qwen3.5-122B-A10B-W8A8-INT8 \
   -tp 2 \
   --trust-remote-code \
@@ -765,8 +731,6 @@ vllm serve Qwen/Qwen3.5-122B-A10B-W8A8-INT8 \
 ### Qwen3.5-122B-A10B-W8A8-INT8 IFB BW1000 4x vLLM 0.18-hotfix
 
 ```bash
-export VLLM_HCU_USE_PD_SPLIT=1
-
 vllm serve Qwen/Qwen3.5-122B-A10B-W8A8-INT8 \
   -tp 4 \
   --trust-remote-code \
@@ -775,7 +739,6 @@ vllm serve Qwen/Qwen3.5-122B-A10B-W8A8-INT8 \
   --speculative-config.method mtp \
   --speculative-config.num_speculative_tokens 3 \
   --speculative-config.quantization "slimquant_marlin" \
-  --kv-cache-dtype fp8_e5m2 \
   --attention-backend FLASH_ATTN_CUSTOM
 ```
 ### Qwen3.5-122B-A10B-W8A8-INT8 IFB K100_AI 4x vLLM 0.18
@@ -824,8 +787,6 @@ vllm serve hygon/Qwen3.5-122B-A10B-Channel-FP8-w8a8 \
 ### Qwen3.5-122B-A10B-Channel-FP8-w8a8 IFB BW1100 2x vLLM 0.18-hotfix
 
 ```bash
-export VLLM_HCU_USE_PD_SPLIT=1
-
 vllm serve hygon/Qwen3.5-122B-A10B-Channel-FP8-w8a8 \
   -tp 4 \
   --trust-remote-code \
@@ -856,8 +817,6 @@ vllm serve Qwen/Qwen3.5-397B-A17B-W8A8-INT8 \
 ### Qwen3.5-397B-A17B-W8A8-INT8 IFB BW1100 8x vLLM 0.18-hotfix
 
 ```bash
-export VLLM_HCU_USE_PD_SPLIT=1
-
 vllm serve Qwen/Qwen3.5-397B-A17B-W8A8-INT8 \
   -tp 8 \
   --trust-remote-code \
@@ -888,8 +847,6 @@ vllm serve Qwen/Qwen3.5-397B-A17B-W8A8-INT8 \
 ### Qwen3.5-397B-A17B-W8A8-INT8 IFB BW1000 8x vLLM 0.18-hotfix
 
 ```bash
-export VLLM_HCU_USE_PD_SPLIT=1
-
 vllm serve Qwen/Qwen3.5-397B-A17B-W8A8-INT8 \
   -tp 8 \
   --trust-remote-code \
@@ -898,7 +855,6 @@ vllm serve Qwen/Qwen3.5-397B-A17B-W8A8-INT8 \
   --speculative-config.method mtp \
   --speculative-config.num_speculative_tokens 3 \
   --speculative-config.quantization "slimquant_marlin" \
-  --kv-cache-dtype fp8_e5m2 \
   --attention-backend FLASH_ATTN_CUSTOM
 ```
 ### Qwen3.5-397B-A17B-W8A8-INT8 IFB K100_AI 8x vLLM 0.18
@@ -947,8 +903,6 @@ vllm serve hygon/Qwen3.5-397B-A17B-Channel-FP8 \
 ### Qwen3.5-397B-A17B-Channel-FP8 IFB BW1100 4x vLLM 0.18-hotfix
 
 ```bash
-export VLLM_HCU_USE_PD_SPLIT=1
-
 vllm serve hygon/Qwen3.5-397B-A17B-Channel-FP8 \
   -tp 4 \
   --trust-remote-code \

--- a/docs/model-deployment/vllm/qwen3.6.md
+++ b/docs/model-deployment/vllm/qwen3.6.md
@@ -76,7 +76,6 @@ vllm serve Qwen/Qwen3.6-27B \
   --max-num-batched-tokens 10240 \
   --speculative-config.method mtp \
   --speculative-config.num_speculative_tokens 3 \
-  --kv-cache-dtype fp8_e5m2 \
   --attention-backend FLASH_ATTN_CUSTOM
 ```
 ### Qwen3.6-27B IFB K100_AI 2x vLLM 0.18
@@ -164,7 +163,6 @@ vllm serve Qwen/Qwen3.6-35B-A3B \
   --max-num-batched-tokens 10240 \
   --speculative-config.method mtp \
   --speculative-config.num_speculative_tokens 3 \
-  --kv-cache-dtype fp8_e5m2 \
   --attention-backend FLASH_ATTN_CUSTOM \
   --moe-backend aiter
 ```

--- a/docs/model-deployment/vllm/qwen3.md
+++ b/docs/model-deployment/vllm/qwen3.md
@@ -169,7 +169,6 @@ export VLLM_HCU_USE_PD_SPLIT=1
 vllm serve Qwen/Qwen3-0.6B \
   -tp 1 \
   --trust-remote-code \
-  --kv-cache-dtype fp8_e5m2 \
   --attention-backend FLASH_ATTN_CUSTOM
 ```
 ### Qwen3-0.6B IFB K100_AI 1x vLLM 0.18
@@ -252,7 +251,6 @@ export VLLM_HCU_USE_PD_SPLIT=1
 vllm serve Qwen/Qwen3-1.7B \
   -tp 1 \
   --trust-remote-code \
-  --kv-cache-dtype fp8_e5m2 \
   --attention-backend FLASH_ATTN_CUSTOM
 ```
 ### Qwen3-1.7B IFB K100_AI 1x vLLM 0.18
@@ -329,7 +327,6 @@ export VLLM_HCU_USE_PD_SPLIT=1
 vllm serve Qwen/Qwen3-4B \
   -tp 1 \
   --trust-remote-code \
-  --kv-cache-dtype fp8_e5m2 \
   --max-num-batched-tokens 10240 \
   --attention-backend FLASH_ATTN_CUSTOM
 ```
@@ -406,7 +403,6 @@ vllm serve Qwen/Qwen3-4B-Channel-INT8-w8a8 \
   --trust-remote-code \
   --max-num-batched-tokens 10240 \
   --q slimquant_marlin \
-  --kv-cache-dtype fp8_e5m2 \
   --attention-backend FLASH_ATTN_CUSTOM
 ```
 ### Qwen3-4B-Channel-INT8-w8a8 IFB K100_AI 1x vLLM 0.18
@@ -461,7 +457,6 @@ export VLLM_HCU_USE_PD_SPLIT=1
 vllm serve Qwen/Qwen3-8B \
   -tp 1 \
   --trust-remote-code \
-  --kv-cache-dtype fp8_e5m2 \
   --max-num-batched-tokens 10240 \
   --attention-backend FLASH_ATTN_CUSTOM
 ```
@@ -538,7 +533,6 @@ vllm serve Qwen/Qwen3-8B-Channel-INT8-w8a8 \
   --trust-remote-code \
   --max-num-batched-tokens 10240 \
   --q slimquant_marlin \
-  --kv-cache-dtype fp8_e5m2 \
   --attention-backend FLASH_ATTN_CUSTOM
 ```
 ### Qwen3-8B-Channel-INT8-w8a8 IFB K100_AI 1x vLLM 0.18
@@ -593,7 +587,6 @@ export VLLM_HCU_USE_PD_SPLIT=1
 vllm serve Qwen/Qwen3-14B \
   -tp 1 \
   --trust-remote-code \
-  --kv-cache-dtype fp8_e5m2 \
   --max-num-batched-tokens 10240 \
   --attention-backend FLASH_ATTN_CUSTOM
 ```
@@ -670,7 +663,6 @@ vllm serve Qwen/Qwen3-14B-Channel-INT8-w8a8 \
   --trust-remote-code \
   --max-num-batched-tokens 10240 \
   --q slimquant_marlin \
-  --kv-cache-dtype fp8_e5m2 \
   --attention-backend FLASH_ATTN_CUSTOM
 ```
 ### Qwen3-14B-Channel-INT8-w8a8 IFB K100_AI 1x vLLM 0.18
@@ -725,7 +717,6 @@ export VLLM_HCU_USE_PD_SPLIT=1
 vllm serve Qwen/Qwen3-32B \
   -tp 2 \
   --trust-remote-code \
-  --kv-cache-dtype fp8_e5m2 \
   --max-num-batched-tokens 10240 \
   --attention-backend FLASH_ATTN_CUSTOM
 ```
@@ -804,7 +795,6 @@ vllm serve Qwen/Qwen3-30B-A3B-Instruct-2507 \
   -tp 2 \
   --trust-remote-code \
   --max-num-batched-tokens 10240 \
-  --kv-cache-dtype fp8_e5m2 \
   --attention-backend FLASH_ATTN_CUSTOM \
   --moe-backend aiter
 ```
@@ -895,7 +885,6 @@ vllm serve Qwen/Qwen3-30B-A3B-Instruct-2507-W8A8 \
   --trust-remote-code \
   --max-num-batched-tokens 10240 \
   --q slimquant_marlin \
-  --kv-cache-dtype fp8_e5m2 \
   --attention-backend FLASH_ATTN_CUSTOM
 ```
 ### Qwen3-30B-A3B-Instruct-2507-W8A8-INT8 IFB K100_AI 1x vLLM 0.18
@@ -955,7 +944,6 @@ vllm serve Qwen/Qwen3-235B-A22B-Instruct-2507 \
   --trust-remote-code \
   --max-num-batched-tokens 10240 \
   --gpu-memory-utilization 0.95 \
-  --kv-cache-dtype fp8_e5m2 \
   --attention-backend FLASH_ATTN_CUSTOM \
   --moe-backend aiter
 ```
@@ -1053,7 +1041,6 @@ vllm serve Qwen/Qwen3-235B-A22B-Channel-INT8-w8a8 \
   --max-num-batched-tokens 10240 \
   --max-model-len 40960 \
   --gpu-memory-utilization 0.95 \
-  --kv-cache-dtype fp8_e5m2 \
   --attention-backend FLASH_ATTN_CUSTOM
 ```
 ### Qwen3-235B-A22B-Channel-INT8-w8a8 IFB K100_AI 4x vLLM 0.18


### PR DESCRIPTION
## Summary
- Remove `--kv-cache-dtype fp8_e5m2` from BW1000 Qwen vLLM 0.18-hotfix examples.
- Disable `VLLM_HCU_USE_PD_SPLIT=1` for Qwen3.5 vLLM 0.18-hotfix examples.
- Ensure other Qwen vLLM 0.18-hotfix examples enable `VLLM_HCU_USE_PD_SPLIT=1`.

## Verification
- Ran a section-level scan for Qwen vLLM 0.18-hotfix rules.
- Ran `git diff --check`.