### PR TITLE
docs: update vLLM version links

### DIFF
--- a/docs/model-deployment/vllm/deepseek-r1.md
+++ b/docs/model-deployment/vllm/deepseek-r1.md
@@ -20,10 +20,10 @@ DeepSeek-R1 是 DeepSeek 推出的推理强化模型，面向复杂推理、数�
 |                                                                                                             | FP8 W8A8 | [0.15](../docker_images.md) | BW1100 | 8 | IFB | [**`>_`**](#deepseek-r1-channel-fp8-w8a8-ifb-bw1100-8x-vllm-015) |
 | [hygon/DeepSeek-R1-W4A8-V2_6](https://www.modelscope.cn/models/hygon/DeepSeek-R1-W4A8-V2_6) | INT4 W4A8 | 0.21 | BW1100 | 8 | IFB | [**`>_`**](#deepseek-r1-w4a8-v2_6-ifb-bw1100-8x-vllm-021) |
 |                                                                                              | INT4 W4A8 | 0.21 | BW1000 | 8 | IFB | [**`>_`**](#deepseek-r1-w4a8-v2_6-ifb-bw1000-8x-vllm-021) |
-|                                                                                              | INT4 W4A8 | [0.18](../docker_images.md) | BW1100 | 8 | IFB | [**`>_`**](#deepseek-r1-w4a8-v2_6-ifb-bw1100-8x-vllm-018) |
-|                                                                                              | INT4 W4A8 | [0.18](../docker_images.md) | BW1000 | 8 | IFB | [**`>_`**](#deepseek-r1-w4a8-v2_6-ifb-bw1000-8x-vllm-018) |
-| [hygon/DeepSeek-R1-0528-W4A8-V2](https://www.modelscope.cn/models/hygon/DeepSeek-R1-0528-W4A8-V2) | W4A8 | [0.15](../docker_images.md) | BW1100 | 8 | IFB | [**`>_`**](#deepseek-r1-w4a8-ifb-bw1100-8x-vllm-015) |
-| [hygon/DeepSeek-R1-0528-W4A8-V2](https://www.modelscope.cn/models/hygon/DeepSeek-R1-0528-W4A8-V2) | W4A8 | [0.15](../docker_images.md) | BW1000 | 8 | IFB | [**`>_`**](#deepseek-r1-w4a8-ifb-bw1000-8x-vllm-015) |
+|                                                                                              | INT4 W4A8 | [0.18] | BW1100 | 8 | IFB | [**`>_`**](#deepseek-r1-w4a8-v2_6-ifb-bw1100-8x-vllm-018) |
+|                                                                                              | INT4 W4A8 | [0.18] | BW1000 | 8 | IFB | [**`>_`**](#deepseek-r1-w4a8-v2_6-ifb-bw1000-8x-vllm-018) |
+| [hygon/DeepSeek-R1-0528-W4A8-V2](https://www.modelscope.cn/models/hygon/DeepSeek-R1-0528-W4A8-V2) | W4A8 | [0.15] | BW1100 | 8 | IFB | [**`>_`**](#deepseek-r1-w4a8-ifb-bw1100-8x-vllm-015) |
+| [hygon/DeepSeek-R1-0528-W4A8-V2](https://www.modelscope.cn/models/hygon/DeepSeek-R1-0528-W4A8-V2) | W4A8 | [0.15] | BW1000 | 8 | IFB | [**`>_`**](#deepseek-r1-w4a8-ifb-bw1000-8x-vllm-015) |
 
 ## 启动命令
 

--- a/docs/model-deployment/vllm/glm-4.md
+++ b/docs/model-deployment/vllm/glm-4.md
@@ -8,7 +8,7 @@ GLM-4-32B-0414 是智谱 AI 推出的 32B 参数稠密大语言模型，支持�
 
 | 模型权重 | 量化方式 | vLLM 版本 | 推荐硬件 | 卡数 | 部署方式 | 启动命令 |
 | -------- | -------- | --------- | -------- | ---- | -------- | -------- |
-| [ZhipuAI/GLM-4-32B-0414](https://www.modelscope.cn/models/ZhipuAI/GLM-4-32B-0414) | BF16 | 0.18 | BW1100 | 1x | IFB | [**`>_`**](#glm-4-32b-0414-ifb-bw1100-1x-vllm-018) |
+| [ZhipuAI/GLM-4-32B-0414](https://www.modelscope.cn/models/ZhipuAI/GLM-4-32B-0414) | BF16 | [0.18](../docker_images.md)  | BW1100 | 1x | IFB | [**`>_`**](#glm-4-32b-0414-ifb-bw1100-1x-vllm-018) |
 |                                                                               | BF16 | 0.18 | BW1000 | 2x | IFB | [**`>_`**](#glm-4-32b-0414-ifb-bw1000-2x-vllm-018) |
 |                                                                               | BF16 | 0.18 | K100_AI | 2x | IFB | [**`>_`**](#glm-4-32b-0414-ifb-k100_ai-2x-vllm-018) |
 

--- a/docs/model-deployment/vllm/glm-5.1.md
+++ b/docs/model-deployment/vllm/glm-5.1.md
@@ -8,16 +8,16 @@ GLM-5.1 是智谱 AI 推出的新一代大语言模型，在中文理解、长�
 
 | 模型权重 | 量化方式 | vLLM 版本 | 推荐硬件 | 卡数 | 部署方式 | 启动命令 |
 | -------- | -------- | --------- | -------- | ---- | -------- | -------- |
-| [hygon/GLM-5.1-Channel-INT4-w4a8](https://www.modelscope.cn/models/hygon/GLM-5.1-Channel-INT4-w4a8) | INT4 W4A8 | [0.18](../docker_images.md) | BW1100 | 8 | IFB | [**`>_`**](#glm-51-channel-int4-w4a8-ifb-bw1100-8x-vllm-018) |
-|  | INT4 W4A8 | [0.18](../docker_images.md) | BW1000 | 16 | PP2+TP8 | [**`>_`**](#glm-51-channel-int4-w4a8-pp2tp8-bw1000-16x-vllm-018) |
-|  | INT4 W4A8 | [0.15](../docker_images.md) | BW1100 | 8 | IFB | [**`>_`**](#glm-51-channel-int4-w4a8-ifb-bw1100-8x-vllm-015) |
-| [hygon/GLM-5.1-Channel-FP8-w8a8](https://www.modelscope.cn/models/hygon/GLM-5.1-Channel-FP8-w8a8) | FP8 W8A8 | [0.18](../docker_images.md) | BW1100 | 8 | IFB | [**`>_`**](#glm-51-channel-fp8-w8a8-ifb-bw1100-8x-vllm-018) |
-|  | FP8 W8A8 | [0.15](../docker_images.md) | BW1100 | 8 | IFB | [**`>_`**](#glm-51-channel-fp8-w8a8-ifb-bw1100-8x-vllm-015) |
-| [hygon/GLM-5.1-Channel-INT8-w8a8](https://www.modelscope.cn/models/hygon/GLM-5.1-Channel-INT8-w8a8) | INT8 W8A8 | [0.18](../docker_images.md) | BW1100 | 8 | IFB | [**`>_`**](#glm-51-channel-int8-w8a8-ifb-bw1100-8x-vllm-018) |
-|  | INT8 W8A8 | [0.18](../docker_images.md) | BW1100 | 24 | 1P2D | [**`>_`**](#glm-51-channel-int8-w8a8-1p2d-bw1100-24x-vllm-018) |
-|  | INT8 W8A8 | [0.18](../docker_images.md) | BW1000 | 16 | IFB | [**`>_`**](#glm-51-channel-int8-w8a8-ifb-bw1000-16x-vllm-018) |
-|  | INT8 W8A8 | [0.15](../docker_images.md) | BW1100 | 8 | IFB | [**`>_`**](#glm-51-channel-int8-w8a8-ifb-bw1100-8x-vllm-015) |
-|  | INT8 W8A8 | [0.15](../docker_images.md) | BW1100 | 24 | 1P2D | [**`>_`**](#glm-51-channel-int8-w8a8-1p2d-bw1100-24x-vllm-015) |
+| [hygon/GLM-5.1-Channel-INT4-w4a8](https://www.modelscope.cn/models/hygon/GLM-5.1-Channel-INT4-w4a8) | INT4 W4A8 | [0.18] | BW1100 | 8 | IFB | [**`>_`**](#glm-51-channel-int4-w4a8-ifb-bw1100-8x-vllm-018) |
+|  | INT4 W4A8 | [0.18] | BW1000 | 16 | PP2+TP8 | [**`>_`**](#glm-51-channel-int4-w4a8-pp2tp8-bw1000-16x-vllm-018) |
+|  | INT4 W4A8 | [0.15]| BW1100 | 8 | IFB | [**`>_`**](#glm-51-channel-int4-w4a8-ifb-bw1100-8x-vllm-015) |
+| [hygon/GLM-5.1-Channel-FP8-w8a8](https://www.modelscope.cn/models/hygon/GLM-5.1-Channel-FP8-w8a8) | FP8 W8A8 | [0.18] | BW1100 | 8 | IFB | [**`>_`**](#glm-51-channel-fp8-w8a8-ifb-bw1100-8x-vllm-018) |
+|  | FP8 W8A8 | [0.15] | BW1100 | 8 | IFB | [**`>_`**](#glm-51-channel-fp8-w8a8-ifb-bw1100-8x-vllm-015) |
+| [hygon/GLM-5.1-Channel-INT8-w8a8](https://www.modelscope.cn/models/hygon/GLM-5.1-Channel-INT8-w8a8) | INT8 W8A8 | [0.18] | BW1100 | 8 | IFB | [**`>_`**](#glm-51-channel-int8-w8a8-ifb-bw1100-8x-vllm-018) |
+|  | INT8 W8A8 | [0.18] | BW1100 | 24 | 1P2D | [**`>_`**](#glm-51-channel-int8-w8a8-1p2d-bw1100-24x-vllm-018) |
+|  | INT8 W8A8 | [0.18] | BW1000 | 16 | IFB | [**`>_`**](#glm-51-channel-int8-w8a8-ifb-bw1000-16x-vllm-018) |
+|  | INT8 W8A8 | [0.15] | BW1100 | 8 | IFB | [**`>_`**](#glm-51-channel-int8-w8a8-ifb-bw1100-8x-vllm-015) |
+|  | INT8 W8A8 | [0.15] | BW1100 | 24 | 1P2D | [**`>_`**](#glm-51-channel-int8-w8a8-1p2d-bw1100-24x-vllm-015) |
 
 ## 启动命令
 

--- a/docs/model-deployment/vllm/glm-5.md
+++ b/docs/model-deployment/vllm/glm-5.md
@@ -10,15 +10,15 @@ GLM-5 是智谱 AI 推出的新一代大语言模型，在中文理解、长文�
 | -------- | -------- | --------- | -------- | ---- | -------- | -------- |
 | [hygon/GLM-5-Channel-INT4-w4a8](https://www.modelscope.cn/models/hygon/GLM-5-Channel-INT4-w4a8) | INT4 W4A8 | 0.21 | BW1100 | 8 | IFB | [**`>_`**](#glm-5-channel-int4-w4a8-ifb-bw1100-8x-vllm-021) |
 |  | INT4 W4A8 | 0.21 | BW1000 | 16 | PP2+TP8 | [**`>_`**](#glm-5-channel-int4-w4a8-pp2tp8-bw1000-16x-vllm-021) |
-|  | INT4 W4A8 | 0.18 | BW1100 | 8 | IFB | [**`>_`**](#glm-5-channel-int4-w4a8-ifb-bw1100-8x-vllm-018) |
+|  | INT4 W4A8 | [0.18](../docker_images.md) | BW1100 | 8 | IFB | [**`>_`**](#glm-5-channel-int4-w4a8-ifb-bw1100-8x-vllm-018) |
 |  | INT4 W4A8 | 0.18 | BW1000 | 16 | PP2+TP8 | [**`>_`**](#glm-5-channel-int4-w4a8-pp2tp8-bw1000-16x-vllm-018) |
 |  | INT4 W4A8 | 0.15 | BW1100 | 8 | IFB | [**`>_`**](#glm-5-channel-int4-w4a8-ifb-bw1100-8x-vllm-015) |
 | [hygon/GLM-5-Channel-FP8-w8a8](https://www.modelscope.cn/models/hygon/GLM-5-Channel-FP8-w8a8) | FP8 W8A8 | 0.21 | BW1100 | 8 | IFB | [**`>_`**](#glm-5-channel-fp8-w8a8-ifb-bw1100-8x-vllm-021) |
-|  | FP8 W8A8 | 0.18 | BW1100 | 8 | IFB | [**`>_`**](#glm-5-channel-fp8-w8a8-ifb-bw1100-8x-vllm-018) |
+|  | FP8 W8A8 | [0.18](../docker_images.md) | BW1100 | 8 | IFB | [**`>_`**](#glm-5-channel-fp8-w8a8-ifb-bw1100-8x-vllm-018) |
 |  | FP8 W8A8 | 0.15 | BW1100 | 8 | IFB | [**`>_`**](#glm-5-channel-fp8-w8a8-ifb-bw1100-8x-vllm-015) |
 | [hygon/GLM-5-Channel-INT8-w8a8](https://www.modelscope.cn/models/hygon/GLM-5-Channel-INT8-w8a8) | INT8 W8A8 | 0.21 | BW1100 | 8 | IFB | [**``>_``**](#glm-5-channel-int8-w8a8-ifb-bw1100-8x-vllm-021) |
 |  | INT8 W8A8 | 0.21 | BW1000 | 16 | IFB | [**``>_``**](#glm-5-channel-int8-w8a8-ifb-bw1000-16x-vllm-021) |
-|  | INT8 W8A8 | 0.18 | BW1100 | 8 | IFB | [**``>_``**](#glm-5-channel-int8-w8a8-ifb-bw1100-8x-vllm-018) |
+|  | INT8 W8A8 | [0.18](../docker_images.md) | BW1100 | 8 | IFB | [**``>_``**](#glm-5-channel-int8-w8a8-ifb-bw1100-8x-vllm-018) |
 |  | INT8 W8A8 | 0.18 | BW1000 | 16 | IFB | [**``>_``**](#glm-5-channel-int8-w8a8-ifb-bw1000-16x-vllm-018) |
 |  | INT8 W8A8 | 0.15 | BW1100 | 8 | IFB | [**`>_`**](#glm-5-channel-int8-w8a8-ifb-bw1100-8x-vllm-015) |
 |  | INT8 W8A8 | 0.15 | BW1100 | 24 | 1P2D | [**``>_``**](#glm-5-channel-int8-w8a8-1p2d-bw1100-24x-vllm-015) |

--- a/docs/model-deployment/vllm/qwen3.5.md
+++ b/docs/model-deployment/vllm/qwen3.5.md
@@ -67,13 +67,13 @@ Qwen3.5 是 Qwen3 系列的增强版本，在推理能力、代码生成、多�
 |  | FP8 W8A8  | 0.18 | BW1100  | 1 | IFB | [**`>_`**](#qwen35-35b-a3b-channel-fp8-w8a8-ifb-bw1100-1x-vllm-018) |
 |  | FP8 W8A8 | 0.18-hotfix | BW1100 | 1 | IFB | [**`>_`**](#qwen35-35b-a3b-channel-fp8-w8a8-ifb-bw1100-1x-vllm-018-hotfix) |
 | [Qwen/Qwen3.5-122B-A10B](https://www.modelscope.cn/models/Qwen/Qwen3.5-122B-A10B) | BF16 | 0.21 | BW1100 | 4 | IFB | [**`>_`**](#qwen35-122b-a10b-ifb-bw1100-4x-vllm-021) |
-|  | BF16   | 0.18 | BW1100  | 4 | IFB | [**`>_`**](#qwen35-122b-a10b-ifb-bw1100-4x-vllm-018)  |
+|  | BF16   | [0.18](../docker_images.md) | BW1100  | 4 | IFB | [**`>_`**](#qwen35-122b-a10b-ifb-bw1100-4x-vllm-018)  |
 |  | BF16 | 0.18-hotfix | BW1100 | 4 | IFB | [**`>_`**](#qwen35-122b-a10b-ifb-bw1100-4x-vllm-018-hotfix) |
 |  | BF16 | 0.21 | BW1000 | 8 | IFB | [**`>_`**](#qwen35-122b-a10b-ifb-bw1000-8x-vllm-021) |
-|                                                                                  | BF16   | 0.18 | BW1000  | 8 | IFB | [**`>_`**](#qwen35-122b-a10b-ifb-bw1000-8x-vllm-018)   |
+|                                                                                  | BF16   | [0.18](../docker_images.md) | BW1000  | 8 | IFB | [**`>_`**](#qwen35-122b-a10b-ifb-bw1000-8x-vllm-018)   |
 |  | BF16 | 0.18-hotfix | BW1000 | 8 | IFB | [**`>_`**](#qwen35-122b-a10b-ifb-bw1000-8x-vllm-018-hotfix) |
 |  | BF16 | 0.21 | K100_AI | 8 | IFB | [**`>_`**](#qwen35-122b-a10b-ifb-k100_ai-8x-vllm-021) |
-|                                                                                  | BF16   | 0.18 | K100_AI | 8 | IFB | [**`>_`**](#qwen35-122b-a10b-ifb-k100_ai-8x-vllm-018)   |
+|                                                                                  | BF16   | [0.18](../docker_images.md) | K100_AI | 8 | IFB | [**`>_`**](#qwen35-122b-a10b-ifb-k100_ai-8x-vllm-018)   |
 |  | BF16 | 0.18-hotfix | K100_AI | 8 | IFB | [**`>_`**](#qwen35-122b-a10b-ifb-k100_ai-8x-vllm-018-hotfix) |
 | [Qwen/Qwen3.5-122B-A10B-AWQ](https://www.modelscope.cn/models/tclf90/Qwen3.5-122B-A10B-AWQ) | AWQ | 0.18 | K100_AI | 4 | IFB | [**`>_`**](#qwen35-122b-a10b-awq-ifb-k100_ai-4x-vllm-018) |
 | [Qwen/Qwen3.5-122B-A10B-W8A8-INT8](https://www.modelscope.cn/models/Qwen/Qwen3.5-122B-A10B-W8A8-INT8) | INT8 W8A8 | 0.21 | BW1100 | 2 | IFB | [**`>_`**](#qwen35-122b-a10b-w8a8-int8-ifb-bw1100-2x-vllm-021) |
@@ -83,7 +83,7 @@ Qwen3.5 是 Qwen3 系列的增强版本，在推理能力、代码生成、多�
 |                                                                                               | INT8 W8A8 | 0.18 | BW1000  | 4 | IFB | [**`>_`**](#qwen35-122b-a10b-w8a8-int8-ifb-bw1000-4x-vllm-018) |
 |  | INT8 W8A8 | 0.18-hotfix | BW1000 | 4 | IFB | [**`>_`**](#qwen35-122b-a10b-w8a8-int8-ifb-bw1000-4x-vllm-018-hotfix) |
 |  | INT8 W8A8 | 0.21 | K100_AI | 4 | IFB | [**`>_`**](#qwen35-122b-a10b-w8a8-int8-ifb-k100_ai-4x-vllm-021) |
-|                                                                                               | INT8 W8A8 | 0.18 | K100_AI | 4 | IFB | [**`>_`**](#qwen35-122b-a10b-w8a8-int8-ifb-k100_ai-4x-vllm-018) |
+|                                                                                               | INT8 W8A8 | [0.18](../docker_images.md) | K100_AI | 4 | IFB | [**`>_`**](#qwen35-122b-a10b-w8a8-int8-ifb-k100_ai-4x-vllm-018) |
 |  | INT8 W8A8 | 0.18-hotfix | K100_AI | 4 | IFB | [**`>_`**](#qwen35-122b-a10b-w8a8-int8-ifb-k100_ai-4x-vllm-018-hotfix) |
 | [hygon/Qwen3.5-122B-A10B-Channel-FP8-w8a8](https://www.modelscope.cn/models/hygon/Qwen3.5-122B-A10B-Channel-FP8-w8a8)    | FP8 W8A8 | 0.21 | BW1100 | 2 | IFB | [**`>_`**](#qwen35-122b-a10b-channel-fp8-w8a8-ifb-bw1100-2x-vllm-021) |
 |  | FP8 W8A8  | 0.18 | BW1100  | 2 | IFB | [**`>_`**](#qwen35-122b-a10b-channel-fp8-w8a8-ifb-bw1100-2x-vllm-018) |

--- a/docs/model-deployment/vllm/qwen3.md
+++ b/docs/model-deployment/vllm/qwen3.md
@@ -15,7 +15,7 @@ Qwen3 是阿里通义千问第三代大语言模型，支持 0.6B ~ 235B 多种�
 |                                                                               | BF16 | 0.18 | BW1000  | 1 | IFB | [**`>_`**](#qwen3-06b-ifb-bw1000-1x-vllm-018)           |
 |  | BF16 | 0.18-hotfix | BW1000 | 1 | IFB | [**`>_`**](#qwen3-06b-ifb-bw1000-1x-vllm-018-hotfix) |
 |  | BF16 | 0.21 | K100_AI | 1 | IFB | [**`>_`**](#qwen3-06b-ifb-k100_ai-1x-vllm-021) |
-|                                                                               | BF16 | 0.18 | K100_AI | 1 | IFB | [**`>_`**](#qwen3-06b-ifb-k100_ai-1x-vllm-018)          |
+|                                                                               | BF16 | [0.18](../docker_images.md) | K100_AI | 1 | IFB | [**`>_`**](#qwen3-06b-ifb-k100_ai-1x-vllm-018)          |
 |  | BF16 | 0.18-hotfix | K100_AI | 1 | IFB | [**`>_`**](#qwen3-06b-ifb-k100_ai-1x-vllm-018-hotfix) |
 |                                                                               | BF16 | 0.15 | BW1100  | 1   | IFB | [**`>_`**](#qwen3-06b-ifb-bw1100-1x-vllm-015) |
 |                                                                               | BF16 | 0.15 | BW1000  | 1 | IFB | [**`>_`**](#qwen3-06b-ifb-bw1000-1x-vllm-015)           |
@@ -39,7 +39,7 @@ Qwen3 是阿里通义千问第三代大语言模型，支持 0.6B ~ 235B 多种�
 |                                                                               | BF16 | 0.18 | BW1000  | 1 | IFB | [**`>_`**](#qwen3-4b-ifb-bw1000-1x-vllm-018)            |
 |  | BF16 | 0.18-hotfix | BW1000 | 1 | IFB | [**`>_`**](#qwen3-4b-ifb-bw1000-1x-vllm-018-hotfix) |
 |  | BF16 | 0.21 | K100_AI | 1 | IFB | [**`>_`**](#qwen3-4b-ifb-k100_ai-1x-vllm-021) |
-|                                                                               | BF16 | 0.18 | K100_AI | 1 | IFB | [**`>_`**](#qwen3-4b-ifb-k100_ai-1x-vllm-018)           |
+|                                                                               | BF16 | [0.18](../docker_images.md) | K100_AI | 1 | IFB | [**`>_`**](#qwen3-4b-ifb-k100_ai-1x-vllm-018)           |
 |  | BF16 | 0.18-hotfix | K100_AI | 1 | IFB | [**`>_`**](#qwen3-4b-ifb-k100_ai-1x-vllm-018-hotfix) |
 |                                                                               | BF16 | 0.15 | BW1100  | 1   | IFB | [**`>_`**](#qwen3-4b-ifb-bw1100-1x-vllm-015) |
 |                                                                               | BF16 | 0.15 | BW1000  | 1 | IFB | [**`>_`**](#qwen3-4b-ifb-bw1000-1x-vllm-015)            |
@@ -55,13 +55,13 @@ Qwen3 是阿里通义千问第三代大语言模型，支持 0.6B ~ 235B 多种�
 |                                                                               | INT8 W8A8 | 0.15 | BW1000 | 1 | IFB | [**`>_`**](#qwen3-4b-channel-int8-w8a8-ifb-bw1000-1x-vllm-015) |
 |                                                                               | INT8 W8A8 | 0.15 | K100_AI | 1 | IFB | [**`>_`**](#qwen3-4b-channel-int8-w8a8-ifb-k100_ai-1x-vllm-015) |
 | [Qwen/Qwen3-8B](https://www.modelscope.cn/models/Qwen/Qwen3-8B)               | BF16 | 0.21 | BW1100 | 1 | IFB | [**`>_`**](#qwen3-8b-ifb-bw1100-1x-vllm-021) |
-|  | BF16 | 0.18 | BW1100  | 1 | IFB | [**`>_`**](#qwen3-8b-ifb-bw1100-1x-vllm-018)            |
+|  | BF16 | [0.18](../docker_images.md) | BW1100  | 1 | IFB | [**`>_`**](#qwen3-8b-ifb-bw1100-1x-vllm-018)            |
 |  | BF16 | 0.18-hotfix | BW1100 | 1 | IFB | [**`>_`**](#qwen3-8b-ifb-bw1100-1x-vllm-018-hotfix) |
 |  | BF16 | 0.21 | BW1000 | 1 | IFB | [**`>_`**](#qwen3-8b-ifb-bw1000-1x-vllm-021) |
-|                                                                               | BF16 | 0.18 | BW1000  | 1 | IFB | [**`>_`**](#qwen3-8b-ifb-bw1000-1x-vllm-018)            |
+|                                                                               | BF16 | [0.18](../docker_images.md) | BW1000  | 1 | IFB | [**`>_`**](#qwen3-8b-ifb-bw1000-1x-vllm-018)            |
 |  | BF16 | 0.18-hotfix | BW1000 | 1 | IFB | [**`>_`**](#qwen3-8b-ifb-bw1000-1x-vllm-018-hotfix) |
 |  | BF16 | 0.21 | K100_AI | 1 | IFB | [**`>_`**](#qwen3-8b-ifb-k100_ai-1x-vllm-021) |
-|                                                                               | BF16 | 0.18 | K100_AI | 1 | IFB | [**`>_`**](#qwen3-8b-ifb-k100_ai-1x-vllm-018)           |
+|                                                                               | BF16 | [0.18](../docker_images.md) | K100_AI | 1 | IFB | [**`>_`**](#qwen3-8b-ifb-k100_ai-1x-vllm-018)           |
 |  | BF16 | 0.18-hotfix | K100_AI | 1 | IFB | [**`>_`**](#qwen3-8b-ifb-k100_ai-1x-vllm-018-hotfix) |
 |                                                                               | BF16 | 0.15 | BW1100  | 1   | IFB | [**`>_`**](#qwen3-8b-ifb-bw1100-1x-vllm-015) |
 |                                                                               | BF16 | 0.15 | BW1000  | 1 | IFB | [**`>_`**](#qwen3-8b-ifb-bw1000-1x-vllm-015)            |
@@ -133,7 +133,7 @@ Qwen3 是阿里通义千问第三代大语言模型，支持 0.6B ~ 235B 多种�
 |                                                                               | INT8 W8A8 | 0.15 | BW1000 | 1 | IFB | [**`>_`**](#qwen3-30b-a3b-instruct-2507-w8a8-int8-ifb-bw1000-1x-vllm-015) |
 |                                                                               | INT8 W8A8 | 0.15 | K100_AI | 1 | IFB | [**`>_`**](#qwen3-30b-a3b-instruct-2507-w8a8-int8-ifb-k100_ai-1x-vllm-015) |
 | [Qwen/Qwen3-235B-A22B-Instruct-2507](https://www.modelscope.cn/models/Qwen/Qwen3-235B-A22B-Instruct-2507) | BF16 | 0.21 | BW1100 | 4 | IFB | [**`>_`**](#qwen3-235b-a22b-instruct-2507-ifb-bw1100-4x-vllm-021) |
-|  | BF16 | 0.18 | BW1100 | 4 | IFB | [**`>_`**](#qwen3-235b-a22b-instruct-2507-ifb-bw1100-4x-vllm-018) |
+|  | BF16 | [0.18](../docker_images.md) | BW1100 | 4 | IFB | [**`>_`**](#qwen3-235b-a22b-instruct-2507-ifb-bw1100-4x-vllm-018) |
 |  | BF16 | 0.18-hotfix | BW1100 | 4 | IFB | [**`>_`**](#qwen3-235b-a22b-instruct-2507-ifb-bw1100-4x-vllm-018-hotfix) |
 |  | BF16 | 0.21 | BW1000 | 8 | IFB | [**`>_`**](#qwen3-235b-a22b-instruct-2507-ifb-bw1000-8x-vllm-021) |
 |                                                                               | BF16 | 0.18 | BW1000 | 8 | IFB | [**`>_`**](#qwen3-235b-a22b-instruct-2507-ifb-bw1000-8x-vllm-018) |


### PR DESCRIPTION
## Summary
- update vLLM version references across DeepSeek, GLM, and Qwen deployment tables
- align selected version entries with the Docker image documentation link

## Verification
- `git diff --check upstream/main...HEAD`
- rebased successfully onto the latest `upstream/main`