### PR TITLE
docs: remove BW1000 vLLM 0.21 fp8_e5m2 kv cache

### DIFF
--- a/docs/model-deployment/vllm/deepseek-r1.md
+++ b/docs/model-deployment/vllm/deepseek-r1.md
@@ -322,7 +322,6 @@ vllm serve hygon/DeepSeek-R1-Channel-INT8-w8a8 \
   --max-num-batched-tokens 16384 \
   --speculative_config '{"method": "deepseek_mtp", "num_speculative_tokens": 2,"quantization": "slimquant_marlin"}' \
   --no-enable-prefix-caching \
-  --kv-cache-dtype fp8_e5m2 \
   --attention-backend FLASHMLA
 ```
 
@@ -617,7 +616,6 @@ export VLLM_HCU_USE_CAT_MLA=0
 vllm serve hygon/DeepSeek-R1-W4A8-V2_6 \
   --trust-remote-code \
   --dtype bfloat16 \
-  --kv-cache-dtype fp8_e5m2 \
   --max-model-len 65536 \
   --max-num-batched-tokens 8192 \
   -tp 8 \


### PR DESCRIPTION
## Summary
- Remove `--kv-cache-dtype fp8_e5m2` from BW1000 vLLM 0.21 command blocks in `docs/model-deployment/vllm/deepseek-r1.md`.

## Validation
- Parsed `###` sections and verified no `BW1000` + `vLLM 0.21` section still contains `--kv-cache-dtype fp8_e5m2`.
- Diff only removes the two matching parameter lines from DeepSeek-R1 BW1000 vLLM 0.21 commands.
