### PR TITLE
docs: add vLLM 0.18 deployment examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@
     <tr>
       <td rowspan="2">Qwen3-Coder</td>
       <td>vLLM</td>
-      <td align="center">🚧</td><td align="center">🚧</td><td align="center">🚧</td>
+      <td align="center">🚧</td><td align="center">🚧</td><td align="center"><a href="docs/model-deployment/vllm/qwen3.md">✅</a></td>
     </tr>
     <tr>
       <td>SGLang</td>

--- a/docs/model-deployment/vllm/deepseek-r1.md
+++ b/docs/model-deployment/vllm/deepseek-r1.md
@@ -22,6 +22,8 @@ DeepSeek-R1 是 DeepSeek 推出的推理强化模型，面向复杂推理、数�
 |                                                                                              | INT4 W4A8 | 0.21 | BW1000 | 8 | IFB | [**`>_`**](#deepseek-r1-w4a8-v2_6-ifb-bw1000-8x-vllm-021) |
 |                                                                                              | INT4 W4A8 | [0.18] | BW1100 | 8 | IFB | [**`>_`**](#deepseek-r1-w4a8-v2_6-ifb-bw1100-8x-vllm-018) |
 |                                                                                              | INT4 W4A8 | [0.18] | BW1000 | 8 | IFB | [**`>_`**](#deepseek-r1-w4a8-v2_6-ifb-bw1000-8x-vllm-018) |
+| [hygon/DeepSeek-R1-0528-W4A8-V2](https://www.modelscope.cn/models/hygon/DeepSeek-R1-0528-W4A8-V2) | INT4 W4A8 | [0.18](../docker_images.md) | BW1100 | 4 | IFB | [**`>_`**](#deepseek-r1-0528-w4a8-v2-ifb-bw1100-4x-vllm-018) |
+|                                      | INT4 W4A8 | [0.18](../docker_images.md) | BW1000 | 8 | IFB | [**`>_`**](#deepseek-r1-0528-w4a8-v2-ifb-bw1000-8x-vllm-018) |
 | [hygon/DeepSeek-R1-0528-W4A8-V2](https://www.modelscope.cn/models/hygon/DeepSeek-R1-0528-W4A8-V2) | W4A8 | [0.15] | BW1100 | 8 | IFB | [**`>_`**](#deepseek-r1-w4a8-ifb-bw1100-8x-vllm-015) |
 | [hygon/DeepSeek-R1-0528-W4A8-V2](https://www.modelscope.cn/models/hygon/DeepSeek-R1-0528-W4A8-V2) | W4A8 | [0.15] | BW1000 | 8 | IFB | [**`>_`**](#deepseek-r1-w4a8-ifb-bw1000-8x-vllm-015) |
 
@@ -417,6 +419,49 @@ vllm serve hygon/DeepSeek-R1-W4A8-V2_6 \
   --max-num-batched-tokens 8192 \
   -tp 8 \
   --gpu-memory-utilization 0.92 \
+  --max-num-seqs 256 \
+  --speculative_config '{"method":"deepseek_mtp","num_speculative_tokens":2}'
+```
+
+### DeepSeek-R1-0528-W4A8-V2 IFB BW1100 4x vLLM 0.18
+
+```bash
+export VLLM_USE_MODELSCOPE=1
+export VLLM_ROCM_USE_AITER_MOE=1
+export VLLM_HCU_USE_FLASHMLA=1
+export LMSLIM_USE_GLOBAL_MOE_CACHE=1
+export VLLM_HCU_USE_CAT_MLA=0
+
+vllm serve hygon/DeepSeek-R1-0528-W4A8-V2 \
+  --trust-remote-code \
+  --dtype bfloat16 \
+  --kv-cache-dtype fp8 \
+  --max-model-len 65536 \
+  --max-num-batched-tokens 8192 \
+  -tp 4 \
+  --gpu-memory-utilization 0.92 \
+  --max-num-seqs 256 \
+  --speculative_config '{"method":"deepseek_mtp","num_speculative_tokens":2}'
+```
+
+### DeepSeek-R1-0528-W4A8-V2 IFB BW1000 8x vLLM 0.18
+
+```bash
+export VLLM_USE_MODELSCOPE=1
+export VLLM_ROCM_USE_AITER_MOE=1
+export VLLM_HCU_USE_FLASHMLA=1
+export LMSLIM_USE_GLOBAL_MOE_CACHE=1
+export VLLM_HCU_USE_CAT_MLA=0
+
+export HIP_VISIBLE_DEVICES=0,1,2,3,4,5,6,7
+
+vllm serve hygon/DeepSeek-R1-0528-W4A8-V2 \
+  --trust-remote-code \
+  --dtype bfloat16 \
+  --max-model-len 16384 \
+  --max-num-batched-tokens 8192 \
+  -tp 8 \
+  --gpu-memory-utilization 0.95 \
   --max-num-seqs 256 \
   --speculative_config '{"method":"deepseek_mtp","num_speculative_tokens":2}'
 ```

--- a/docs/model-deployment/vllm/qwen3.md
+++ b/docs/model-deployment/vllm/qwen3.md
@@ -156,6 +156,8 @@ Qwen3 是阿里通义千问第三代大语言模型，支持 0.6B ~ 235B 多种�
 |  | FP8 | 0.18 | BW1100 | 4 | IFB | [**`>_`**](#qwen3-235b-a22b-fp8-channelwise-ifb-bw1100-4x-vllm-018) |
 |  | FP8 | 0.18-hotfix | BW1100 | 4 | IFB | [**`>_`**](#qwen3-235b-a22b-fp8-channelwise-ifb-bw1100-4x-vllm-018-hotfix) |
 |                                                                               | FP8  | 0.15 | BW1100 | 4 | IFB | [**`>_`**](#qwen3-235b-a22b-fp8-channelwise-ifb-bw1100-4x-vllm-015) |
+| Qwen3-Coder-480B-A35B-Instruct-w8a8 | INT8 W8A8 | [0.18](../docker_images.md) | BW1100 | 8 | IFB | [**`>_`**](#qwen3-coder-480b-a35b-instruct-w8a8-ifb-bw1100-8x-vllm-018) |
+| Qwen3-Coder-480B-A35B-Instruct-FP8-Dynamic | FP8 | [0.18](../docker_images.md) | BW1100 | 8 | IFB | [**`>_`**](#qwen3-coder-480b-a35b-instruct-fp8-dynamic-ifb-bw1100-8x-vllm-018) |
 
 
 ## 启动命令
@@ -1522,6 +1524,88 @@ vllm serve Qwen/Qwen3-235B-A22B-FP8-Channelwise \
   -q slimquant_marlin \
   --disable-cascade-attn \
   -cc '{"pass_config": {"fuse_act_quant": false}, "custom_ops": ["all"]}'
+```
+
+### Qwen3-Coder-480B-A35B-Instruct-w8a8 IFB BW1100 8x vLLM 0.18
+
+```bash
+export VLLM_NUMA_BIND=1
+export VLLM_RANK0_NUMA=0
+export VLLM_RANK1_NUMA=0
+export VLLM_RANK2_NUMA=1
+export VLLM_RANK3_NUMA=1
+export VLLM_RANK4_NUMA=2
+export VLLM_RANK5_NUMA=2
+export VLLM_RANK6_NUMA=3
+export VLLM_RANK7_NUMA=3
+export HSA_FORCE_FINE_GRAIN_PCIE=1
+export NCCL_MAX_NCHANNELS=16
+export NCCL_MIN_NCHANNELS=16
+export NCCL_P2P_LEVEL=SYS
+export NCCL_LAUNCH_MODE=GROUP
+export VLLM_RPC_TIMEOUT=1800000
+
+#export LD_LIBRARY_PATH=/opt/rocblas-install/lib:$LD_LIBRARY_PATH #按照实际
+export VLLM_USE_PIECEWISE=0
+export VLLM_USE_FUSED_FILL_RMS_CAT=0
+export VLLM_USE_FUSED_RMS_ROPE=0
+export VLLM_USE_AITER_MOE_W8A8=0
+
+vllm serve Qwen3-Coder-480B-A35B-Instruct-w8a8 \
+  --trust-remote-code \
+  --dtype bfloat16 \
+  --max-model-len 262144 \
+  -tp 8 \
+  --host 0.0.0.0 \
+  --gpu-memory-utilization 0.9 \
+  --max-num-seqs 128 \
+  --block-size 64 \
+  --max-num-batched-tokens 16384 \
+  --no-enable-prefix-caching \
+  --kv-cache-dtype fp8_e4m3 \
+  --enable-chunked-prefill \
+  --compilation-config '{"pass_config": {"fuse_act_quant": false}}'
+```
+
+### Qwen3-Coder-480B-A35B-Instruct-FP8-Dynamic IFB BW1100 8x vLLM 0.18
+
+```bash
+export VLLM_NUMA_BIND=1
+export VLLM_RANK0_NUMA=0
+export VLLM_RANK1_NUMA=0
+export VLLM_RANK2_NUMA=1
+export VLLM_RANK3_NUMA=1
+export VLLM_RANK4_NUMA=2
+export VLLM_RANK5_NUMA=2
+export VLLM_RANK6_NUMA=3
+export VLLM_RANK7_NUMA=3
+export HSA_FORCE_FINE_GRAIN_PCIE=1
+export NCCL_MAX_NCHANNELS=16
+export NCCL_MIN_NCHANNELS=16
+export NCCL_P2P_LEVEL=SYS
+export NCCL_LAUNCH_MODE=GROUP
+export VLLM_RPC_TIMEOUT=1800000
+
+#export LD_LIBRARY_PATH=/opt/rocblas-install/lib:$LD_LIBRARY_PATH #按照实际
+export VLLM_USE_PIECEWISE=0
+export VLLM_USE_FUSED_FILL_RMS_CAT=0
+export VLLM_USE_FUSED_RMS_ROPE=0
+export VLLM_USE_AITER_MOE_W8A8=0
+
+vllm serve Qwen3-Coder-480B-A35B-Instruct-FP8-Dynamic \
+  --trust-remote-code \
+  --dtype bfloat16 \
+  --max-model-len 262144 \
+  -tp 8 \
+  --host 0.0.0.0 \
+  --gpu-memory-utilization 0.9 \
+  --max-num-seqs 128 \
+  --block-size 64 \
+  --max-num-batched-tokens 16384 \
+  --no-enable-prefix-caching \
+  --enable-chunked-prefill \
+  --kv-cache-dtype fp8_e4m3 \
+  --compilation-config '{"pass_config": {"fuse_act_quant": false}}'
 ```
 
 

--- a/docs/model-deployment/vllm/qwen3.md
+++ b/docs/model-deployment/vllm/qwen3.md
@@ -156,8 +156,6 @@ Qwen3 是阿里通义千问第三代大语言模型，支持 0.6B ~ 235B 多种�
 |  | FP8 | 0.18 | BW1100 | 4 | IFB | [**`>_`**](#qwen3-235b-a22b-fp8-channelwise-ifb-bw1100-4x-vllm-018) |
 |  | FP8 | 0.18-hotfix | BW1100 | 4 | IFB | [**`>_`**](#qwen3-235b-a22b-fp8-channelwise-ifb-bw1100-4x-vllm-018-hotfix) |
 |                                                                               | FP8  | 0.15 | BW1100 | 4 | IFB | [**`>_`**](#qwen3-235b-a22b-fp8-channelwise-ifb-bw1100-4x-vllm-015) |
-| Qwen3-Coder-480B-A35B-Instruct-w8a8 | INT8 W8A8 | [0.18](../docker_images.md) | BW1100 | 8 | IFB | [**`>_`**](#qwen3-coder-480b-a35b-instruct-w8a8-ifb-bw1100-8x-vllm-018) |
-| Qwen3-Coder-480B-A35B-Instruct-FP8-Dynamic | FP8 | [0.18](../docker_images.md) | BW1100 | 8 | IFB | [**`>_`**](#qwen3-coder-480b-a35b-instruct-fp8-dynamic-ifb-bw1100-8x-vllm-018) |
 
 
 ## 启动命令
@@ -1524,88 +1522,6 @@ vllm serve Qwen/Qwen3-235B-A22B-FP8-Channelwise \
   -q slimquant_marlin \
   --disable-cascade-attn \
   -cc '{"pass_config": {"fuse_act_quant": false}, "custom_ops": ["all"]}'
-```
-
-### Qwen3-Coder-480B-A35B-Instruct-w8a8 IFB BW1100 8x vLLM 0.18
-
-```bash
-export VLLM_NUMA_BIND=1
-export VLLM_RANK0_NUMA=0
-export VLLM_RANK1_NUMA=0
-export VLLM_RANK2_NUMA=1
-export VLLM_RANK3_NUMA=1
-export VLLM_RANK4_NUMA=2
-export VLLM_RANK5_NUMA=2
-export VLLM_RANK6_NUMA=3
-export VLLM_RANK7_NUMA=3
-export HSA_FORCE_FINE_GRAIN_PCIE=1
-export NCCL_MAX_NCHANNELS=16
-export NCCL_MIN_NCHANNELS=16
-export NCCL_P2P_LEVEL=SYS
-export NCCL_LAUNCH_MODE=GROUP
-export VLLM_RPC_TIMEOUT=1800000
-
-#export LD_LIBRARY_PATH=/opt/rocblas-install/lib:$LD_LIBRARY_PATH #按照实际
-export VLLM_USE_PIECEWISE=0
-export VLLM_USE_FUSED_FILL_RMS_CAT=0
-export VLLM_USE_FUSED_RMS_ROPE=0
-export VLLM_USE_AITER_MOE_W8A8=0
-
-vllm serve Qwen3-Coder-480B-A35B-Instruct-w8a8 \
-  --trust-remote-code \
-  --dtype bfloat16 \
-  --max-model-len 262144 \
-  -tp 8 \
-  --host 0.0.0.0 \
-  --gpu-memory-utilization 0.9 \
-  --max-num-seqs 128 \
-  --block-size 64 \
-  --max-num-batched-tokens 16384 \
-  --no-enable-prefix-caching \
-  --kv-cache-dtype fp8_e4m3 \
-  --enable-chunked-prefill \
-  --compilation-config '{"pass_config": {"fuse_act_quant": false}}'
-```
-
-### Qwen3-Coder-480B-A35B-Instruct-FP8-Dynamic IFB BW1100 8x vLLM 0.18
-
-```bash
-export VLLM_NUMA_BIND=1
-export VLLM_RANK0_NUMA=0
-export VLLM_RANK1_NUMA=0
-export VLLM_RANK2_NUMA=1
-export VLLM_RANK3_NUMA=1
-export VLLM_RANK4_NUMA=2
-export VLLM_RANK5_NUMA=2
-export VLLM_RANK6_NUMA=3
-export VLLM_RANK7_NUMA=3
-export HSA_FORCE_FINE_GRAIN_PCIE=1
-export NCCL_MAX_NCHANNELS=16
-export NCCL_MIN_NCHANNELS=16
-export NCCL_P2P_LEVEL=SYS
-export NCCL_LAUNCH_MODE=GROUP
-export VLLM_RPC_TIMEOUT=1800000
-
-#export LD_LIBRARY_PATH=/opt/rocblas-install/lib:$LD_LIBRARY_PATH #按照实际
-export VLLM_USE_PIECEWISE=0
-export VLLM_USE_FUSED_FILL_RMS_CAT=0
-export VLLM_USE_FUSED_RMS_ROPE=0
-export VLLM_USE_AITER_MOE_W8A8=0
-
-vllm serve Qwen3-Coder-480B-A35B-Instruct-FP8-Dynamic \
-  --trust-remote-code \
-  --dtype bfloat16 \
-  --max-model-len 262144 \
-  -tp 8 \
-  --host 0.0.0.0 \
-  --gpu-memory-utilization 0.9 \
-  --max-num-seqs 128 \
-  --block-size 64 \
-  --max-num-batched-tokens 16384 \
-  --no-enable-prefix-caching \
-  --enable-chunked-prefill \
-  --kv-cache-dtype fp8_e4m3 \
-  --compilation-config '{"pass_config": {"fuse_act_quant": false}}'
 ```
 
 


### PR DESCRIPTION
## Summary
- Add DeepSeek-R1-0528-W4A8-V2 vLLM 0.18 deployment examples for BW1100 and BW1000.
- Add Qwen3-Coder 480B FP8 Dynamic and W8A8 vLLM 0.18 deployment examples for BW1100.
- Update the README support matrix for Qwen3-Coder on BW1100.

## Verification
- git diff --check