### PR TITLE
docs: update R1 Channel INT8 BW1000 vLLM 0.21 to 16x

### DIFF
--- a/docs/model-deployment/vllm/deepseek-r1.md
+++ b/docs/model-deployment/vllm/deepseek-r1.md
@@ -27,7 +27,7 @@ DeepSeek-R1 是 DeepSeek 推出的推理强化模型，面向复杂推理、数�
 |                                                                                                                                             | INT8 W8A8 | [0.18](../docker_images.md) | BW1000 | 4 | IFB | [**`>_`**](#deepseek-r1-distill-llama-70b-quantizedw8a8-ifb-bw1000-4x-vllm-018) |
 |                                                                                                                                             | INT8 W8A8 | [0.18](../docker_images.md) | K100_AI | 8 | IFB | [**`>_`**](#deepseek-r1-distill-llama-70b-quantizedw8a8-ifb-k100ai-8x-vllm-018) |
 | [hygon/DeepSeek-R1-Channel-INT8-w8a8](https://www.modelscope.cn/models/hygon/DeepSeek-R1-Channel-INT8-w8a8) | INT8 W8A8 | 0.21 | BW1100 | 8 | IFB | [**`>_`**](#deepseek-r1-channel-int8-w8a8-ifb-bw1100-8x-vllm-021) |
-|                                                                                                              | INT8 W8A8 | 0.21 | BW1000 | 8 | IFB | [**`>_`**](#deepseek-r1-channel-int8-w8a8-ifb-bw1000-8x-vllm-021) |
+|                                                                                                              | INT8 W8A8 | 0.21 | BW1000 | 16 | IFB | [**`>_`**](#deepseek-r1-channel-int8-w8a8-ifb-bw1000-16x-vllm-021) |
 |                                                                                                              | INT8 W8A8 | [0.18](../docker_images.md) | BW1100 | 8 | IFB | [**`>_`**](#deepseek-r1-channel-int8-w8a8-ifb-bw1100-8x-vllm-018) |
 |                                                                                                              | INT8 W8A8 | [0.18](../docker_images.md) | BW1000 | 16 | IFB | [**`>_`**](#deepseek-r1-channel-int8-w8a8-ifb-bw1000-16x-vllm-018) |
 |                                                                                                              | INT8 W8A8 | [0.15](../docker_images.md) | BW1100 | 8 | IFB | [**`>_`**](#deepseek-r1-channel-int8-w8a8-ifb-bw1100-8x-vllm-015) |
@@ -317,22 +317,48 @@ vllm serve hygon/DeepSeek-R1-Channel-INT8-w8a8 \
   --attention-backend FLASHMLA
 ```
 
-### DeepSeek-R1-Channel-INT8-w8a8 IFB BW1000 8x vLLM 0.21
+### DeepSeek-R1-Channel-INT8-w8a8 IFB BW1000 16x vLLM 0.21
+
+#### Master node
 
 ```bash
 vllm serve hygon/DeepSeek-R1-Channel-INT8-w8a8 \
   --trust-remote-code \
   -q slimquant_marlin \
-  -tp 8 \
+  -tp 16 \
   --dtype bfloat16 \
-  --max-model-len 65536 \
   --gpu-memory-utilization 0.90 \
-  --max-num-batched-tokens 16384 \
-  --speculative_config '{"method": "deepseek_mtp", "num_speculative_tokens": 2,"quantization": "slimquant_marlin"}' \
   --no-enable-prefix-caching \
-  --attention-backend FLASHMLA
+  --max-model-len 65536 \
+  --max-num-seqs 256 \
+  --max-num-batched-tokens 16384 \
+  --speculative_config '{"method": "deepseek_mtp", "num_speculative_tokens": 3,"quantization": "slimquant_marlin"}' \
+  --attention-backend FLASHMLA \
+  --nnodes 2 \
+  --node-rank 0 \
+  --master-addr <master_node_ip>
 ```
 
+#### Worker node
+
+```bash
+vllm serve hygon/DeepSeek-R1-Channel-INT8-w8a8 \
+  --trust-remote-code \
+  -q slimquant_marlin \
+  -tp 16 \
+  --dtype bfloat16 \
+  --gpu-memory-utilization 0.90 \
+  --no-enable-prefix-caching \
+  --max-model-len 65536 \
+  --max-num-seqs 256 \
+  --max-num-batched-tokens 16384 \
+  --speculative_config '{"method": "deepseek_mtp", "num_speculative_tokens": 3,"quantization": "slimquant_marlin"}' \
+  --attention-backend FLASHMLA \
+  --nnodes 2 \
+  --node-rank 1 \
+  --master-addr <master_node_ip> \
+  --headless
+```
 ### DeepSeek-R1-Channel-INT8-w8a8 IFB BW1100 8x vLLM 0.18
 
 ```bash


### PR DESCRIPTION
## Summary
- Update `hygon/DeepSeek-R1-Channel-INT8-w8a8` vLLM 0.21 BW1000 from 8 cards to 16 cards.
- Replace the single-node BW1000 command with master/worker node commands using `-tp 16`, `--nnodes 2`, and node ranks 0/1.

## Validation
- Verified table card count and anchor now use 16x.
- Verified the BW1000 vLLM 0.21 section has exactly two bash blocks for master and worker nodes.
- Verified both blocks use `-tp 16`, `--nnodes 2`, `--attention-backend FLASHMLA`, and the worker block includes `--headless`.
