### PR TITLE
docs: remove DeepSeek-R1 FP8 BW1000 vLLM 0.21 recipe

### DIFF
--- a/docs/model-deployment/vllm/deepseek-r1.md
+++ b/docs/model-deployment/vllm/deepseek-r1.md
@@ -24,7 +24,6 @@ DeepSeek-R1 是 DeepSeek 推出的推理强化模型，面向复杂推理、数�
 |                                                                                                              | INT8 W8A8 | [0.15](../docker_images.md) | BW1100 | 8 | IFB | [**`>_`**](#deepseek-r1-channel-int8-w8a8-ifb-bw1100-8x-vllm-015) |
 |                                                                                                              | INT8 W8A8 | [0.15](../docker_images.md) | BW1000 | 16 | IFB | [**`>_`**](#deepseek-r1-channel-int8-w8a8-ifb-bw1000-16x-vllm-015) |
 | [hygon/DeepSeek-R1-Channel-FP8-w8a8](https://www.modelscope.cn/models/hygon/DeepSeek-R1-Channel-FP8-w8a8) | FP8 W8A8 | 0.21 | BW1100 | 8 | IFB | [**`>_`**](#deepseek-r1-channel-fp8-w8a8-ifb-bw1100-8x-vllm-021) |
-|                                                                                                             | FP8 W8A8 | 0.21 | BW1000 | 8 | IFB | [**`>_`**](#deepseek-r1-channel-fp8-w8a8-ifb-bw1000-8x-vllm-021) |
 |                                                                                                             | FP8 W8A8 | [0.18](../docker_images.md) | BW1100 | 8 | IFB | [**`>_`**](#deepseek-r1-channel-fp8-w8a8-ifb-bw1100-8x-vllm-018) |
 |                                                                                                             | FP8 W8A8 | [0.15](../docker_images.md) | BW1100 | 8 | IFB | [**`>_`**](#deepseek-r1-channel-fp8-w8a8-ifb-bw1100-8x-vllm-015) |
 | [hygon/DeepSeek-R1-W4A8-V2_6](https://www.modelscope.cn/models/hygon/DeepSeek-R1-W4A8-V2_6) | INT4 W4A8 | 0.21 | BW1100 | 8 | IFB | [**`>_`**](#deepseek-r1-w4a8-v2_6-ifb-bw1100-8x-vllm-021) |
@@ -415,23 +414,6 @@ vllm serve hygon/DeepSeek-R1-Channel-FP8-w8a8 \
   --speculative_config '{"method": "deepseek_mtp", "num_speculative_tokens": 2,"quantization": "slimquant_marlin"}' \
   --no-enable-prefix-caching \
   --kv-cache-dtype fp8_e4m3 \
-  --attention-backend FLASHMLA
-```
-
-### DeepSeek-R1-Channel-FP8-w8a8 IFB BW1000 8x vLLM 0.21
-
-```bash
-vllm serve hygon/DeepSeek-R1-Channel-FP8-w8a8 \
-  --trust-remote-code \
-  -q slimquant_marlin \
-  -tp 8 \
-  --dtype bfloat16 \
-  --max-model-len 65536 \
-  --gpu-memory-utilization 0.90 \
-  --max-num-batched-tokens 16384 \
-  --speculative_config '{"method": "deepseek_mtp", "num_speculative_tokens": 2,"quantization": "slimquant_marlin"}' \
-  --no-enable-prefix-caching \
-  --kv-cache-dtype fp8_e5m2 \
   --attention-backend FLASHMLA
 ```
 


### PR DESCRIPTION
## Summary

- remove the DeepSeek-R1-Channel-FP8-w8a8 vLLM 0.21 BW1000 entry from the model table
- remove the matching BW1000 launch-command section
- preserve the BW1100 and older-vLLM FP8 recipes

## Verification

- `git diff --check origin/main..HEAD`
- confirmed the removed anchor and heading have zero matches
- confirmed all three BW1100 FP8 headings remain