### PR TITLE
docs: add GLM-5.1 FP8 vLLM 0.21 BW1100

### DIFF
--- a/docs/model-deployment/vllm/glm-5.1.md
+++ b/docs/model-deployment/vllm/glm-5.1.md
@@ -163,7 +163,6 @@ vllm serve hygon/GLM-5.1-Channel-FP8-w8a8 \
     "quantization":"slimquant_marlin"
   }' \
   --kv-cache-dtype fp8_ds_mla \
-  --no-async-scheduling \
   --attention-backend FLASHMLA_SPARSE
 ```
 
@@ -253,7 +252,6 @@ vllm serve hygon/GLM-5.1-Channel-INT8-w8a8 \
     "quantization":"slimquant_marlin"
   }' \
   --kv-cache-dtype fp8_ds_mla \
-  --no-async-scheduling \
   --attention-backend FLASHMLA_SPARSE
 ```
 
@@ -770,3 +768,4 @@ curl http://13.13.3.21:9351/v1/chat/completions \
   "max_tokens": 128
   }'
 ```
+

--- a/docs/model-deployment/vllm/glm-5.1.md
+++ b/docs/model-deployment/vllm/glm-5.1.md
@@ -11,7 +11,8 @@ GLM-5.1 是智谱 AI 推出的新一代大语言模型，在中文理解、长�
 | [hygon/GLM-5.1-Channel-INT4-w4a8](https://www.modelscope.cn/models/hygon/GLM-5.1-Channel-INT4-w4a8) | INT4 W4A8 | 0.18 | BW1100 | 8 | IFB | [**`>_`**](#glm-51-channel-int4-w4a8-ifb-bw1100-8x-vllm-018) |
 |  | INT4 W4A8 | 0.18 | BW1000 | 16 | PP2+TP8 | [**`>_`**](#glm-51-channel-int4-w4a8-pp2tp8-bw1000-16x-vllm-018) |
 |  | INT4 W4A8 | 0.15| BW1100 | 8 | IFB | [**`>_`**](#glm-51-channel-int4-w4a8-ifb-bw1100-8x-vllm-015) |
-| [hygon/GLM-5.1-Channel-FP8-w8a8](https://www.modelscope.cn/models/hygon/GLM-5.1-Channel-FP8-w8a8) | FP8 W8A8 | [0.18](../docker_images.md) | BW1100 | 8 | IFB | [**`>_`**](#glm-51-channel-fp8-w8a8-ifb-bw1100-8x-vllm-018) |
+| [hygon/GLM-5.1-Channel-FP8-w8a8](https://www.modelscope.cn/models/hygon/GLM-5.1-Channel-FP8-w8a8) | FP8 W8A8 | 0.21 | BW1100 | 8 | IFB | [**`>_`**](#glm-51-channel-fp8-w8a8-ifb-bw1100-8x-vllm-021) |
+|  | FP8 W8A8 | [0.18](../docker_images.md) | BW1100 | 8 | IFB | [**`>_`**](#glm-51-channel-fp8-w8a8-ifb-bw1100-8x-vllm-018) |
 |  | FP8 W8A8 | 0.15| BW1100 | 8 | IFB | [**`>_`**](#glm-51-channel-fp8-w8a8-ifb-bw1100-8x-vllm-015) |
 | [hygon/GLM-5.1-Channel-INT8-w8a8](https://www.modelscope.cn/models/hygon/GLM-5.1-Channel-INT8-w8a8) | INT8 W8A8 | [0.18](../docker_images.md) | BW1100 | 8 | IFB | [**`>_`**](#glm-51-channel-int8-w8a8-ifb-bw1100-8x-vllm-018) |
 |  | INT8 W8A8 | 0.18 | BW1100 | 24 | 1P2D | [**`>_`**](#glm-51-channel-int8-w8a8-1p2d-bw1100-24x-vllm-018) |
@@ -138,6 +139,31 @@ vllm serve hygon/GLM-5.1-Channel-INT4-w4a8 \
   --kv-cache-dtype fp8_ds_mla \
   -cc '{"pass_config": {"fuse_act_quant": false}}' \
   --speculative_config '{"method": "mtp", "num_speculative_tokens": 2, "quantization": "slimquant_w4a8_marlin"}'
+```
+
+### GLM-5.1-Channel-FP8-w8a8 IFB BW1100 8x vLLM 0.21
+
+```bash
+export LMSLIM_USE_GLOBAL_MOE_CACHE=1
+
+vllm serve hygon/GLM-5.1-Channel-FP8-w8a8 \
+  -q slimquant_marlin \
+  --trust-remote-code \
+  --dtype bfloat16 \
+  --max-model-len 65536 \
+  --max-num-batched-tokens 8192 \
+  -tp 8 \
+  --gpu-memory-utilization 0.9 \
+  --max-num-seqs 64 \
+  --block-size 64 \
+  --speculative_config '{
+    "method":"deepseek_mtp",
+    "num_speculative_tokens":3,
+    "quantization":"slimquant_marlin"
+  }' \
+  --kv-cache-dtype fp8_ds_mla \
+  --no-async-scheduling \
+  --attention-backend FLASHMLA_SPARSE
 ```
 
 ### GLM-5.1-Channel-FP8-w8a8 IFB BW1100 8x vLLM 0.18

--- a/docs/model-deployment/vllm/glm-5.1.md
+++ b/docs/model-deployment/vllm/glm-5.1.md
@@ -8,7 +8,9 @@ GLM-5.1 是智谱 AI 推出的新一代大语言模型，在中文理解、长�
 
 | 模型权重 | 量化方式 | vLLM 版本 | 推荐硬件 | 卡数 | 部署方式 | 启动命令 |
 | -------- | -------- | --------- | -------- | ---- | -------- | -------- |
-| [hygon/GLM-5.1-Channel-INT4-w4a8](https://www.modelscope.cn/models/hygon/GLM-5.1-Channel-INT4-w4a8) | INT4 W4A8 | 0.18 | BW1100 | 8 | IFB | [**`>_`**](#glm-51-channel-int4-w4a8-ifb-bw1100-8x-vllm-018) |
+| [hygon/GLM-5.1-Channel-INT4-w4a8](https://www.modelscope.cn/models/hygon/GLM-5.1-Channel-INT4-w4a8) | INT4 W4A8 | 0.21 | BW1100 | 8 | IFB | [**`>_`**](#glm-51-channel-int4-w4a8-ifb-bw1100-8x-vllm-021) |
+|  | INT4 W4A8 | 0.21 | BW1000 | 8 | IFB | [**`>_`**](#glm-51-channel-int4-w4a8-ifb-bw1000-8x-vllm-021) |
+|  | INT4 W4A8 | 0.18 | BW1100 | 8 | IFB | [**`>_`**](#glm-51-channel-int4-w4a8-ifb-bw1100-8x-vllm-018) |
 |  | INT4 W4A8 | 0.18 | BW1000 | 16 | PP2+TP8 | [**`>_`**](#glm-51-channel-int4-w4a8-pp2tp8-bw1000-16x-vllm-018) |
 |  | INT4 W4A8 | 0.15| BW1100 | 8 | IFB | [**`>_`**](#glm-51-channel-int4-w4a8-ifb-bw1100-8x-vllm-015) |
 | [hygon/GLM-5.1-Channel-FP8-w8a8](https://www.modelscope.cn/models/hygon/GLM-5.1-Channel-FP8-w8a8) | FP8 W8A8 | 0.21 | BW1100 | 8 | IFB | [**`>_`**](#glm-51-channel-fp8-w8a8-ifb-bw1100-8x-vllm-021) |
@@ -22,6 +24,50 @@ GLM-5.1 是智谱 AI 推出的新一代大语言模型，在中文理解、长�
 |  | INT8 W8A8 | 0.15 | BW1100 | 24 | 1P2D | [**`>_`**](#glm-51-channel-int8-w8a8-1p2d-bw1100-24x-vllm-015) |
 
 ## 启动命令
+
+### GLM-5.1-Channel-INT4-w4a8 IFB BW1100 8x vLLM 0.21
+
+```bash
+export LMSLIM_USE_GLOBAL_MOE_CACHE=1
+
+vllm serve hygon/GLM-5.1-Channel-INT4-w4a8 \
+  --trust-remote-code \
+  --dtype bfloat16 \
+  --max-model-len 65536 \
+  --max-num-batched-tokens 8192 \
+  -tp 8 \
+  --gpu-memory-utilization 0.92 \
+  --max-num-seqs 64 \
+  --block-size 64 \
+  --speculative_config '{
+    "method":"deepseek_mtp",
+    "num_speculative_tokens":2
+  }' \
+  --kv-cache-dtype fp8_ds_mla \
+  --attention-backend FLASHMLA_SPARSE
+```
+
+### GLM-5.1-Channel-INT4-w4a8 IFB BW1000 8x vLLM 0.21
+
+```bash
+export LMSLIM_USE_GLOBAL_MOE_CACHE=1
+
+vllm serve hygon/GLM-5.1-Channel-INT4-w4a8 \
+  --trust-remote-code \
+  --dtype bfloat16 \
+  --max-model-len 65536 \
+  --max-num-batched-tokens 8192 \
+  -tp 8 \
+  --gpu-memory-utilization 0.92 \
+  --max-num-seqs 64 \
+  --block-size 64 \
+  --speculative_config '{
+    "method":"deepseek_mtp",
+    "num_speculative_tokens":2
+  }' \
+  --kv-cache-dtype fp8_ds_mla \
+  --attention-backend FLASHMLA_SPARSE
+```
 
 ### GLM-5.1-Channel-INT4-w4a8 IFB BW1100 8x vLLM 0.18
 
@@ -768,4 +814,5 @@ curl http://13.13.3.21:9351/v1/chat/completions \
   "max_tokens": 128
   }'
 ```
+
 

--- a/docs/model-deployment/vllm/glm-5.1.md
+++ b/docs/model-deployment/vllm/glm-5.1.md
@@ -14,7 +14,8 @@ GLM-5.1 是智谱 AI 推出的新一代大语言模型，在中文理解、长�
 | [hygon/GLM-5.1-Channel-FP8-w8a8](https://www.modelscope.cn/models/hygon/GLM-5.1-Channel-FP8-w8a8) | FP8 W8A8 | 0.21 | BW1100 | 8 | IFB | [**`>_`**](#glm-51-channel-fp8-w8a8-ifb-bw1100-8x-vllm-021) |
 |  | FP8 W8A8 | [0.18](../docker_images.md) | BW1100 | 8 | IFB | [**`>_`**](#glm-51-channel-fp8-w8a8-ifb-bw1100-8x-vllm-018) |
 |  | FP8 W8A8 | 0.15| BW1100 | 8 | IFB | [**`>_`**](#glm-51-channel-fp8-w8a8-ifb-bw1100-8x-vllm-015) |
-| [hygon/GLM-5.1-Channel-INT8-w8a8](https://www.modelscope.cn/models/hygon/GLM-5.1-Channel-INT8-w8a8) | INT8 W8A8 | [0.18](../docker_images.md) | BW1100 | 8 | IFB | [**`>_`**](#glm-51-channel-int8-w8a8-ifb-bw1100-8x-vllm-018) |
+| [hygon/GLM-5.1-Channel-INT8-w8a8](https://www.modelscope.cn/models/hygon/GLM-5.1-Channel-INT8-w8a8) | INT8 W8A8 | 0.21 | BW1100 | 8 | IFB | [**`>_`**](#glm-51-channel-int8-w8a8-ifb-bw1100-8x-vllm-021) |
+|  | INT8 W8A8 | [0.18](../docker_images.md) | BW1100 | 8 | IFB | [**`>_`**](#glm-51-channel-int8-w8a8-ifb-bw1100-8x-vllm-018) |
 |  | INT8 W8A8 | 0.18 | BW1100 | 24 | 1P2D | [**`>_`**](#glm-51-channel-int8-w8a8-1p2d-bw1100-24x-vllm-018) |
 |  | INT8 W8A8 | 0.18 | BW1000 | 16 | IFB | [**`>_`**](#glm-51-channel-int8-w8a8-ifb-bw1000-16x-vllm-018) |
 |  | INT8 W8A8 | 0.15 | BW1100 | 8 | IFB | [**`>_`**](#glm-51-channel-int8-w8a8-ifb-bw1100-8x-vllm-015) |
@@ -229,6 +230,31 @@ vllm serve hygon/GLM-5.1-Channel-FP8-w8a8 \
   --kv-cache-dtype fp8_ds_mla \
   -cc '{"pass_config": {"fuse_act_quant": false}}' \
   --speculative_config '{"method": "mtp", "num_speculative_tokens": 2, "quantization": "slimquant_marlin"}'
+```
+
+### GLM-5.1-Channel-INT8-w8a8 IFB BW1100 8x vLLM 0.21
+
+```bash
+export LMSLIM_USE_GLOBAL_MOE_CACHE=1
+
+vllm serve hygon/GLM-5.1-Channel-INT8-w8a8 \
+  -q slimquant_marlin \
+  --trust-remote-code \
+  --dtype bfloat16 \
+  --max-model-len 65536 \
+  --max-num-batched-tokens 8192 \
+  -tp 8 \
+  --gpu-memory-utilization 0.9 \
+  --max-num-seqs 64 \
+  --block-size 64 \
+  --speculative_config '{
+    "method":"deepseek_mtp",
+    "num_speculative_tokens":3,
+    "quantization":"slimquant_marlin"
+  }' \
+  --kv-cache-dtype fp8_ds_mla \
+  --no-async-scheduling \
+  --attention-backend FLASHMLA_SPARSE
 ```
 
 ### GLM-5.1-Channel-INT8-w8a8 IFB BW1100 8x vLLM 0.18


### PR DESCRIPTION
## Summary
- add hygon/GLM-5.1-Channel-FP8-w8a8 vLLM 0.21 BW1100 8-card IFB entry
- add the provided vLLM serve command with LMSLIM MoE cache, deepseek_mtp speculative config, fp8_ds_mla KV cache, and FLASHMLA_SPARSE attention backend

## Validation
- verified table row, grouped FP8 rows, anchor, command block, model ID, card count, and required parameters locally
