### PR TITLE
docs(qwen3.5): add max-num-seqs to vLLM 0.21 commands

### DIFF
--- a/docs/model-deployment/vllm/qwen3.5.md
+++ b/docs/model-deployment/vllm/qwen3.5.md
@@ -109,7 +109,7 @@ Qwen3.5 是 Qwen3 系列的增强版本，在推理能力、代码生成、多�
 vllm serve Qwen/Qwen3.5-4B \
   -tp 1 \
   --trust-remote-code \
-  --max-num-batched-tokens 10240 \
+  --max-num-batched-tokens 16384 \
   --speculative-config.method mtp \
   --speculative-config.num_speculative_tokens 3 \
   --kv-cache-dtype fp8_e4m3 \
@@ -148,7 +148,7 @@ vllm serve Qwen/Qwen3.5-4B \
 vllm serve Qwen/Qwen3.5-4B \
   -tp 1 \
   --trust-remote-code \
-  --max-num-batched-tokens 10240 \
+  --max-num-batched-tokens 16384 \
   --speculative-config.method mtp \
   --speculative-config.num_speculative_tokens 3 \
   --attention-backend FLASH_ATTN_CUSTOM \
@@ -190,7 +190,7 @@ export VLLM_HCU_USE_CUSTOM_OPS=0
 vllm serve Qwen/Qwen3.5-4B \
   -tp 1 \
   --trust-remote-code \
-  --max-num-batched-tokens 10240 \
+  --max-num-batched-tokens 16384 \
   --speculative-config.method mtp \
   --speculative-config.num_speculative_tokens 3 \
   --max-num-seqs 32
@@ -228,7 +228,7 @@ vllm serve Qwen/Qwen3.5-4B \
 vllm serve Qwen/Qwen3.5-9B \
   -tp 1 \
   --trust-remote-code \
-  --max-num-batched-tokens 10240 \
+  --max-num-batched-tokens 16384 \
   --speculative-config.method mtp \
   --speculative-config.num_speculative_tokens 3 \
   --kv-cache-dtype fp8_e4m3 \
@@ -267,7 +267,7 @@ vllm serve Qwen/Qwen3.5-9B \
 vllm serve Qwen/Qwen3.5-9B \
   -tp 1 \
   --trust-remote-code \
-  --max-num-batched-tokens 10240 \
+  --max-num-batched-tokens 16384 \
   --speculative-config.method mtp \
   --speculative-config.num_speculative_tokens 3 \
   --attention-backend FLASH_ATTN_CUSTOM \
@@ -307,7 +307,7 @@ export VLLM_HCU_USE_CUSTOM_OPS=0
 vllm serve Qwen/Qwen3.5-9B \
   -tp 1 \
   --trust-remote-code \
-  --max-num-batched-tokens 10240 \
+  --max-num-batched-tokens 16384 \
   --speculative-config.method mtp \
   --speculative-config.num_speculative_tokens 3 \
   --max-num-seqs 32
@@ -345,7 +345,7 @@ vllm serve Qwen/Qwen3.5-9B \
 vllm serve Qwen/Qwen3.5-27B \
   -tp 1 \
   --trust-remote-code \
-  --max-num-batched-tokens 10240 \
+  --max-num-batched-tokens 16384 \
   --speculative-config.method mtp \
   --speculative-config.num_speculative_tokens 3 \
   --kv-cache-dtype fp8_e4m3 \
@@ -384,7 +384,7 @@ vllm serve Qwen/Qwen3.5-27B \
 vllm serve Qwen/Qwen3.5-27B \
   -tp 2 \
   --trust-remote-code \
-  --max-num-batched-tokens 10240 \
+  --max-num-batched-tokens 16384 \
   --speculative-config.method mtp \
   --speculative-config.num_speculative_tokens 3 \
   --attention-backend FLASH_ATTN_CUSTOM \
@@ -424,7 +424,7 @@ export VLLM_HCU_USE_CUSTOM_OPS=0
 vllm serve Qwen/Qwen3.5-27B \
   -tp 2 \
   --trust-remote-code \
-  --max-num-batched-tokens 10240 \
+  --max-num-batched-tokens 16384 \
   --speculative-config.method mtp \
   --speculative-config.num_speculative_tokens 3 \
   --max-num-seqs 32
@@ -462,7 +462,7 @@ vllm serve Qwen/Qwen3.5-27B \
 vllm serve hygon/Qwen3.5-27B-Channel-INT8-w8a8 \
   -tp 1 \
   --trust-remote-code \
-  --max-num-batched-tokens 10240 \
+  --max-num-batched-tokens 16384 \
   -q slimquant_marlin \
   --speculative-config.method mtp \
   --speculative-config.num_speculative_tokens 3 \
@@ -507,7 +507,7 @@ vllm serve hygon/Qwen3.5-27B-Channel-INT8-w8a8 \
 vllm serve hygon/Qwen3.5-27B-Channel-INT8-w8a8 \
   -tp 1 \
   --trust-remote-code \
-  --max-num-batched-tokens 10240 \
+  --max-num-batched-tokens 16384 \
   -q slimquant_marlin \
   --speculative-config.method mtp \
   --speculative-config.num_speculative_tokens 3 \
@@ -553,7 +553,7 @@ export VLLM_HCU_USE_CUSTOM_OPS=0
 vllm serve hygon/Qwen3.5-27B-Channel-INT8-w8a8 \
   -tp 1 \
   --trust-remote-code \
-  --max-num-batched-tokens 10240 \
+  --max-num-batched-tokens 16384 \
   --speculative-config.method mtp \
   --speculative-config.num_speculative_tokens 3 \
   --max-num-seqs 32
@@ -591,7 +591,7 @@ vllm serve hygon/Qwen3.5-27B-Channel-INT8-w8a8 \
 vllm serve Qwen/Qwen3.5-35B-A3B \
   -tp 1 \
   --trust-remote-code \
-  --max-num-batched-tokens 10240 \
+  --max-num-batched-tokens 16384 \
   --speculative-config.method mtp \
   --speculative-config.num_speculative_tokens 3 \
   --kv-cache-dtype fp8_e4m3 \
@@ -635,7 +635,7 @@ vllm serve Qwen/Qwen3.5-35B-A3B \
 vllm serve Qwen/Qwen3.5-35B-A3B \
   -tp 2 \
   --trust-remote-code \
-  --max-num-batched-tokens 10240 \
+  --max-num-batched-tokens 16384 \
   --speculative-config.method mtp \
   --speculative-config.num_speculative_tokens 3 \
   --attention-backend FLASH_ATTN_CUSTOM \
@@ -680,7 +680,7 @@ export VLLM_HCU_USE_CUSTOM_OPS=0
 vllm serve Qwen/Qwen3.5-35B-A3B \
   -tp 2 \
   --trust-remote-code \
-  --max-num-batched-tokens 10240 \
+  --max-num-batched-tokens 16384 \
   --speculative-config.method mtp \
   --speculative-config.num_speculative_tokens 3 \
   --max-num-seqs 32
@@ -718,7 +718,7 @@ vllm serve Qwen/Qwen3.5-35B-A3B \
 vllm serve hygon/Qwen3.5-35B-A3B-Channel-INT8-w8a8 \
   -tp 1 \
   --trust-remote-code \
-  --max-num-batched-tokens 10240 \
+  --max-num-batched-tokens 16384 \
   -q slimquant_marlin \
   --speculative-config.method mtp \
   --speculative-config.num_speculative_tokens 3 \
@@ -763,7 +763,7 @@ vllm serve hygon/Qwen3.5-35B-A3B-Channel-INT8-w8a8 \
 vllm serve hygon/Qwen3.5-35B-A3B-Channel-INT8-w8a8 \
   -tp 1 \
   --trust-remote-code \
-  --max-num-batched-tokens 10240 \
+  --max-num-batched-tokens 16384 \
   -q slimquant_marlin \
   --speculative-config.method mtp \
   --speculative-config.num_speculative_tokens 3 \
@@ -809,7 +809,7 @@ export VLLM_HCU_USE_CUSTOM_OPS=0
 vllm serve hygon/Qwen3.5-35B-A3B-Channel-INT8-w8a8 \
   -tp 1 \
   --trust-remote-code \
-  --max-num-batched-tokens 10240 \
+  --max-num-batched-tokens 16384 \
   --speculative-config.method mtp \
   --speculative-config.num_speculative_tokens 3 \
   --max-num-seqs 32
@@ -847,7 +847,7 @@ vllm serve hygon/Qwen3.5-35B-A3B-Channel-INT8-w8a8 \
 vllm serve hygon/Qwen3.5-35B-A3B-Channel-FP8-w8a8 \
   -tp 1 \
   --trust-remote-code \
-  --max-num-batched-tokens 10240 \
+  --max-num-batched-tokens 16384 \
   -q slimquant_marlin \
   --speculative-config.method mtp \
   --speculative-config.num_speculative_tokens 3 \
@@ -892,7 +892,7 @@ vllm serve hygon/Qwen3.5-35B-A3B-Channel-FP8-w8a8 \
 vllm serve Qwen/Qwen3.5-122B-A10B \
   -tp 4 \
   --trust-remote-code \
-  --max-num-batched-tokens 10240 \
+  --max-num-batched-tokens 16384 \
   --speculative-config.method mtp \
   --speculative-config.num_speculative_tokens 3 \
   --kv-cache-dtype fp8_e4m3 \
@@ -936,7 +936,7 @@ vllm serve Qwen/Qwen3.5-122B-A10B \
 vllm serve Qwen/Qwen3.5-122B-A10B \
   -tp 8 \
   --trust-remote-code \
-  --max-num-batched-tokens 10240 \
+  --max-num-batched-tokens 16384 \
   --speculative-config.method mtp \
   --speculative-config.num_speculative_tokens 3 \
   --attention-backend FLASH_ATTN_CUSTOM \
@@ -981,7 +981,7 @@ export VLLM_HCU_USE_CUSTOM_OPS=0
 vllm serve Qwen/Qwen3.5-122B-A10B \
   -tp 8 \
   --trust-remote-code \
-  --max-num-batched-tokens 10240 \
+  --max-num-batched-tokens 16384 \
   --speculative-config.method mtp \
   --speculative-config.num_speculative_tokens 3 \
   --max-num-seqs 32
@@ -1019,7 +1019,7 @@ vllm serve Qwen/Qwen3.5-122B-A10B \
 vllm serve Qwen/Qwen3.5-122B-A10B-W8A8-INT8 \
   -tp 2 \
   --trust-remote-code \
-  --max-num-batched-tokens 10240 \
+  --max-num-batched-tokens 16384 \
   -q slimquant_marlin \
   --speculative-config.method mtp \
   --speculative-config.num_speculative_tokens 3 \
@@ -1064,7 +1064,7 @@ vllm serve Qwen/Qwen3.5-122B-A10B-W8A8-INT8 \
 vllm serve Qwen/Qwen3.5-122B-A10B-W8A8-INT8 \
   -tp 4 \
   --trust-remote-code \
-  --max-num-batched-tokens 10240 \
+  --max-num-batched-tokens 16384 \
   -q slimquant_marlin \
   --speculative-config.method mtp \
   --speculative-config.num_speculative_tokens 3 \
@@ -1110,7 +1110,7 @@ export VLLM_HCU_USE_CUSTOM_OPS=0
 vllm serve Qwen/Qwen3.5-122B-A10B-W8A8-INT8 \
   -tp 4 \
   --trust-remote-code \
-  --max-num-batched-tokens 10240 \
+  --max-num-batched-tokens 16384 \
   --speculative-config.method mtp \
   --speculative-config.num_speculative_tokens 3 \
   --max-num-seqs 32
@@ -1148,7 +1148,7 @@ vllm serve Qwen/Qwen3.5-122B-A10B-W8A8-INT8 \
 vllm serve hygon/Qwen3.5-122B-A10B-Channel-FP8-w8a8 \
   -tp 4 \
   --trust-remote-code \
-  --max-num-batched-tokens 10240 \
+  --max-num-batched-tokens 16384 \
   -q slimquant_marlin \
   --speculative-config.method mtp \
   --speculative-config.num_speculative_tokens 3 \
@@ -1193,7 +1193,7 @@ vllm serve hygon/Qwen3.5-122B-A10B-Channel-FP8-w8a8 \
 vllm serve Qwen/Qwen3.5-397B-A17B-W8A8-INT8 \
   -tp 8 \
   --trust-remote-code \
-  --max-num-batched-tokens 10240 \
+  --max-num-batched-tokens 16384 \
   -q slimquant_marlin \
   --speculative-config.method mtp \
   --speculative-config.num_speculative_tokens 3 \
@@ -1238,7 +1238,7 @@ vllm serve Qwen/Qwen3.5-397B-A17B-W8A8-INT8 \
 vllm serve Qwen/Qwen3.5-397B-A17B-W8A8-INT8 \
   -tp 8 \
   --trust-remote-code \
-  --max-num-batched-tokens 10240 \
+  --max-num-batched-tokens 16384 \
   -q slimquant_marlin \
   --speculative-config.method mtp \
   --speculative-config.num_speculative_tokens 3 \
@@ -1284,7 +1284,7 @@ export VLLM_HCU_USE_CUSTOM_OPS=0
 vllm serve Qwen/Qwen3.5-397B-A17B-W8A8-INT8 \
   -tp 8 \
   --trust-remote-code \
-  --max-num-batched-tokens 10240 \
+  --max-num-batched-tokens 16384 \
   --speculative-config.method mtp \
   --speculative-config.num_speculative_tokens 3 \
   --max-num-seqs 32
@@ -1322,7 +1322,7 @@ vllm serve Qwen/Qwen3.5-397B-A17B-W8A8-INT8 \
 vllm serve hygon/Qwen3.5-397B-A17B-Channel-FP8 \
   -tp 4 \
   --trust-remote-code \
-  --max-num-batched-tokens 10240 \
+  --max-num-batched-tokens 16384 \
   -q slimquant_marlin \
   --speculative-config.method mtp \
   --speculative-config.num_speculative_tokens 3 \

--- a/docs/model-deployment/vllm/qwen3.5.md
+++ b/docs/model-deployment/vllm/qwen3.5.md
@@ -113,7 +113,8 @@ vllm serve Qwen/Qwen3.5-4B \
   --speculative-config.method mtp \
   --speculative-config.num_speculative_tokens 3 \
   --kv-cache-dtype fp8_e4m3 \
-  --attention-backend FLASH_ATTN_CUSTOM
+  --attention-backend FLASH_ATTN_CUSTOM \
+  --max-num-seqs 32
 ```
 ### Qwen3.5-4B IFB BW1100 1x vLLM 0.18
 
@@ -150,7 +151,8 @@ vllm serve Qwen/Qwen3.5-4B \
   --max-num-batched-tokens 10240 \
   --speculative-config.method mtp \
   --speculative-config.num_speculative_tokens 3 \
-  --attention-backend FLASH_ATTN_CUSTOM
+  --attention-backend FLASH_ATTN_CUSTOM \
+  --max-num-seqs 32
 ```
 
 ### Qwen3.5-4B IFB BW1000 1x vLLM 0.18
@@ -190,7 +192,8 @@ vllm serve Qwen/Qwen3.5-4B \
   --trust-remote-code \
   --max-num-batched-tokens 10240 \
   --speculative-config.method mtp \
-  --speculative-config.num_speculative_tokens 3
+  --speculative-config.num_speculative_tokens 3 \
+  --max-num-seqs 32
 ```
 ### Qwen3.5-4B IFB K100_AI 1x vLLM 0.18
 
@@ -229,7 +232,8 @@ vllm serve Qwen/Qwen3.5-9B \
   --speculative-config.method mtp \
   --speculative-config.num_speculative_tokens 3 \
   --kv-cache-dtype fp8_e4m3 \
-  --attention-backend FLASH_ATTN_CUSTOM
+  --attention-backend FLASH_ATTN_CUSTOM \
+  --max-num-seqs 32
 ```
 ### Qwen3.5-9B IFB BW1100 1x vLLM 0.18
 
@@ -266,7 +270,8 @@ vllm serve Qwen/Qwen3.5-9B \
   --max-num-batched-tokens 10240 \
   --speculative-config.method mtp \
   --speculative-config.num_speculative_tokens 3 \
-  --attention-backend FLASH_ATTN_CUSTOM
+  --attention-backend FLASH_ATTN_CUSTOM \
+  --max-num-seqs 32
 ```
 ### Qwen3.5-9B IFB BW1000 1x vLLM 0.18
 
@@ -304,7 +309,8 @@ vllm serve Qwen/Qwen3.5-9B \
   --trust-remote-code \
   --max-num-batched-tokens 10240 \
   --speculative-config.method mtp \
-  --speculative-config.num_speculative_tokens 3
+  --speculative-config.num_speculative_tokens 3 \
+  --max-num-seqs 32
 ```
 ### Qwen3.5-9B IFB K100_AI 1x vLLM 0.18
 
@@ -343,7 +349,8 @@ vllm serve Qwen/Qwen3.5-27B \
   --speculative-config.method mtp \
   --speculative-config.num_speculative_tokens 3 \
   --kv-cache-dtype fp8_e4m3 \
-  --attention-backend FLASH_ATTN_CUSTOM
+  --attention-backend FLASH_ATTN_CUSTOM \
+  --max-num-seqs 32
 ```
 ### Qwen3.5-27B IFB BW1100 1x vLLM 0.18
 
@@ -380,7 +387,8 @@ vllm serve Qwen/Qwen3.5-27B \
   --max-num-batched-tokens 10240 \
   --speculative-config.method mtp \
   --speculative-config.num_speculative_tokens 3 \
-  --attention-backend FLASH_ATTN_CUSTOM
+  --attention-backend FLASH_ATTN_CUSTOM \
+  --max-num-seqs 32
 ```
 ### Qwen3.5-27B IFB BW1000 2x vLLM 0.18
 
@@ -418,7 +426,8 @@ vllm serve Qwen/Qwen3.5-27B \
   --trust-remote-code \
   --max-num-batched-tokens 10240 \
   --speculative-config.method mtp \
-  --speculative-config.num_speculative_tokens 3
+  --speculative-config.num_speculative_tokens 3 \
+  --max-num-seqs 32
 ```
 ### Qwen3.5-27B IFB K100_AI 2x vLLM 0.18
 
@@ -459,7 +468,8 @@ vllm serve hygon/Qwen3.5-27B-Channel-INT8-w8a8 \
   --speculative-config.num_speculative_tokens 3 \
   --speculative-config.quantization "slimquant_marlin" \
   --kv-cache-dtype fp8_e4m3 \
-  --attention-backend FLASH_ATTN_CUSTOM
+  --attention-backend FLASH_ATTN_CUSTOM \
+  --max-num-seqs 32
 ```
 ### Qwen3.5-27B-Channel-INT8-w8a8 IFB BW1100 1x vLLM 0.18
 
@@ -502,7 +512,8 @@ vllm serve hygon/Qwen3.5-27B-Channel-INT8-w8a8 \
   --speculative-config.method mtp \
   --speculative-config.num_speculative_tokens 3 \
   --speculative-config.quantization "slimquant_marlin" \
-  --attention-backend FLASH_ATTN_CUSTOM
+  --attention-backend FLASH_ATTN_CUSTOM \
+  --max-num-seqs 32
 ```
 ### Qwen3.5-27B-Channel-INT8-w8a8 IFB BW1000 1x vLLM 0.18
 
@@ -544,7 +555,8 @@ vllm serve hygon/Qwen3.5-27B-Channel-INT8-w8a8 \
   --trust-remote-code \
   --max-num-batched-tokens 10240 \
   --speculative-config.method mtp \
-  --speculative-config.num_speculative_tokens 3 
+  --speculative-config.num_speculative_tokens 3 \
+  --max-num-seqs 32
 ```
 ### Qwen3.5-27B-Channel-INT8-w8a8 IFB K100_AI 1x vLLM 0.18
 
@@ -584,7 +596,8 @@ vllm serve Qwen/Qwen3.5-35B-A3B \
   --speculative-config.num_speculative_tokens 3 \
   --kv-cache-dtype fp8_e4m3 \
   --attention-backend FLASH_ATTN_CUSTOM \
-  --moe-backend aiter
+  --moe-backend aiter \
+  --max-num-seqs 32
 ```
 ### Qwen3.5-35B-A3B IFB BW1100 1x vLLM 0.18
 
@@ -626,7 +639,8 @@ vllm serve Qwen/Qwen3.5-35B-A3B \
   --speculative-config.method mtp \
   --speculative-config.num_speculative_tokens 3 \
   --attention-backend FLASH_ATTN_CUSTOM \
-  --moe-backend aiter
+  --moe-backend aiter \
+  --max-num-seqs 32
 ```
 ### Qwen3.5-35B-A3B IFB BW1000 2x vLLM 0.18
 
@@ -668,7 +682,8 @@ vllm serve Qwen/Qwen3.5-35B-A3B \
   --trust-remote-code \
   --max-num-batched-tokens 10240 \
   --speculative-config.method mtp \
-  --speculative-config.num_speculative_tokens 3
+  --speculative-config.num_speculative_tokens 3 \
+  --max-num-seqs 32
 ```
 ### Qwen3.5-35B-A3B IFB K100_AI 2x vLLM 0.18
 
@@ -709,7 +724,8 @@ vllm serve hygon/Qwen3.5-35B-A3B-Channel-INT8-w8a8 \
   --speculative-config.num_speculative_tokens 3 \
   --speculative-config.quantization "slimquant_marlin" \
   --kv-cache-dtype fp8_e4m3 \
-  --attention-backend FLASH_ATTN_CUSTOM
+  --attention-backend FLASH_ATTN_CUSTOM \
+  --max-num-seqs 32
 ```
 ### Qwen3.5-35B-A3B-Channel-INT8-w8a8 IFB BW1100 1x vLLM 0.18
 
@@ -752,7 +768,8 @@ vllm serve hygon/Qwen3.5-35B-A3B-Channel-INT8-w8a8 \
   --speculative-config.method mtp \
   --speculative-config.num_speculative_tokens 3 \
   --speculative-config.quantization "slimquant_marlin" \
-  --attention-backend FLASH_ATTN_CUSTOM
+  --attention-backend FLASH_ATTN_CUSTOM \
+  --max-num-seqs 32
 ```
 ### Qwen3.5-35B-A3B-Channel-INT8-w8a8 IFB BW1000 1x vLLM 0.18
 
@@ -794,7 +811,8 @@ vllm serve hygon/Qwen3.5-35B-A3B-Channel-INT8-w8a8 \
   --trust-remote-code \
   --max-num-batched-tokens 10240 \
   --speculative-config.method mtp \
-  --speculative-config.num_speculative_tokens 3
+  --speculative-config.num_speculative_tokens 3 \
+  --max-num-seqs 32
 ```
 ### Qwen3.5-35B-A3B-Channel-INT8-w8a8 IFB K100_AI 1x vLLM 0.18
 
@@ -835,7 +853,8 @@ vllm serve hygon/Qwen3.5-35B-A3B-Channel-FP8-w8a8 \
   --speculative-config.num_speculative_tokens 3 \
   --speculative-config.quantization "slimquant_marlin" \
   --kv-cache-dtype fp8_e4m3 \
-  --attention-backend FLASH_ATTN_CUSTOM
+  --attention-backend FLASH_ATTN_CUSTOM \
+  --max-num-seqs 32
 ```
 ### Qwen3.5-35B-A3B-Channel-FP8-w8a8 IFB BW1100 1x vLLM 0.18
 
@@ -878,7 +897,8 @@ vllm serve Qwen/Qwen3.5-122B-A10B \
   --speculative-config.num_speculative_tokens 3 \
   --kv-cache-dtype fp8_e4m3 \
   --attention-backend FLASH_ATTN_CUSTOM \
-  --moe-backend aiter
+  --moe-backend aiter \
+  --max-num-seqs 32
 ```
 ### Qwen3.5-122B-A10B IFB BW1100 4x vLLM 0.18
 
@@ -920,7 +940,8 @@ vllm serve Qwen/Qwen3.5-122B-A10B \
   --speculative-config.method mtp \
   --speculative-config.num_speculative_tokens 3 \
   --attention-backend FLASH_ATTN_CUSTOM \
-  --moe-backend aiter
+  --moe-backend aiter \
+  --max-num-seqs 32
 ```
 ### Qwen3.5-122B-A10B IFB BW1000 8x vLLM 0.18
 
@@ -962,7 +983,8 @@ vllm serve Qwen/Qwen3.5-122B-A10B \
   --trust-remote-code \
   --max-num-batched-tokens 10240 \
   --speculative-config.method mtp \
-  --speculative-config.num_speculative_tokens 3
+  --speculative-config.num_speculative_tokens 3 \
+  --max-num-seqs 32
 ```
 ### Qwen3.5-122B-A10B IFB K100_AI 8x vLLM 0.18
 
@@ -1003,7 +1025,8 @@ vllm serve Qwen/Qwen3.5-122B-A10B-W8A8-INT8 \
   --speculative-config.num_speculative_tokens 3 \
   --speculative-config.quantization "slimquant_marlin" \
   --kv-cache-dtype fp8_e4m3 \
-  --attention-backend FLASH_ATTN_CUSTOM
+  --attention-backend FLASH_ATTN_CUSTOM \
+  --max-num-seqs 32
 ```
 ### Qwen3.5-122B-A10B-W8A8-INT8 IFB BW1100 2x vLLM 0.18
 
@@ -1046,7 +1069,8 @@ vllm serve Qwen/Qwen3.5-122B-A10B-W8A8-INT8 \
   --speculative-config.method mtp \
   --speculative-config.num_speculative_tokens 3 \
   --speculative-config.quantization "slimquant_marlin" \
-  --attention-backend FLASH_ATTN_CUSTOM
+  --attention-backend FLASH_ATTN_CUSTOM \
+  --max-num-seqs 32
 ```
 ### Qwen3.5-122B-A10B-W8A8-INT8 IFB BW1000 4x vLLM 0.18
 
@@ -1088,7 +1112,8 @@ vllm serve Qwen/Qwen3.5-122B-A10B-W8A8-INT8 \
   --trust-remote-code \
   --max-num-batched-tokens 10240 \
   --speculative-config.method mtp \
-  --speculative-config.num_speculative_tokens 3 
+  --speculative-config.num_speculative_tokens 3 \
+  --max-num-seqs 32
 ```
 ### Qwen3.5-122B-A10B-W8A8-INT8 IFB K100_AI 4x vLLM 0.18
 
@@ -1129,7 +1154,8 @@ vllm serve hygon/Qwen3.5-122B-A10B-Channel-FP8-w8a8 \
   --speculative-config.num_speculative_tokens 3 \
   --speculative-config.quantization "slimquant_marlin" \
   --kv-cache-dtype fp8_e4m3 \
-  --attention-backend FLASH_ATTN_CUSTOM
+  --attention-backend FLASH_ATTN_CUSTOM \
+  --max-num-seqs 32
 ```
 ### Qwen3.5-122B-A10B-Channel-FP8-w8a8 IFB BW1100 2x vLLM 0.18
 
@@ -1173,7 +1199,8 @@ vllm serve Qwen/Qwen3.5-397B-A17B-W8A8-INT8 \
   --speculative-config.num_speculative_tokens 3 \
   --speculative-config.quantization "slimquant_marlin" \
   --kv-cache-dtype fp8_e4m3 \
-  --attention-backend FLASH_ATTN_CUSTOM
+  --attention-backend FLASH_ATTN_CUSTOM \
+  --max-num-seqs 32
 ```
 ### Qwen3.5-397B-A17B-W8A8-INT8 IFB BW1100 8x vLLM 0.18
 
@@ -1216,7 +1243,8 @@ vllm serve Qwen/Qwen3.5-397B-A17B-W8A8-INT8 \
   --speculative-config.method mtp \
   --speculative-config.num_speculative_tokens 3 \
   --speculative-config.quantization "slimquant_marlin" \
-  --attention-backend FLASH_ATTN_CUSTOM
+  --attention-backend FLASH_ATTN_CUSTOM \
+  --max-num-seqs 32
 ```
 ### Qwen3.5-397B-A17B-W8A8-INT8 IFB BW1000 8x vLLM 0.18
 
@@ -1258,7 +1286,8 @@ vllm serve Qwen/Qwen3.5-397B-A17B-W8A8-INT8 \
   --trust-remote-code \
   --max-num-batched-tokens 10240 \
   --speculative-config.method mtp \
-  --speculative-config.num_speculative_tokens 3 
+  --speculative-config.num_speculative_tokens 3 \
+  --max-num-seqs 32
 ```
 ### Qwen3.5-397B-A17B-W8A8-INT8 IFB K100_AI 8x vLLM 0.18
 
@@ -1299,7 +1328,8 @@ vllm serve hygon/Qwen3.5-397B-A17B-Channel-FP8 \
   --speculative-config.num_speculative_tokens 3 \
   --speculative-config.quantization "slimquant_marlin" \
   --kv-cache-dtype fp8_e4m3 \
-  --attention-backend FLASH_ATTN_CUSTOM
+  --attention-backend FLASH_ATTN_CUSTOM \
+  --max-num-seqs 32
 ```
 ### Qwen3.5-397B-A17B-Channel-FP8 IFB BW1100 4x vLLM 0.18
 

--- a/docs/model-deployment/vllm/qwen3.5.md
+++ b/docs/model-deployment/vllm/qwen3.5.md
@@ -114,7 +114,7 @@ vllm serve Qwen/Qwen3.5-4B \
   --speculative-config.num_speculative_tokens 3 \
   --kv-cache-dtype fp8_e4m3 \
   --attention-backend FLASH_ATTN_CUSTOM \
-  --max-num-seqs 32
+  --max-num-seqs 128
 ```
 ### Qwen3.5-4B IFB BW1100 1x vLLM 0.18
 
@@ -152,7 +152,7 @@ vllm serve Qwen/Qwen3.5-4B \
   --speculative-config.method mtp \
   --speculative-config.num_speculative_tokens 3 \
   --attention-backend FLASH_ATTN_CUSTOM \
-  --max-num-seqs 32
+  --max-num-seqs 128
 ```
 
 ### Qwen3.5-4B IFB BW1000 1x vLLM 0.18
@@ -193,7 +193,7 @@ vllm serve Qwen/Qwen3.5-4B \
   --max-num-batched-tokens 16384 \
   --speculative-config.method mtp \
   --speculative-config.num_speculative_tokens 3 \
-  --max-num-seqs 32
+  --max-num-seqs 128
 ```
 ### Qwen3.5-4B IFB K100_AI 1x vLLM 0.18
 
@@ -233,7 +233,7 @@ vllm serve Qwen/Qwen3.5-9B \
   --speculative-config.num_speculative_tokens 3 \
   --kv-cache-dtype fp8_e4m3 \
   --attention-backend FLASH_ATTN_CUSTOM \
-  --max-num-seqs 32
+  --max-num-seqs 128
 ```
 ### Qwen3.5-9B IFB BW1100 1x vLLM 0.18
 
@@ -271,7 +271,7 @@ vllm serve Qwen/Qwen3.5-9B \
   --speculative-config.method mtp \
   --speculative-config.num_speculative_tokens 3 \
   --attention-backend FLASH_ATTN_CUSTOM \
-  --max-num-seqs 32
+  --max-num-seqs 128
 ```
 ### Qwen3.5-9B IFB BW1000 1x vLLM 0.18
 
@@ -310,7 +310,7 @@ vllm serve Qwen/Qwen3.5-9B \
   --max-num-batched-tokens 16384 \
   --speculative-config.method mtp \
   --speculative-config.num_speculative_tokens 3 \
-  --max-num-seqs 32
+  --max-num-seqs 128
 ```
 ### Qwen3.5-9B IFB K100_AI 1x vLLM 0.18
 
@@ -350,7 +350,7 @@ vllm serve Qwen/Qwen3.5-27B \
   --speculative-config.num_speculative_tokens 3 \
   --kv-cache-dtype fp8_e4m3 \
   --attention-backend FLASH_ATTN_CUSTOM \
-  --max-num-seqs 32
+  --max-num-seqs 128
 ```
 ### Qwen3.5-27B IFB BW1100 1x vLLM 0.18
 
@@ -388,7 +388,7 @@ vllm serve Qwen/Qwen3.5-27B \
   --speculative-config.method mtp \
   --speculative-config.num_speculative_tokens 3 \
   --attention-backend FLASH_ATTN_CUSTOM \
-  --max-num-seqs 32
+  --max-num-seqs 128
 ```
 ### Qwen3.5-27B IFB BW1000 2x vLLM 0.18
 
@@ -427,7 +427,7 @@ vllm serve Qwen/Qwen3.5-27B \
   --max-num-batched-tokens 16384 \
   --speculative-config.method mtp \
   --speculative-config.num_speculative_tokens 3 \
-  --max-num-seqs 32
+  --max-num-seqs 128
 ```
 ### Qwen3.5-27B IFB K100_AI 2x vLLM 0.18
 
@@ -469,7 +469,7 @@ vllm serve hygon/Qwen3.5-27B-Channel-INT8-w8a8 \
   --speculative-config.quantization "slimquant_marlin" \
   --kv-cache-dtype fp8_e4m3 \
   --attention-backend FLASH_ATTN_CUSTOM \
-  --max-num-seqs 32
+  --max-num-seqs 128
 ```
 ### Qwen3.5-27B-Channel-INT8-w8a8 IFB BW1100 1x vLLM 0.18
 
@@ -513,7 +513,7 @@ vllm serve hygon/Qwen3.5-27B-Channel-INT8-w8a8 \
   --speculative-config.num_speculative_tokens 3 \
   --speculative-config.quantization "slimquant_marlin" \
   --attention-backend FLASH_ATTN_CUSTOM \
-  --max-num-seqs 32
+  --max-num-seqs 128
 ```
 ### Qwen3.5-27B-Channel-INT8-w8a8 IFB BW1000 1x vLLM 0.18
 
@@ -556,7 +556,7 @@ vllm serve hygon/Qwen3.5-27B-Channel-INT8-w8a8 \
   --max-num-batched-tokens 16384 \
   --speculative-config.method mtp \
   --speculative-config.num_speculative_tokens 3 \
-  --max-num-seqs 32
+  --max-num-seqs 128
 ```
 ### Qwen3.5-27B-Channel-INT8-w8a8 IFB K100_AI 1x vLLM 0.18
 
@@ -597,7 +597,7 @@ vllm serve Qwen/Qwen3.5-35B-A3B \
   --kv-cache-dtype fp8_e4m3 \
   --attention-backend FLASH_ATTN_CUSTOM \
   --moe-backend aiter \
-  --max-num-seqs 32
+  --max-num-seqs 128
 ```
 ### Qwen3.5-35B-A3B IFB BW1100 1x vLLM 0.18
 
@@ -640,7 +640,7 @@ vllm serve Qwen/Qwen3.5-35B-A3B \
   --speculative-config.num_speculative_tokens 3 \
   --attention-backend FLASH_ATTN_CUSTOM \
   --moe-backend aiter \
-  --max-num-seqs 32
+  --max-num-seqs 128
 ```
 ### Qwen3.5-35B-A3B IFB BW1000 2x vLLM 0.18
 
@@ -683,7 +683,7 @@ vllm serve Qwen/Qwen3.5-35B-A3B \
   --max-num-batched-tokens 16384 \
   --speculative-config.method mtp \
   --speculative-config.num_speculative_tokens 3 \
-  --max-num-seqs 32
+  --max-num-seqs 128
 ```
 ### Qwen3.5-35B-A3B IFB K100_AI 2x vLLM 0.18
 
@@ -725,7 +725,7 @@ vllm serve hygon/Qwen3.5-35B-A3B-Channel-INT8-w8a8 \
   --speculative-config.quantization "slimquant_marlin" \
   --kv-cache-dtype fp8_e4m3 \
   --attention-backend FLASH_ATTN_CUSTOM \
-  --max-num-seqs 32
+  --max-num-seqs 128
 ```
 ### Qwen3.5-35B-A3B-Channel-INT8-w8a8 IFB BW1100 1x vLLM 0.18
 
@@ -769,7 +769,7 @@ vllm serve hygon/Qwen3.5-35B-A3B-Channel-INT8-w8a8 \
   --speculative-config.num_speculative_tokens 3 \
   --speculative-config.quantization "slimquant_marlin" \
   --attention-backend FLASH_ATTN_CUSTOM \
-  --max-num-seqs 32
+  --max-num-seqs 128
 ```
 ### Qwen3.5-35B-A3B-Channel-INT8-w8a8 IFB BW1000 1x vLLM 0.18
 
@@ -812,7 +812,7 @@ vllm serve hygon/Qwen3.5-35B-A3B-Channel-INT8-w8a8 \
   --max-num-batched-tokens 16384 \
   --speculative-config.method mtp \
   --speculative-config.num_speculative_tokens 3 \
-  --max-num-seqs 32
+  --max-num-seqs 128
 ```
 ### Qwen3.5-35B-A3B-Channel-INT8-w8a8 IFB K100_AI 1x vLLM 0.18
 
@@ -854,7 +854,7 @@ vllm serve hygon/Qwen3.5-35B-A3B-Channel-FP8-w8a8 \
   --speculative-config.quantization "slimquant_marlin" \
   --kv-cache-dtype fp8_e4m3 \
   --attention-backend FLASH_ATTN_CUSTOM \
-  --max-num-seqs 32
+  --max-num-seqs 128
 ```
 ### Qwen3.5-35B-A3B-Channel-FP8-w8a8 IFB BW1100 1x vLLM 0.18
 
@@ -898,7 +898,7 @@ vllm serve Qwen/Qwen3.5-122B-A10B \
   --kv-cache-dtype fp8_e4m3 \
   --attention-backend FLASH_ATTN_CUSTOM \
   --moe-backend aiter \
-  --max-num-seqs 32
+  --max-num-seqs 128
 ```
 ### Qwen3.5-122B-A10B IFB BW1100 4x vLLM 0.18
 
@@ -941,7 +941,7 @@ vllm serve Qwen/Qwen3.5-122B-A10B \
   --speculative-config.num_speculative_tokens 3 \
   --attention-backend FLASH_ATTN_CUSTOM \
   --moe-backend aiter \
-  --max-num-seqs 32
+  --max-num-seqs 128
 ```
 ### Qwen3.5-122B-A10B IFB BW1000 8x vLLM 0.18
 
@@ -984,7 +984,7 @@ vllm serve Qwen/Qwen3.5-122B-A10B \
   --max-num-batched-tokens 16384 \
   --speculative-config.method mtp \
   --speculative-config.num_speculative_tokens 3 \
-  --max-num-seqs 32
+  --max-num-seqs 128
 ```
 ### Qwen3.5-122B-A10B IFB K100_AI 8x vLLM 0.18
 
@@ -1026,7 +1026,7 @@ vllm serve Qwen/Qwen3.5-122B-A10B-W8A8-INT8 \
   --speculative-config.quantization "slimquant_marlin" \
   --kv-cache-dtype fp8_e4m3 \
   --attention-backend FLASH_ATTN_CUSTOM \
-  --max-num-seqs 32
+  --max-num-seqs 128
 ```
 ### Qwen3.5-122B-A10B-W8A8-INT8 IFB BW1100 2x vLLM 0.18
 
@@ -1070,7 +1070,7 @@ vllm serve Qwen/Qwen3.5-122B-A10B-W8A8-INT8 \
   --speculative-config.num_speculative_tokens 3 \
   --speculative-config.quantization "slimquant_marlin" \
   --attention-backend FLASH_ATTN_CUSTOM \
-  --max-num-seqs 32
+  --max-num-seqs 128
 ```
 ### Qwen3.5-122B-A10B-W8A8-INT8 IFB BW1000 4x vLLM 0.18
 
@@ -1113,7 +1113,7 @@ vllm serve Qwen/Qwen3.5-122B-A10B-W8A8-INT8 \
   --max-num-batched-tokens 16384 \
   --speculative-config.method mtp \
   --speculative-config.num_speculative_tokens 3 \
-  --max-num-seqs 32
+  --max-num-seqs 128
 ```
 ### Qwen3.5-122B-A10B-W8A8-INT8 IFB K100_AI 4x vLLM 0.18
 
@@ -1155,7 +1155,7 @@ vllm serve hygon/Qwen3.5-122B-A10B-Channel-FP8-w8a8 \
   --speculative-config.quantization "slimquant_marlin" \
   --kv-cache-dtype fp8_e4m3 \
   --attention-backend FLASH_ATTN_CUSTOM \
-  --max-num-seqs 32
+  --max-num-seqs 128
 ```
 ### Qwen3.5-122B-A10B-Channel-FP8-w8a8 IFB BW1100 2x vLLM 0.18
 
@@ -1200,7 +1200,7 @@ vllm serve Qwen/Qwen3.5-397B-A17B-W8A8-INT8 \
   --speculative-config.quantization "slimquant_marlin" \
   --kv-cache-dtype fp8_e4m3 \
   --attention-backend FLASH_ATTN_CUSTOM \
-  --max-num-seqs 32
+  --max-num-seqs 128
 ```
 ### Qwen3.5-397B-A17B-W8A8-INT8 IFB BW1100 8x vLLM 0.18
 
@@ -1244,7 +1244,7 @@ vllm serve Qwen/Qwen3.5-397B-A17B-W8A8-INT8 \
   --speculative-config.num_speculative_tokens 3 \
   --speculative-config.quantization "slimquant_marlin" \
   --attention-backend FLASH_ATTN_CUSTOM \
-  --max-num-seqs 32
+  --max-num-seqs 128
 ```
 ### Qwen3.5-397B-A17B-W8A8-INT8 IFB BW1000 8x vLLM 0.18
 
@@ -1287,7 +1287,7 @@ vllm serve Qwen/Qwen3.5-397B-A17B-W8A8-INT8 \
   --max-num-batched-tokens 16384 \
   --speculative-config.method mtp \
   --speculative-config.num_speculative_tokens 3 \
-  --max-num-seqs 32
+  --max-num-seqs 128
 ```
 ### Qwen3.5-397B-A17B-W8A8-INT8 IFB K100_AI 8x vLLM 0.18
 
@@ -1329,7 +1329,7 @@ vllm serve hygon/Qwen3.5-397B-A17B-Channel-FP8 \
   --speculative-config.quantization "slimquant_marlin" \
   --kv-cache-dtype fp8_e4m3 \
   --attention-backend FLASH_ATTN_CUSTOM \
-  --max-num-seqs 32
+  --max-num-seqs 128
 ```
 ### Qwen3.5-397B-A17B-Channel-FP8 IFB BW1100 4x vLLM 0.18
 


### PR DESCRIPTION
## Summary
- 同步最新 main 后新建分支
- 为 qwen3.5 系列所有 vLLM 0.21 启动命令统一新增/更新：
  - `--max-num-seqs 128`
  - `--max-num-batched-tokens 16384`

## Test plan
- [x] 校验 qwen3.5.md 中 30 个 `vLLM 0.21` 章节均包含 `--max-num-seqs 128`
- [x] 校验 qwen3.5.md 中 30 个 `vLLM 0.21` 章节均包含 `--max-num-batched-tokens 16384`
- [x] 校验 qwen3.5.md 中 0 个 `vLLM 0.21` 章节残留 `--max-num-seqs 32` 或 `--max-num-batched-tokens 10240`

🤖 Generated with [Claude Code](https://claude.com/claude-code)