### PR TITLE
docs: add Qwen vLLM 0.18 best practices

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@
     <tr>
       <td rowspan="2">Qwen3-VL</td>
       <td>vLLM</td>
-      <td align="center">🚧</td><td align="center"><a href="docs/model-deployment/vllm/qwen3-vl.md">✅</a></td><td align="center">🚧</td>
+      <td align="center"><a href="docs/model-deployment/vllm/qwen3-vl.md">✅</a></td><td align="center"><a href="docs/model-deployment/vllm/qwen3-vl.md">✅</a></td><td align="center"><a href="docs/model-deployment/vllm/qwen3-vl.md">✅</a></td>
     </tr>
     <tr>
       <td>SGLang</td>
@@ -58,7 +58,7 @@
     <tr>
       <td rowspan="2">Qwen3-Next</td>
       <td>vLLM</td>
-      <td align="center">-</td><td align="center">-</td><td align="center">-</td>
+      <td align="center"><a href="docs/model-deployment/vllm/qwen3-next.md">✅</a></td><td align="center"><a href="docs/model-deployment/vllm/qwen3-next.md">✅</a></td><td align="center"><a href="docs/model-deployment/vllm/qwen3-next.md">✅</a></td>
     </tr>
     <tr>
       <td>SGLang</td>

--- a/docs/model-deployment/vllm/qwen3-next.md
+++ b/docs/model-deployment/vllm/qwen3-next.md
@@ -1,0 +1,90 @@
+# Qwen3-Next on vLLM
+
+## 模型简介
+
+Qwen3-Next 是 Qwen 系列的下一代模型架构。本页提供 Qwen3-Next-80B-A3B-Instruct 在 DCU 平台上的 vLLM 部署最佳实践。
+
+## 模型列表
+
+| 模型权重 | 量化方式 | vLLM 版本 | 推荐硬件 | 卡数 | 部署方式 | 启动命令 |
+| -------- | -------- | --------- | -------- | ---- | -------- | -------- |
+| [Qwen/Qwen3-Next-80B-A3B-Instruct](https://www.modelscope.cn/models/Qwen/Qwen3-Next-80B-A3B-Instruct) | BF16 | [0.18](../docker_images.md) | BW1100 | 4 | IFB | [**`>_`**](#qwen3-next-80b-a3b-instruct-ifb-bw1100-4x-vllm-018) |
+|                                                                                                                   | BF16 | [0.18](../docker_images.md) | BW1000 | 4 | IFB | [**`>_`**](#qwen3-next-80b-a3b-instruct-ifb-bw1000-4x-vllm-018) |
+|                                                                                                                   | BF16 | [0.18](../docker_images.md) | K100_AI | 4 | IFB | [**`>_`**](#qwen3-next-80b-a3b-instruct-ifb-k100ai-4x-vllm-018) |
+
+## 启动命令
+
+### Qwen3-Next-80B-A3B-Instruct IFB BW1100 4x vLLM 0.18
+
+```bash
+vllm serve Qwen/Qwen3-Next-80B-A3B-Instruct \
+  --dtype float16 \
+  --tensor-parallel-size 4 \
+  --gpu-memory-utilization 0.9 \
+  --max-num-seqs 1024 \
+  --trust-remote-code \
+  --distributed-executor-backend=mp \
+  --no-enable-prefix-caching \
+  --disable-cascade-attn
+```
+
+### Qwen3-Next-80B-A3B-Instruct IFB BW1000 4x vLLM 0.18
+
+```bash
+vllm serve Qwen/Qwen3-Next-80B-A3B-Instruct \
+  --dtype float16 \
+  --tensor-parallel-size 4 \
+  --gpu-memory-utilization 0.9 \
+  --max-num-seqs 1024 \
+  --trust-remote-code \
+  --distributed-executor-backend=mp \
+  --no-enable-prefix-caching \
+  --disable-cascade-attn
+```
+### Qwen3-Next-80B-A3B-Instruct IFB K100_AI 4x vLLM 0.18
+
+```bash
+
+vllm serve Qwen/Qwen3-Next-80B-A3B-Instruct \
+  --dtype float16 \
+  --tensor-parallel-size 4 \
+  --gpu-memory-utilization 0.9 \
+  --max-num-seqs 1024 \
+  --trust-remote-code \
+  --distributed-executor-backend=mp \
+  --no-enable-prefix-caching \
+  --disable-cascade-attn
+```
+
+## API 调用
+
+### IFB
+
+```python
+from openai import OpenAI
+
+client = OpenAI(base_url="http://localhost:8000/v1", api_key="not-needed")
+
+response = client.chat.completions.create(
+    model="Qwen/Qwen3-Next-80B-A3B-Instruct",
+    messages=[
+        {"role": "system", "content": "你是一个专业的编程助手。"},
+        {"role": "user", "content": "用 Python 实现一个高效的 LRU Cache"},
+    ],
+    max_tokens=2048,
+)
+print(response.choices[0].message.content)
+```
+
+```bash
+curl http://localhost:8000/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+  "model": "Qwen/Qwen3-Next-80B-A3B-Instruct",
+  "messages": [
+    {"role": "system", "content": "你是一个专业的编程助手。"},
+    {"role": "user", "content": "用 Python 实现一个高效的 LRU Cache"}
+  ],
+  "max_tokens": 128
+  }'
+```

--- a/docs/model-deployment/vllm/qwen3-next.md
+++ b/docs/model-deployment/vllm/qwen3-next.md
@@ -2,7 +2,7 @@
 
 ## 模型简介
 
-Qwen3-Next 是 Qwen 系列的下一代模型架构。本页提供 Qwen3-Next-80B-A3B-Instruct 在 DCU 平台上的 vLLM 部署最佳实践。
+Qwen3-Next 是 Qwen 系列的下一代模型架构。本页提供 Qwen3-Next-80B-A3B-Instruct 在 HCU 平台上的 vLLM 部署最佳实践。
 
 ## 模型列表
 

--- a/docs/model-deployment/vllm/qwen3-vl.md
+++ b/docs/model-deployment/vllm/qwen3-vl.md
@@ -84,13 +84,13 @@ Qwen3-VL 是阿里云推出的新一代多模态视觉语言模型（Vision-Lang
 |                                                                               | BF16      | 0.18 | K100_AI | 2x | IFB | [**`>_`**](#qwen3-vl-30b-a3b-instruct-ifb-k100_ai-2x-vllm-018) |
 |  | BF16 | 0.18-hotfix | K100_AI | 2x | IFB | [**`>_`**](#qwen3-vl-30b-a3b-instruct-ifb-k100_ai-2x-vllm-018-hotfix) |
 | [Qwen/Qwen3-VL-30B-A3B-Thinking](https://www.modelscope.cn/models/Qwen/Qwen3-VL-30B-A3B-Thinking) | BF16 | 0.21 | BW1100 | 1x | IFB | [**`>_`**](#qwen3-vl-30b-a3b-thinking-ifb-bw1100-1x-vllm-021) |
-|  | BF16 | [0.18](../docker_images.md) | BW1100  | 2x | IFB | [**`>_`**](#qwen3-vl-30b-a3b-thinking-ifb-bw1100-2x-vllm-018) |
+|  | BF16 | 0.18 | BW1100  | 1x | IFB | [**`>_`**](#qwen3-vl-30b-a3b-thinking-ifb-bw1100-1x-vllm-018) |
 |  | BF16 | 0.18-hotfix | BW1100 | 1x | IFB | [**`>_`**](#qwen3-vl-30b-a3b-thinking-ifb-bw1100-1x-vllm-018-hotfix) |
 |  | BF16 | 0.21 | BW1000 | 2x | IFB | [**`>_`**](#qwen3-vl-30b-a3b-thinking-ifb-bw1000-2x-vllm-021) |
-|                                                                               | BF16      | [0.18](../docker_images.md) | BW1000  | 2x | IFB | [**`>_`**](#qwen3-vl-30b-a3b-thinking-ifb-bw1000-2x-vllm-018) |
+|                                                                               | BF16      | 0.18 | BW1000  | 2x | IFB | [**`>_`**](#qwen3-vl-30b-a3b-thinking-ifb-bw1000-2x-vllm-018) |
 |  | BF16 | 0.18-hotfix | BW1000 | 2x | IFB | [**`>_`**](#qwen3-vl-30b-a3b-thinking-ifb-bw1000-2x-vllm-018-hotfix) |
 |  | BF16 | 0.21 | K100_AI | 2x | IFB | [**`>_`**](#qwen3-vl-30b-a3b-thinking-ifb-k100_ai-2x-vllm-021) |
-|                                                                               | BF16      | [0.18](../docker_images.md) | K100_AI | 4x | IFB | [**`>_`**](#qwen3-vl-30b-a3b-thinking-ifb-k100_ai-4x-vllm-018) |
+|                                                                               | BF16      | 0.18 | K100_AI | 2x | IFB | [**`>_`**](#qwen3-vl-30b-a3b-thinking-ifb-k100_ai-2x-vllm-018) |
 |  | BF16 | 0.18-hotfix | K100_AI | 2x | IFB | [**`>_`**](#qwen3-vl-30b-a3b-thinking-ifb-k100_ai-2x-vllm-018-hotfix) |
 | [Qwen/Qwen3-VL-32B-Instruct](https://www.modelscope.cn/models/Qwen/Qwen3-VL-32B-Instruct) | BF16 | 0.21 | BW1100 | 1x | IFB | [**`>_`**](#qwen3-vl-32b-instruct-ifb-bw1100-1x-vllm-021) |
 |  | BF16 | 0.18 | BW1100 | 1x | IFB | [**`>_`**](#qwen3-vl-32b-instruct-ifb-bw1100-1x-vllm-018) |
@@ -779,16 +779,14 @@ vllm serve Qwen/Qwen3-VL-30B-A3B-Thinking \
   --kv-cache-dtype fp8_e4m3 \
   --attention-backend FLASH_ATTN_CUSTOM
 ```
-### Qwen3-VL-30B-A3B-Thinking IFB BW1100 2x vLLM 0.18
+### Qwen3-VL-30B-A3B-Thinking IFB BW1100 1x vLLM 0.18
 ```bash
-export VLLM_HCU_USE_FLASH_ATTN=1
-export VLLM_HCU_USE_FLASH_ATTN_UNIFIED=1
-export VLLM_HCU_USE_CUSTOM_TOPK_TOPP_SAMPLER=1
-
+export VLLM_USE_MODELSCOPE=1
+export VLLM_HCU_USE_PD_SPLIT=1
+export VLLM_HCU_USE_CUSTOM_FLASH_ATTN=1
 vllm serve Qwen/Qwen3-VL-30B-A3B-Thinking \
-  --tensor-parallel-size 2 \
-  --disable-cascade-attn \
-  --trust-remote-code
+  -tp 1 \
+  --trust-remote-code 
 ```
 
 ### Qwen3-VL-30B-A3B-Thinking IFB BW1100 1x vLLM 0.18-hotfix
@@ -814,14 +812,12 @@ vllm serve Qwen/Qwen3-VL-30B-A3B-Thinking \
 ```
 ### Qwen3-VL-30B-A3B-Thinking IFB BW1000 2x vLLM 0.18
 ```bash
-export VLLM_HCU_USE_FLASH_ATTN=1
-export VLLM_HCU_USE_FLASH_ATTN_UNIFIED=1
-export VLLM_HCU_USE_CUSTOM_TOPK_TOPP_SAMPLER=1
-
+export VLLM_USE_MODELSCOPE=1
+export VLLM_HCU_USE_PD_SPLIT=1
+export VLLM_HCU_USE_CUSTOM_FLASH_ATTN=1
 vllm serve Qwen/Qwen3-VL-30B-A3B-Thinking \
-  --tensor-parallel-size 2 \
-  --disable-cascade-attn \
-  --trust-remote-code
+  -tp 2 \
+  --trust-remote-code 
 ```
 
 ### Qwen3-VL-30B-A3B-Thinking IFB BW1000 2x vLLM 0.18-hotfix
@@ -844,15 +840,14 @@ vllm serve Qwen/Qwen3-VL-30B-A3B-Thinking \
   -tp 2 \
   --trust-remote-code 
 ```
-### Qwen3-VL-30B-A3B-Thinking IFB K100_AI 4x vLLM 0.18
+### Qwen3-VL-30B-A3B-Thinking IFB K100_AI 2x vLLM 0.18
 ```bash
-export VLLM_HCU_USE_FLASH_ATTN=1
-export VLLM_HCU_USE_FLASH_ATTN_UNIFIED=1
-export VLLM_HCU_USE_CUSTOM_TOPK_TOPP_SAMPLER=1
-
+export VLLM_HCU_USE_CUSTOM_QUANTIZATION_GEMM=0
+export VLLM_HCU_USE_CUSTOM_OPS=0
+export VLLM_USE_MODELSCOPE=1
 vllm serve Qwen/Qwen3-VL-30B-A3B-Thinking \
-  --tensor-parallel-size 4 \
-  --trust-remote-code
+  -tp 2 \
+  --trust-remote-code 
 ```
 
 ### Qwen3-VL-30B-A3B-Thinking IFB K100_AI 2x vLLM 0.18-hotfix

--- a/docs/model-deployment/vllm/qwen3-vl.md
+++ b/docs/model-deployment/vllm/qwen3-vl.md
@@ -84,13 +84,13 @@ Qwen3-VL 是阿里云推出的新一代多模态视觉语言模型（Vision-Lang
 |                                                                               | BF16      | 0.18 | K100_AI | 2x | IFB | [**`>_`**](#qwen3-vl-30b-a3b-instruct-ifb-k100_ai-2x-vllm-018) |
 |  | BF16 | 0.18-hotfix | K100_AI | 2x | IFB | [**`>_`**](#qwen3-vl-30b-a3b-instruct-ifb-k100_ai-2x-vllm-018-hotfix) |
 | [Qwen/Qwen3-VL-30B-A3B-Thinking](https://www.modelscope.cn/models/Qwen/Qwen3-VL-30B-A3B-Thinking) | BF16 | 0.21 | BW1100 | 1x | IFB | [**`>_`**](#qwen3-vl-30b-a3b-thinking-ifb-bw1100-1x-vllm-021) |
-|  | BF16 | 0.18 | BW1100  | 1x | IFB | [**`>_`**](#qwen3-vl-30b-a3b-thinking-ifb-bw1100-1x-vllm-018) |
+|  | BF16 | [0.18](../docker_images.md) | BW1100  | 2x | IFB | [**`>_`**](#qwen3-vl-30b-a3b-thinking-ifb-bw1100-2x-vllm-018) |
 |  | BF16 | 0.18-hotfix | BW1100 | 1x | IFB | [**`>_`**](#qwen3-vl-30b-a3b-thinking-ifb-bw1100-1x-vllm-018-hotfix) |
 |  | BF16 | 0.21 | BW1000 | 2x | IFB | [**`>_`**](#qwen3-vl-30b-a3b-thinking-ifb-bw1000-2x-vllm-021) |
-|                                                                               | BF16      | 0.18 | BW1000  | 2x | IFB | [**`>_`**](#qwen3-vl-30b-a3b-thinking-ifb-bw1000-2x-vllm-018) |
+|                                                                               | BF16      | [0.18](../docker_images.md) | BW1000  | 2x | IFB | [**`>_`**](#qwen3-vl-30b-a3b-thinking-ifb-bw1000-2x-vllm-018) |
 |  | BF16 | 0.18-hotfix | BW1000 | 2x | IFB | [**`>_`**](#qwen3-vl-30b-a3b-thinking-ifb-bw1000-2x-vllm-018-hotfix) |
 |  | BF16 | 0.21 | K100_AI | 2x | IFB | [**`>_`**](#qwen3-vl-30b-a3b-thinking-ifb-k100_ai-2x-vllm-021) |
-|                                                                               | BF16      | 0.18 | K100_AI | 2x | IFB | [**`>_`**](#qwen3-vl-30b-a3b-thinking-ifb-k100_ai-2x-vllm-018) |
+|                                                                               | BF16      | [0.18](../docker_images.md) | K100_AI | 4x | IFB | [**`>_`**](#qwen3-vl-30b-a3b-thinking-ifb-k100_ai-4x-vllm-018) |
 |  | BF16 | 0.18-hotfix | K100_AI | 2x | IFB | [**`>_`**](#qwen3-vl-30b-a3b-thinking-ifb-k100_ai-2x-vllm-018-hotfix) |
 | [Qwen/Qwen3-VL-32B-Instruct](https://www.modelscope.cn/models/Qwen/Qwen3-VL-32B-Instruct) | BF16 | 0.21 | BW1100 | 1x | IFB | [**`>_`**](#qwen3-vl-32b-instruct-ifb-bw1100-1x-vllm-021) |
 |  | BF16 | 0.18 | BW1100 | 1x | IFB | [**`>_`**](#qwen3-vl-32b-instruct-ifb-bw1100-1x-vllm-018) |
@@ -779,14 +779,16 @@ vllm serve Qwen/Qwen3-VL-30B-A3B-Thinking \
   --kv-cache-dtype fp8_e4m3 \
   --attention-backend FLASH_ATTN_CUSTOM
 ```
-### Qwen3-VL-30B-A3B-Thinking IFB BW1100 1x vLLM 0.18
+### Qwen3-VL-30B-A3B-Thinking IFB BW1100 2x vLLM 0.18
 ```bash
-export VLLM_USE_MODELSCOPE=1
-export VLLM_HCU_USE_PD_SPLIT=1
-export VLLM_HCU_USE_CUSTOM_FLASH_ATTN=1
+export VLLM_HCU_USE_FLASH_ATTN=1
+export VLLM_HCU_USE_FLASH_ATTN_UNIFIED=1
+export VLLM_HCU_USE_CUSTOM_TOPK_TOPP_SAMPLER=1
+
 vllm serve Qwen/Qwen3-VL-30B-A3B-Thinking \
-  -tp 1 \
-  --trust-remote-code 
+  --tensor-parallel-size 2 \
+  --disable-cascade-attn \
+  --trust-remote-code
 ```
 
 ### Qwen3-VL-30B-A3B-Thinking IFB BW1100 1x vLLM 0.18-hotfix
@@ -812,12 +814,14 @@ vllm serve Qwen/Qwen3-VL-30B-A3B-Thinking \
 ```
 ### Qwen3-VL-30B-A3B-Thinking IFB BW1000 2x vLLM 0.18
 ```bash
-export VLLM_USE_MODELSCOPE=1
-export VLLM_HCU_USE_PD_SPLIT=1
-export VLLM_HCU_USE_CUSTOM_FLASH_ATTN=1
+export VLLM_HCU_USE_FLASH_ATTN=1
+export VLLM_HCU_USE_FLASH_ATTN_UNIFIED=1
+export VLLM_HCU_USE_CUSTOM_TOPK_TOPP_SAMPLER=1
+
 vllm serve Qwen/Qwen3-VL-30B-A3B-Thinking \
-  -tp 2 \
-  --trust-remote-code 
+  --tensor-parallel-size 2 \
+  --disable-cascade-attn \
+  --trust-remote-code
 ```
 
 ### Qwen3-VL-30B-A3B-Thinking IFB BW1000 2x vLLM 0.18-hotfix
@@ -840,14 +844,15 @@ vllm serve Qwen/Qwen3-VL-30B-A3B-Thinking \
   -tp 2 \
   --trust-remote-code 
 ```
-### Qwen3-VL-30B-A3B-Thinking IFB K100_AI 2x vLLM 0.18
+### Qwen3-VL-30B-A3B-Thinking IFB K100_AI 4x vLLM 0.18
 ```bash
-export VLLM_HCU_USE_CUSTOM_QUANTIZATION_GEMM=0
-export VLLM_HCU_USE_CUSTOM_OPS=0
-export VLLM_USE_MODELSCOPE=1
+export VLLM_HCU_USE_FLASH_ATTN=1
+export VLLM_HCU_USE_FLASH_ATTN_UNIFIED=1
+export VLLM_HCU_USE_CUSTOM_TOPK_TOPP_SAMPLER=1
+
 vllm serve Qwen/Qwen3-VL-30B-A3B-Thinking \
-  -tp 2 \
-  --trust-remote-code 
+  --tensor-parallel-size 4 \
+  --trust-remote-code
 ```
 
 ### Qwen3-VL-30B-A3B-Thinking IFB K100_AI 2x vLLM 0.18-hotfix

--- a/docs/model-deployment/vllm/qwen3.md
+++ b/docs/model-deployment/vllm/qwen3.md
@@ -138,7 +138,7 @@ Qwen3 是阿里通义千问第三代大语言模型，支持 0.6B ~ 235B 多种�
 |  | BF16 | 0.21 | BW1000 | 8 | IFB | [**`>_`**](#qwen3-235b-a22b-instruct-2507-ifb-bw1000-8x-vllm-021) |
 |                                                                               | BF16 | 0.18 | BW1000 | 8 | IFB | [**`>_`**](#qwen3-235b-a22b-instruct-2507-ifb-bw1000-8x-vllm-018) |
 |  | BF16 | 0.18-hotfix | BW1000 | 8 | IFB | [**`>_`**](#qwen3-235b-a22b-instruct-2507-ifb-bw1000-8x-vllm-018-hotfix) |
-|                                                                               | BF16 | 0.18 | K100_AI | 8 | IFB | [**`>_`**](#qwen3-235b-a22b-instruct-2507-ifb-k100_ai-8x-vllm-018) |
+|                                                                               | BF16 | [0.18](../docker_images.md) | K100_AI | 8 | IFB | [**`>_`**](#qwen3-235b-a22b-instruct-2507-ifb-k100_ai-8x-vllm-018) |
 |                                                                               | BF16 | 0.15 | BW1100  | 4 | IFB | [**`>_`**](#qwen3-235b-a22b-instruct-2507-ifb-bw1100-4x-vllm-015) |
 |                                                                               | BF16 | 0.15 | BW1000  | 8 | IFB | [**`>_`**](#qwen3-235b-a22b-instruct-2507-ifb-bw1000-8x-vllm-015) |
 |                                                                               | BF16 | 0.15 | K100_AI | 8 | IFB | [**`>_`**](#qwen3-235b-a22b-instruct-2507-ifb-k100_ai-8x-vllm-015) |
@@ -1338,7 +1338,19 @@ vllm serve Qwen/Qwen3-235B-A22B-Instruct-2507 \
 ```
 ### Qwen3-235B-A22B-Instruct-2507 IFB K100_AI 8x vLLM 0.18
 
-<!-- TODO: 启动命令待补充 -->
+```bash
+export VLLM_HCU_USE_CUSTOM_QUANTIZATION_GEMM=0
+export VLLM_HCU_USE_CUSTOM_OPS=0
+
+vllm serve Qwen/Qwen3-235B-A22B-Instruct-2507 \
+  --dtype float16 \
+  --trust-remote-code \
+  --gpu-memory-utilization 0.95 \
+  --max-num-seqs 16 \
+  -tp 8 \
+  --disable-cascade-attn \
+  --max-model-len 32768
+```
 
 ### Qwen3-235B-A22B-Instruct-2507 IFB BW1100 4x vLLM 0.15
 


### PR DESCRIPTION
## Summary
- add vLLM 0.18 best practices for Qwen3-Next-80B-A3B-Instruct
- complete Qwen3-235B-A22B-Instruct-2507 K100_AI deployment guidance
- update Qwen3-VL-30B-A3B-Thinking deployment commands and support matrix

## Verification
- git diff --check
- reviewed the complete four-file change set for accidental secrets