### PR TITLE
docs: add DeepSeek-R1-0528-W4A8-V2 vLLM 0.21

### DIFF
--- a/docs/model-deployment/vllm/deepseek-r1.md
+++ b/docs/model-deployment/vllm/deepseek-r1.md
@@ -39,6 +39,8 @@ DeepSeek-R1 是 DeepSeek 推出的推理强化模型，面向复杂推理、数�
 |                                                                                              | INT4 W4A8 | 0.21 | BW1000 | 8 | IFB | [**`>_`**](#deepseek-r1-w4a8-v2_6-ifb-bw1000-8x-vllm-021) |
 |                                                                                              | INT4 W4A8 | [0.18] | BW1100 | 8 | IFB | [**`>_`**](#deepseek-r1-w4a8-v2_6-ifb-bw1100-8x-vllm-018) |
 |                                                                                              | INT4 W4A8 | [0.18] | BW1000 | 8 | IFB | [**`>_`**](#deepseek-r1-w4a8-v2_6-ifb-bw1000-8x-vllm-018) |
+| [hygon/DeepSeek-R1-0528-W4A8-V2](https://www.modelscope.cn/models/hygon/DeepSeek-R1-0528-W4A8-V2) | INT4 W4A8 | 0.21 | BW1100 | 8 | IFB | [**`>_`**](#deepseek-r1-0528-w4a8-v2-ifb-bw1100-8x-vllm-021) |
+|                                      | INT4 W4A8 | 0.21 | BW1000 | 8 | IFB | [**`>_`**](#deepseek-r1-0528-w4a8-v2-ifb-bw1000-8x-vllm-021) |
 | [hygon/DeepSeek-R1-0528-W4A8-V2](https://www.modelscope.cn/models/hygon/DeepSeek-R1-0528-W4A8-V2) | INT4 W4A8 | [0.18](../docker_images.md) | BW1100 | 4 | IFB | [**`>_`**](#deepseek-r1-0528-w4a8-v2-ifb-bw1100-4x-vllm-018) |
 |                                      | INT4 W4A8 | [0.18](../docker_images.md) | BW1000 | 8 | IFB | [**`>_`**](#deepseek-r1-0528-w4a8-v2-ifb-bw1000-8x-vllm-018) |
 | [hygon/DeepSeek-R1-0528-W4A8-V2](https://www.modelscope.cn/models/hygon/DeepSeek-R1-0528-W4A8-V2) | W4A8 | [0.15] | BW1100 | 8 | IFB | [**`>_`**](#deepseek-r1-w4a8-ifb-bw1100-8x-vllm-015) |
@@ -667,6 +669,47 @@ vllm serve hygon/DeepSeek-R1-W4A8-V2_6 \
   --gpu-memory-utilization 0.92 \
   --max-num-seqs 256 \
   --speculative_config '{"method":"deepseek_mtp","num_speculative_tokens":2}'
+```
+
+### DeepSeek-R1-0528-W4A8-V2 IFB BW1100 8x vLLM 0.21
+
+```bash
+export VLLM_USE_MODELSCOPE=1
+export LMSLIM_USE_GLOBAL_MOE_CACHE=1
+export VLLM_HCU_USE_CAT_MLA=0
+
+vllm serve hygon/DeepSeek-R1-0528-W4A8-V2 \
+  --trust-remote-code \
+  --dtype bfloat16 \
+  --kv-cache-dtype fp8_e4m3 \
+  --max-model-len 65536 \
+  --max-num-batched-tokens 8192 \
+  -tp 8 \
+  --gpu-memory-utilization 0.92 \
+  --max-num-seqs 256 \
+  --speculative_config '{"method":"deepseek_mtp","num_speculative_tokens":2}' \
+  --attention-backend FLASHMLA \
+  --moe-backend aiter
+```
+
+### DeepSeek-R1-0528-W4A8-V2 IFB BW1000 8x vLLM 0.21
+
+```bash
+export VLLM_USE_MODELSCOPE=1
+export LMSLIM_USE_GLOBAL_MOE_CACHE=1
+export VLLM_HCU_USE_CAT_MLA=0
+
+vllm serve hygon/DeepSeek-R1-0528-W4A8-V2 \
+  --trust-remote-code \
+  --dtype bfloat16 \
+  --max-model-len 65536 \
+  --max-num-batched-tokens 8192 \
+  -tp 8 \
+  --gpu-memory-utilization 0.92 \
+  --max-num-seqs 256 \
+  --speculative_config '{"method":"deepseek_mtp","num_speculative_tokens":2}' \
+  --attention-backend FLASHMLA \
+  --moe-backend aiter
 ```
 
 ### DeepSeek-R1-0528-W4A8-V2 IFB BW1100 4x vLLM 0.18

--- a/docs/model-deployment/vllm/deepseek-r1.md
+++ b/docs/model-deployment/vllm/deepseek-r1.md
@@ -41,7 +41,7 @@ DeepSeek-R1 是 DeepSeek 推出的推理强化模型，面向复杂推理、数�
 |                                                                                              | INT4 W4A8 | [0.18] | BW1000 | 8 | IFB | [**`>_`**](#deepseek-r1-w4a8-v2_6-ifb-bw1000-8x-vllm-018) |
 | [hygon/DeepSeek-R1-0528-W4A8-V2](https://www.modelscope.cn/models/hygon/DeepSeek-R1-0528-W4A8-V2) | INT4 W4A8 | 0.21 | BW1100 | 8 | IFB | [**`>_`**](#deepseek-r1-0528-w4a8-v2-ifb-bw1100-8x-vllm-021) |
 |                                      | INT4 W4A8 | 0.21 | BW1000 | 8 | IFB | [**`>_`**](#deepseek-r1-0528-w4a8-v2-ifb-bw1000-8x-vllm-021) |
-| [hygon/DeepSeek-R1-0528-W4A8-V2](https://www.modelscope.cn/models/hygon/DeepSeek-R1-0528-W4A8-V2) | INT4 W4A8 | [0.18](../docker_images.md) | BW1100 | 4 | IFB | [**`>_`**](#deepseek-r1-0528-w4a8-v2-ifb-bw1100-4x-vllm-018) |
+|                                      | INT4 W4A8 | [0.18](../docker_images.md) | BW1100 | 4 | IFB | [**`>_`**](#deepseek-r1-0528-w4a8-v2-ifb-bw1100-4x-vllm-018) |
 |                                      | INT4 W4A8 | [0.18](../docker_images.md) | BW1000 | 8 | IFB | [**`>_`**](#deepseek-r1-0528-w4a8-v2-ifb-bw1000-8x-vllm-018) |
 | [hygon/DeepSeek-R1-0528-W4A8-V2](https://www.modelscope.cn/models/hygon/DeepSeek-R1-0528-W4A8-V2) | W4A8 | [0.15] | BW1100 | 8 | IFB | [**`>_`**](#deepseek-r1-w4a8-ifb-bw1100-8x-vllm-015) |
 | [hygon/DeepSeek-R1-0528-W4A8-V2](https://www.modelscope.cn/models/hygon/DeepSeek-R1-0528-W4A8-V2) | W4A8 | [0.15] | BW1000 | 8 | IFB | [**`>_`**](#deepseek-r1-w4a8-ifb-bw1000-8x-vllm-015) |


### PR DESCRIPTION
## Summary
- Add vLLM 0.21 IFB entries for `hygon/DeepSeek-R1-0528-W4A8-V2` on BW1100 and BW1000.
- Place the new 0.21 rows in the same `INT4 W4A8` model group as the existing 0.18 rows, with only the first row carrying the model link.
- Mirror the existing `DeepSeek-R1-W4A8-V2_6` vLLM 0.21 command structure with the target model ID.
- Keep BW1000 without `--kv-cache-dtype fp8_e5m2`.

## Validation
- Verified the 0.21 and 0.18 `INT4 W4A8` rows for `hygon/DeepSeek-R1-0528-W4A8-V2` are grouped together with one model-link row.
- Verified table anchors point to the command sections.
- Verified both new command blocks use `hygon/DeepSeek-R1-0528-W4A8-V2` and the new BW1000 vLLM 0.21 block does not include `--kv-cache-dtype fp8_e5m2`.
