### PR TITLE
docs: update Hy3 deployment guide

### DIFF
--- a/docs/model-deployment/vllm/hy3.md
+++ b/docs/model-deployment/vllm/hy3.md
@@ -9,8 +9,8 @@ Hy3 是由腾讯混元团队开发的一款拥有 2950 亿参数的混合专家�
 | 模型权重 | 量化方式 | vLLM 版本 | 推荐硬件 | 卡数 | 部署方式 | 启动命令 |
 | -------- | -------- | --------- | -------- | ---- | -------- | -------- |
 | [hygon/Hy3-Channel-FP8-w8a8](https://www.modelscope.cn/models/hygon/Hy3-Channel-FP8-w8a8) | FP8 W8A8 | 0.21 | BW1100 | 8 | IFB | [**`>_`**](#hy3-channel-fp8-w8a8-ifb-bw1100-8x-vllm-021) |
-| [hygon/Hy3-Channel-FP8-w8a8](https://www.modelscope.cn/models/hygon/Hy3-Channel-FP8-w8a8) | FP8 W8A8 | 0.21 | BW1100 | 16 | IFB | [**`>_`**](#hy3-channel-fp8-w8a8-ifb-bw1100-16x-vllm-021) |
-| [hygon/Hy3-Channel-FP8-w8a8](https://www.modelscope.cn/models/hygon/Hy3-Channel-FP8-w8a8) | FP8 W8A8 | 0.21 | BW1100 | 32 | 2P1D | [**`>_`**](#hy3-channel-fp8-w8a8-2p1d-bw1100-32x-vllm-021) |
+| [hygon/Hy3-Channel-FP8-w8a8](https://www.modelscope.cn/models/hygon/Hy3-Channel-FP8-w8a8) | FP8 W8A8 | 0.21 | BW1100(超节点) | 16 | IFB | [**`>_`**](#hy3-channel-fp8-w8a8-ifb-bw1100-16x-vllm-021) |
+| [hygon/Hy3-Channel-FP8-w8a8](https://www.modelscope.cn/models/hygon/Hy3-Channel-FP8-w8a8) | FP8 W8A8 | 0.21 | BW1100(超节点) | 32 | 2P1D | [**`>_`**](#hy3-channel-fp8-w8a8-2p1d-bw1100-32x-vllm-021) |
 
 ## 启动命令
 
@@ -19,12 +19,8 @@ Hy3 是由腾讯混元团队开发的一款拥有 2950 亿参数的混合专家�
 以下示例为单节点部署。
 
 ```bash
-export VLLM_HCU_USE_LIGHTOP_MOE_ALIGN=1
 export VLLM_HCU_USE_CUSTOM_FLASH_ATTN=1
-export VLLM_HCU_USE_FUSE_MOE_GATE=1
-export LMSLIM_USE_LIGHTOP=1
 export GPU_MAX_HW_QUEUES=4
-export ALLREDUCE_STREAM_WITH_COMPUTE=1
 export HIP_VISIBLE_DEVICES=0,1,2,3,4,5,6,7
 
 vllm serve hygon/Hy3-Channel-FP8-w8a8 \
@@ -47,18 +43,11 @@ vllm serve hygon/Hy3-Channel-FP8-w8a8 \
 
 ```bash
 export HIP_VISIBLE_DEVICES=0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15
-export Allgather_Base_STREAM_WITH_COMPUTE=1
-export HIP_KERNEL_EVENT_SYSTENFENCE=1
-export ROCSHMEM_MAX_NUM_CONTEXTS=48
 export ROCSHMEM_HEAP_SIZE=5368709120
 export ROCSHMEM_IPC_MNVL=1
-export HIP_BUFFER_EXTRA_SIZE=0
 export VLLM_DEEPEP_BUFFER_SIZE_MB=0
-export ROCSHMEM_IPC_MNVL=1
 export GPU_MAX_HW_QUEUES=4
 export VLLM_HCU_USE_CUSTOM_FLASH_ATTN=1
-export ROCSHMEM_GDR_DISABLE_XDP=1
-export LD_LIBRARY_PATH=/usr/local/hyhal/lib:/usr/local/hyhal/lib64:/host-rdma:$LD_LIBRARY_PATH
 
 vllm serve hygon/Hy3-Channel-FP8-w8a8 \
   --trust-remote-code \
@@ -90,16 +79,11 @@ P node 0 和 P node 1 分别使用服务端口 `8010` 和 `8011`。
 
 ```bash
 export HIP_VISIBLE_DEVICES=0,1,2,3,4,5,6,7
-export VLLM_HCU_USE_LIGHTOP_MOE_ALIGN=1
 export VLLM_HCU_USE_CUSTOM_FLASH_ATTN=1
 export GPU_MAX_HW_QUEUES=4
-export ROCSHMEM_HEAP_SIZE=4000000000
-export USE_SPE_MQP=1
-export ROCSHMEM_SQ_SIZE=1024
+export ROCSHMEM_HEAP_SIZE=5368709120
 export MC_ENABLE_DEST_DEVICE_AFFINITY=1
 export VLLM_MOONCAKE_BOOTSTRAP_PORT=8998
-export MC_TRANSFER_TIMEOUT=3600
-export LD_LIBRARY_PATH=/usr/local/hyhal/lib:/usr/local/hyhal/lib64:/host-rdma:$LD_LIBRARY_PATH
 
 vllm serve hygon/Hy3-Channel-FP8-w8a8 \
   --trust-remote-code \
@@ -129,16 +113,11 @@ vllm serve hygon/Hy3-Channel-FP8-w8a8 \
 
 ```bash
 export HIP_VISIBLE_DEVICES=8,9,10,11,12,13,14,15
-export VLLM_HCU_USE_LIGHTOP_MOE_ALIGN=1
 export VLLM_HCU_USE_CUSTOM_FLASH_ATTN=1
 export GPU_MAX_HW_QUEUES=4
-export ROCSHMEM_HEAP_SIZE=4000000000
-export USE_SPE_MQP=1
-export ROCSHMEM_SQ_SIZE=1024
+export ROCSHMEM_HEAP_SIZE=5368709120
 export MC_ENABLE_DEST_DEVICE_AFFINITY=1
 export VLLM_MOONCAKE_BOOTSTRAP_PORT=8998
-export MC_TRANSFER_TIMEOUT=3600
-export LD_LIBRARY_PATH=/usr/local/hyhal/lib:/usr/local/hyhal/lib64:/host-rdma:$LD_LIBRARY_PATH
 
 vllm serve hygon/Hy3-Channel-FP8-w8a8 \
   --trust-remote-code \
@@ -168,21 +147,12 @@ vllm serve hygon/Hy3-Channel-FP8-w8a8 \
 
 ```bash
 export HIP_VISIBLE_DEVICES=0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15
-export Allgather_Base_STREAM_WITH_COMPUTE=1
-export HIP_KERNEL_EVENT_SYSTENFENCE=1
-export ROCSHMEM_MAX_NUM_CONTEXTS=48
 export ROCSHMEM_HEAP_SIZE=5368709120
 export ROCSHMEM_IPC_MNVL=1
-export HIP_BUFFER_EXTRA_SIZE=0
 export VLLM_DEEPEP_BUFFER_SIZE_MB=0
-export ROCSHMEM_IPC_MNVL=1
 export GPU_MAX_HW_QUEUES=4
 export VLLM_HCU_USE_CUSTOM_FLASH_ATTN=1
-export ROCSHMEM_GDR_DISABLE_XDP=1
-export VLLM_ENGINE_READY_TIMEOUT_S=3600
-export MC_TRANSFER_TIMEOUT=3600
 export MC_ENABLE_DEST_DEVICE_AFFINITY=1
-export LD_LIBRARY_PATH=/usr/local/hyhal/lib:/usr/local/hyhal/lib64:/host-rdma:$LD_LIBRARY_PATH
 
 vllm serve hygon/Hy3-Channel-FP8-w8a8 \
   --trust-remote-code \
@@ -209,7 +179,7 @@ vllm serve hygon/Hy3-Channel-FP8-w8a8 \
 
 #### + Static EPLB
 
-详细配置和使用流程请参考：[Static EPLB：离线专家布局的记录与加载](../../optimization/static_eplb.md)。
+详细配置和使用流程请参考：[Static EPLB：离线专家布局的记录与加载](../../optimization/static-eplb-vllm.md)。
 
 ```bash
 #record阶段 参数加:

--- a/docs/model-deployment/vllm/hy3.md
+++ b/docs/model-deployment/vllm/hy3.md
@@ -9,6 +9,8 @@ Hy3 是由腾讯混元团队开发的一款拥有 2950 亿参数的混合专家�
 | 模型权重 | 量化方式 | vLLM 版本 | 推荐硬件 | 卡数 | 部署方式 | 启动命令 |
 | -------- | -------- | --------- | -------- | ---- | -------- | -------- |
 | [hygon/Hy3-Channel-FP8-w8a8](https://www.modelscope.cn/models/hygon/Hy3-Channel-FP8-w8a8) | FP8 W8A8 | 0.21 | BW1100 | 8 | IFB | [**`>_`**](#hy3-channel-fp8-w8a8-ifb-bw1100-8x-vllm-021) |
+| [hygon/Hy3-Channel-FP8-w8a8](https://www.modelscope.cn/models/hygon/Hy3-Channel-FP8-w8a8) | FP8 W8A8 | 0.21 | BW1100 | 16 | IFB | [**`>_`**](#hy3-channel-fp8-w8a8-ifb-bw1100-16x-vllm-021) |
+| [hygon/Hy3-Channel-FP8-w8a8](https://www.modelscope.cn/models/hygon/Hy3-Channel-FP8-w8a8) | FP8 W8A8 | 0.21 | BW1100 | 32 | 2P1D | [**`>_`**](#hy3-channel-fp8-w8a8-2p1d-bw1100-32x-vllm-021) |
 
 ## 启动命令
 
@@ -41,6 +43,184 @@ vllm serve hygon/Hy3-Channel-FP8-w8a8 \
   --served-model-name hy3-fp8
 ```
 
+### Hy3-Channel-FP8-w8a8 IFB BW1100 16x vLLM 0.21
+
+```bash
+export HIP_VISIBLE_DEVICES=0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15
+export Allgather_Base_STREAM_WITH_COMPUTE=1
+export HIP_KERNEL_EVENT_SYSTENFENCE=1
+export ROCSHMEM_MAX_NUM_CONTEXTS=48
+export ROCSHMEM_HEAP_SIZE=5368709120
+export ROCSHMEM_IPC_MNVL=1
+export HIP_BUFFER_EXTRA_SIZE=0
+export VLLM_DEEPEP_BUFFER_SIZE_MB=0
+export ROCSHMEM_IPC_MNVL=1
+export GPU_MAX_HW_QUEUES=4
+export VLLM_HCU_USE_CUSTOM_FLASH_ATTN=1
+export ROCSHMEM_GDR_DISABLE_XDP=1
+export LD_LIBRARY_PATH=/usr/local/hyhal/lib:/usr/local/hyhal/lib64:/host-rdma:$LD_LIBRARY_PATH
+
+vllm serve hygon/Hy3-Channel-FP8-w8a8 \
+  --trust-remote-code \
+  -dp 16 \
+  -tp 1 \
+  -q slimquant_marlin \
+  --enable-expert-parallel \
+  --all2all_backend=deepep_low_latency \
+  --disable-custom-all-reduce \
+  --dtype bfloat16 \
+  --enable-chunked-prefill \
+  --max-model-len 16384 \
+  --max-num-seqs 700 \
+  --max-num-batched-tokens 700 \
+  --no-enable-prefix-caching \
+  --block-size 64 \
+  --gpu-memory-utilization 0.90 \
+  --data-parallel-size-local 16 \
+  --data-parallel-rpc-port 1127 \
+  --kv-cache-dtype fp8_e4m3 \
+  --speculative_config '{"method":"mtp","num_speculative_tokens":2, "quantization": "slimquant_marlin"}'
+```
+
+### Hy3-Channel-FP8-w8a8 2P1D BW1100 32x vLLM 0.21
+
+P node 0 和 P node 1 分别使用服务端口 `8010` 和 `8011`。
+
+#### P node 0
+
+```bash
+export HIP_VISIBLE_DEVICES=0,1,2,3,4,5,6,7
+export VLLM_HCU_USE_LIGHTOP_MOE_ALIGN=1
+export VLLM_HCU_USE_CUSTOM_FLASH_ATTN=1
+export GPU_MAX_HW_QUEUES=4
+export ROCSHMEM_HEAP_SIZE=4000000000
+export USE_SPE_MQP=1
+export ROCSHMEM_SQ_SIZE=1024
+export MC_ENABLE_DEST_DEVICE_AFFINITY=1
+export VLLM_MOONCAKE_BOOTSTRAP_PORT=8998
+export MC_TRANSFER_TIMEOUT=3600
+export LD_LIBRARY_PATH=/usr/local/hyhal/lib:/usr/local/hyhal/lib64:/host-rdma:$LD_LIBRARY_PATH
+
+vllm serve hygon/Hy3-Channel-FP8-w8a8 \
+  --trust-remote-code \
+  --speculative-config.method mtp \
+  --speculative-config.num_speculative_tokens 2 \
+  --speculative-config.quantization "slimquant_marlin" \
+  -q slimquant_marlin \
+  --max-model-len 65536 \
+  --max-num-batched-tokens 8192 \
+  --max-num-seqs 128 \
+  --dtype bfloat16 \
+  --tensor-parallel-size 8 \
+  --enable-prefix-caching \
+  --tool-call-parser hy_v3 \
+  --reasoning-parser hy_v3 \
+  --enable-auto-tool-choice \
+  --enable-custom-sp \
+  --enforce-eager \
+  --kv_cache_dtype fp8_e4m3 \
+  --port 8010 \
+  --enable-expert-parallel \
+  --all2all_backend deepep_high_throughput \
+  --kv-transfer-config '{"kv_connector":"MooncakeConnector","kv_role":"kv_producer"}'
+```
+
+#### P node 1
+
+```bash
+export HIP_VISIBLE_DEVICES=8,9,10,11,12,13,14,15
+export VLLM_HCU_USE_LIGHTOP_MOE_ALIGN=1
+export VLLM_HCU_USE_CUSTOM_FLASH_ATTN=1
+export GPU_MAX_HW_QUEUES=4
+export ROCSHMEM_HEAP_SIZE=4000000000
+export USE_SPE_MQP=1
+export ROCSHMEM_SQ_SIZE=1024
+export MC_ENABLE_DEST_DEVICE_AFFINITY=1
+export VLLM_MOONCAKE_BOOTSTRAP_PORT=8998
+export MC_TRANSFER_TIMEOUT=3600
+export LD_LIBRARY_PATH=/usr/local/hyhal/lib:/usr/local/hyhal/lib64:/host-rdma:$LD_LIBRARY_PATH
+
+vllm serve hygon/Hy3-Channel-FP8-w8a8 \
+  --trust-remote-code \
+  --speculative-config.method mtp \
+  --speculative-config.num_speculative_tokens 2 \
+  --speculative-config.quantization "slimquant_marlin" \
+  -q slimquant_marlin \
+  --max-model-len 65536 \
+  --max-num-batched-tokens 8192 \
+  --max-num-seqs 128 \
+  --dtype bfloat16 \
+  --tensor-parallel-size 8 \
+  --enable-prefix-caching \
+  --tool-call-parser hy_v3 \
+  --reasoning-parser hy_v3 \
+  --enable-auto-tool-choice \
+  --enable-custom-sp \
+  --enforce-eager \
+  --kv_cache_dtype fp8_e4m3 \
+  --port 8011 \
+  --enable-expert-parallel \
+  --all2all_backend deepep_high_throughput \
+  --kv-transfer-config '{"kv_connector":"MooncakeConnector","kv_role":"kv_producer"}'
+```
+
+#### D node
+
+```bash
+export HIP_VISIBLE_DEVICES=0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15
+export Allgather_Base_STREAM_WITH_COMPUTE=1
+export HIP_KERNEL_EVENT_SYSTENFENCE=1
+export ROCSHMEM_MAX_NUM_CONTEXTS=48
+export ROCSHMEM_HEAP_SIZE=5368709120
+export ROCSHMEM_IPC_MNVL=1
+export HIP_BUFFER_EXTRA_SIZE=0
+export VLLM_DEEPEP_BUFFER_SIZE_MB=0
+export ROCSHMEM_IPC_MNVL=1
+export GPU_MAX_HW_QUEUES=4
+export VLLM_HCU_USE_CUSTOM_FLASH_ATTN=1
+export ROCSHMEM_GDR_DISABLE_XDP=1
+export VLLM_ENGINE_READY_TIMEOUT_S=3600
+export MC_TRANSFER_TIMEOUT=3600
+export MC_ENABLE_DEST_DEVICE_AFFINITY=1
+export LD_LIBRARY_PATH=/usr/local/hyhal/lib:/usr/local/hyhal/lib64:/host-rdma:$LD_LIBRARY_PATH
+
+vllm serve hygon/Hy3-Channel-FP8-w8a8 \
+  --trust-remote-code \
+  -dp 16 \
+  -tp 1 \
+  -q slimquant_marlin \
+  --enable-expert-parallel \
+  --all2all_backend=deepep_low_latency \
+  --disable-custom-all-reduce \
+  --dtype bfloat16 \
+  --enable-chunked-prefill \
+  --max-model-len 16384 \
+  --max-num-seqs 700 \
+  --max-num-batched-tokens 700 \
+  --no-enable-prefix-caching \
+  --block-size 64 \
+  --gpu-memory-utilization 0.90 \
+  --data-parallel-size-local 16 \
+  --data-parallel-rpc-port 1127 \
+  --kv-cache-dtype fp8_e4m3 \
+  --speculative_config '{"method":"mtp","num_speculative_tokens":2, "quantization": "slimquant_marlin"}' \
+  --kv-transfer-config '{"kv_connector":"MooncakeConnector","kv_role":"kv_consumer"}'
+```
+
+#### + Static EPLB
+
+详细配置和使用流程请参考：[Static EPLB：离线专家布局的记录与加载](../../optimization/static_eplb.md)。
+
+```bash
+#record阶段 参数加:
+--enable-eplb \
+  --eplb-config '{"expert_map_record_path":"/path/to/eplb.json", "num_redundant_experts":16, "step_interval":3000, "log_balancedness":true, "log_balancedness_interval":100, "use_async":false}'
+
+#replay阶段 参数加:
+--enable-eplb \
+  --eplb-config '{"expert_map_path":"/path/to/eplb.json", "num_redundant_experts":16, "step_interval":100000000000, "log_balancedness":true, "log_balancedness_interval":100, "use_async":false}'
+```
+
 ## API 调用
 
 ### IFB
@@ -69,6 +249,39 @@ curl http://0.0.0.0:8000/v1/chat/completions \
   "model": "hy3-fp8",
   "messages": [
     {"role": "user", "content": "你好，请用Python写一个贪吃蛇的游戏脚本"}
+  ],
+  "max_tokens": 1500,
+  "temperature": 0.0
+  }'
+```
+
+### PD 分离
+
+PD 分离模式下，客户端请求发送到 P 节点服务端口。下面以 P node 0 的 `8010` 端口为例。
+
+```python
+from openai import OpenAI
+
+client = OpenAI(base_url="http://<P_node0_ip>:8010/v1", api_key="not-needed")
+
+response = client.chat.completions.create(
+    model="hygon/Hy3-Channel-FP8-w8a8",
+    messages=[
+        {"role": "system", "content": "你是一个专业的编程助手。"},
+        {"role": "user", "content": "用 Python 实现一个高效的 LRU Cache"},
+    ],
+    max_tokens=2048,
+)
+print(response.choices[0].message.content)
+```
+
+```bash
+curl http://<P_node0_ip>:8010/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+  "model": "hygon/Hy3-Channel-FP8-w8a8",
+  "messages": [
+    {"role": "user", "content": "你好，请用 Python 写一个贪吃蛇游戏脚本"}
   ],
   "max_tokens": 1500,
   "temperature": 0.0


### PR DESCRIPTION
## 变更说明

- 更新 Hy3 在 BW1100 上的 vLLM 部署文档。
- 新增 16 卡 IFB 部署配置。
- 新增 32 卡 2P1D 部署配置。
- 新增 Static EPLB 布局记录与加载示例。
- 新增 PD 分离模式的 API 调用示例。
- 添加 Static EPLB 优化指南的参考链接。

## 依赖关系

依赖 #245，该 PR 提供本文档引用的 Static EPLB 优化指南。