### PR TITLE
docs: add GLM-4-32B vLLM 0.21.0

### DIFF
--- a/docs/model-deployment/vllm/glm-4.md
+++ b/docs/model-deployment/vllm/glm-4.md
@@ -8,11 +8,40 @@ GLM-4-32B-0414 是智谱 AI 推出的 32B 参数稠密大语言模型，支持�
 
 | 模型权重 | 量化方式 | vLLM 版本 | 推荐硬件 | 卡数 | 部署方式 | 启动命令 |
 | -------- | -------- | --------- | -------- | ---- | -------- | -------- |
-| [ZhipuAI/GLM-4-32B-0414](https://www.modelscope.cn/models/ZhipuAI/GLM-4-32B-0414) | BF16 | [0.18](../docker_images.md)  | BW1100 | 1x | IFB | [**`>_`**](#glm-4-32b-0414-ifb-bw1100-1x-vllm-018) |
+| [ZhipuAI/GLM-4-32B-0414](https://www.modelscope.cn/models/ZhipuAI/GLM-4-32B-0414) | BF16 | [0.21.0](../docker_images.md) | BW1100 | 1x | IFB | [**`>_`**](#glm-4-32b-0414-ifb-bw1100-1x-vllm-0210) |
+|                                                                               | BF16 | 0.21.0 | BW1000 | 2x | IFB | [**`>_`**](#glm-4-32b-0414-ifb-bw1000-2x-vllm-0210) |
+|                                                                               | BF16 | 0.21.0 | K100_AI | 2x | IFB | [**`>_`**](#glm-4-32b-0414-ifb-k100_ai-2x-vllm-0210) |
+|                                                                               | BF16 | [0.18](../docker_images.md)  | BW1100 | 1x | IFB | [**`>_`**](#glm-4-32b-0414-ifb-bw1100-1x-vllm-018) |
 |                                                                               | BF16 | 0.18 | BW1000 | 2x | IFB | [**`>_`**](#glm-4-32b-0414-ifb-bw1000-2x-vllm-018) |
 |                                                                               | BF16 | 0.18 | K100_AI | 2x | IFB | [**`>_`**](#glm-4-32b-0414-ifb-k100_ai-2x-vllm-018) |
 
 ## 启动命令
+
+### GLM-4-32B-0414 IFB BW1100 1x vLLM 0.21.0
+
+```bash
+vllm serve ZhipuAI/GLM-4-32B-0414 \
+  --tensor-parallel-size 1 \
+  --trust-remote-code \
+  --attention-backend FLASH_ATTN_CUTLASS
+```
+
+### GLM-4-32B-0414 IFB BW1000 2x vLLM 0.21.0
+
+```bash
+vllm serve ZhipuAI/GLM-4-32B-0414 \
+  --tensor-parallel-size 2 \
+  --trust-remote-code \
+  --attention-backend FLASH_ATTN_CUTLASS
+```
+
+### GLM-4-32B-0414 IFB K100_AI 2x vLLM 0.21.0
+
+```bash
+vllm serve ZhipuAI/GLM-4-32B-0414 \
+  --tensor-parallel-size 2 \
+  --trust-remote-code
+```
 
 ### GLM-4-32B-0414 IFB BW1100 1x vLLM 0.18
 

--- a/docs/model-deployment/vllm/glm-4.md
+++ b/docs/model-deployment/vllm/glm-4.md
@@ -8,16 +8,16 @@ GLM-4-32B-0414 是智谱 AI 推出的 32B 参数稠密大语言模型，支持�
 
 | 模型权重 | 量化方式 | vLLM 版本 | 推荐硬件 | 卡数 | 部署方式 | 启动命令 |
 | -------- | -------- | --------- | -------- | ---- | -------- | -------- |
-| [ZhipuAI/GLM-4-32B-0414](https://www.modelscope.cn/models/ZhipuAI/GLM-4-32B-0414) | BF16 | [0.21.0](../docker_images.md) | BW1100 | 1x | IFB | [**`>_`**](#glm-4-32b-0414-ifb-bw1100-1x-vllm-0210) |
-|                                                                               | BF16 | 0.21.0 | BW1000 | 2x | IFB | [**`>_`**](#glm-4-32b-0414-ifb-bw1000-2x-vllm-0210) |
-|                                                                               | BF16 | 0.21.0 | K100_AI | 2x | IFB | [**`>_`**](#glm-4-32b-0414-ifb-k100_ai-2x-vllm-0210) |
+| [ZhipuAI/GLM-4-32B-0414](https://www.modelscope.cn/models/ZhipuAI/GLM-4-32B-0414) | BF16 | 0.21 | BW1100 | 1x | IFB | [**`>_`**](#glm-4-32b-0414-ifb-bw1100-1x-vllm-021) |
+|                                                                               | BF16 | 0.21 | BW1000 | 2x | IFB | [**`>_`**](#glm-4-32b-0414-ifb-bw1000-2x-vllm-021) |
+|                                                                               | BF16 | 0.21 | K100_AI | 2x | IFB | [**`>_`**](#glm-4-32b-0414-ifb-k100_ai-2x-vllm-021) |
 |                                                                               | BF16 | [0.18](../docker_images.md)  | BW1100 | 1x | IFB | [**`>_`**](#glm-4-32b-0414-ifb-bw1100-1x-vllm-018) |
 |                                                                               | BF16 | 0.18 | BW1000 | 2x | IFB | [**`>_`**](#glm-4-32b-0414-ifb-bw1000-2x-vllm-018) |
 |                                                                               | BF16 | 0.18 | K100_AI | 2x | IFB | [**`>_`**](#glm-4-32b-0414-ifb-k100_ai-2x-vllm-018) |
 
 ## 启动命令
 
-### GLM-4-32B-0414 IFB BW1100 1x vLLM 0.21.0
+### GLM-4-32B-0414 IFB BW1100 1x vLLM 0.21
 
 ```bash
 vllm serve ZhipuAI/GLM-4-32B-0414 \
@@ -26,7 +26,7 @@ vllm serve ZhipuAI/GLM-4-32B-0414 \
   --attention-backend FLASH_ATTN_CUTLASS
 ```
 
-### GLM-4-32B-0414 IFB BW1000 2x vLLM 0.21.0
+### GLM-4-32B-0414 IFB BW1000 2x vLLM 0.21
 
 ```bash
 vllm serve ZhipuAI/GLM-4-32B-0414 \
@@ -35,7 +35,7 @@ vllm serve ZhipuAI/GLM-4-32B-0414 \
   --attention-backend FLASH_ATTN_CUTLASS
 ```
 
-### GLM-4-32B-0414 IFB K100_AI 2x vLLM 0.21.0
+### GLM-4-32B-0414 IFB K100_AI 2x vLLM 0.21
 
 ```bash
 vllm serve ZhipuAI/GLM-4-32B-0414 \


### PR DESCRIPTION
## Summary
- add ZhipuAI/GLM-4-32B-0414 vLLM 0.21.0 rows for BW1100, BW1000, and K100_AI
- convert the 0.18 FLASH_ATTN env usage to --attention-backend FLASH_ATTN_CUTLASS for the new BW1100/BW1000 0.21.0 commands
- omit VLLM_HCU_USE_CUSTOM_TOPK_TOPP_SAMPLER from the new 0.21.0 commands

## Validation
- verified table rows, anchors, model grouping, tensor parallel sizes, and command parameters locally
