### PR TITLE
docs: move GLM-4.7 K100_AI command to hygon INT8

### DIFF
--- a/docs/model-deployment/vllm/glm4.7.md
+++ b/docs/model-deployment/vllm/glm4.7.md
@@ -10,9 +10,7 @@ GLM-4.7 是智谱 AI 推出的大语言模型，支持长上下文和高效推�
 | -------- | -------- | --------- | -------- | ---- | -------- | -------- |
 | [GLM-4.7-Channel-INT8-w8a8](https://www.modelscope.cn/models/hygon/GLM-4.7-Channel-INT8-w8a8) | INT8 W8A8 | 0.18 | BW1100 | 8 | IFB | [**``>_``**](#glm-47-channel-int8-w8a8-ifb-bw1100-8x-vllm-018) |
 |                                                                               | INT8 W8A8 | 0.18 | BW1000 | 8 | IFB | [**``>_``**](#glm-47-channel-int8-w8a8-ifb-bw1000-8x-vllm-018) |
-| [metax-tech/GLM-4.7-W8A8](https://www.modelscope.cn/models/metax-tech/GLM-4.7-W8A8) | INT8 W8A8 | [0.18](../docker_images.md) | BW1100 | 8 | IFB | [**`>_`**](#glm-47-w8a8-ifb-bw1100-8x-vllm-018) |
-|  | INT8 W8A8 | [0.18](../docker_images.md) | BW1000 | 8 | IFB | [**`>_`**](#glm-47-w8a8-ifb-bw1000-8x-vllm-018) |
-|  | INT8 W8A8 | [0.18](../docker_images.md) | K100_AI | 8 | IFB | [**`>_`**](#glm-47-w8a8-ifb-k100_ai-8x-vllm-018) |
+|                                                                               | INT8 W8A8 | 0.18 | K100_AI | 8 | IFB | [**``>_``**](#glm-47-channel-int8-w8a8-ifb-k100_ai-8x-vllm-018) |
 
 ## 启动命令
 
@@ -54,55 +52,14 @@ vllm serve hygon/GLM-4.7-Channel-INT8-w8a8 \
   --compilation-config.cudagraph_mode PIECEWISE
 ```
 
-### GLM-4.7-W8A8 IFB BW1100 8x vLLM 0.18
+### GLM-4.7-Channel-INT8-w8a8 IFB K100_AI 8x vLLM 0.18
 
 ```bash
 export VLLM_USE_MODELSCOPE=1
-export VLLM_HCU_USE_CUSTOM_FLASH_ATTN=1
-
-vllm serve metax-tech/GLM-4.7-W8A8 \
-  -tp 8 \
-  -q slimquant_marlin \
-  --trust-remote-code \
-  --dtype bfloat16 \
-  --disable-cascade-attn \
-  --max-model-len 74000 \
-  --max-num-batched-tokens 8192 \
-  --speculative-config.method mtp \
-  --speculative-config.num_speculative_tokens 2 \
-  --speculative-config.quantization slimquant_marlin \
-  --compilation-config.cudagraph_mode PIECEWISE
-```
-
-### GLM-4.7-W8A8 IFB BW1000 8x vLLM 0.18
-
-```bash
-export VLLM_USE_MODELSCOPE=1
-export VLLM_HCU_USE_CUSTOM_FLASH_ATTN=1
-
-vllm serve metax-tech/GLM-4.7-W8A8 \
-  -tp 8 \
-  -q slimquant_marlin \
-  --trust-remote-code \
-  --dtype bfloat16 \
-  --disable-cascade-attn \
-  --max-model-len 74000 \
-  --max-num-batched-tokens 8192 \
-  --speculative-config.method mtp \
-  --speculative-config.num_speculative_tokens 2 \
-  --speculative-config.quantization slimquant_marlin \
-  --compilation-config.cudagraph_mode PIECEWISE
-```
-
-### GLM-4.7-W8A8 IFB K100_AI 8x vLLM 0.18
-
-```bash
-export VLLM_USE_MODELSCOPE=1
-export VLLM_HCU_USE_CUSTOM_FLASH_ATTN=1
 export VLLM_HCU_USE_CUSTOM_QUANTIZATION_GEMM=0
 export VLLM_HCU_USE_CUSTOM_OPS=0
 
-vllm serve metax-tech/GLM-4.7-W8A8 \
+vllm serve hygon/GLM-4.7-Channel-INT8-w8a8 \
   -tp 8 \
   -q slimquant_marlin \
   --trust-remote-code \
@@ -148,3 +105,4 @@ curl http://localhost:8000/v1/chat/completions \
   "max_tokens": 128
   }'
 ```
+


### PR DESCRIPTION
## Summary
- move the K100_AI vLLM 0.18 command from metax-tech/GLM-4.7-W8A8 to the hygon GLM-4.7 Channel INT8 section
- update the served model ID to hygon/GLM-4.7-Channel-INT8-w8a8
- remove the metax-tech GLM-4.7-W8A8 section

## Validation
- verified metax-tech references are removed
- verified K100_AI command keeps required K100_AI env vars and drops VLLM_HCU_USE_CUSTOM_FLASH_ATTN