### PR TITLE
docs: add GLM-4.7 W8A8 vLLM 0.21

### DIFF
--- a/docs/model-deployment/vllm/glm4.7.md
+++ b/docs/model-deployment/vllm/glm4.7.md
@@ -8,11 +8,72 @@ GLM-4.7 是智谱 AI 推出的大语言模型，支持长上下文和高效推�
 
 | 模型权重 | 量化方式 | vLLM 版本 | 推荐硬件 | 卡数 | 部署方式 | 启动命令 |
 | -------- | -------- | --------- | -------- | ---- | -------- | -------- |
-| [GLM-4.7-Channel-INT8-w8a8](https://www.modelscope.cn/models/hygon/GLM-4.7-Channel-INT8-w8a8) | INT8 W8A8 | 0.18 | BW1100 | 8 | IFB | [**``>_``**](#glm-47-channel-int8-w8a8-ifb-bw1100-8x-vllm-018) |
+| [GLM-4.7-Channel-INT8-w8a8](https://www.modelscope.cn/models/hygon/GLM-4.7-Channel-INT8-w8a8) | INT8 W8A8 | 0.21 | BW1100 | 8 | IFB | [**``>_``**](#glm-47-channel-int8-w8a8-ifb-bw1100-8x-vllm-021) |
+|                                                                               | INT8 W8A8 | 0.21 | BW1000 | 8 | IFB | [**``>_``**](#glm-47-channel-int8-w8a8-ifb-bw1000-8x-vllm-021) |
+|                                                                               | INT8 W8A8 | 0.21 | K100_AI | 8 | IFB | [**``>_``**](#glm-47-channel-int8-w8a8-ifb-k100_ai-8x-vllm-021) |
+|                                                                               | INT8 W8A8 | 0.18 | BW1100 | 8 | IFB | [**``>_``**](#glm-47-channel-int8-w8a8-ifb-bw1100-8x-vllm-018) |
 |                                                                               | INT8 W8A8 | 0.18 | BW1000 | 8 | IFB | [**``>_``**](#glm-47-channel-int8-w8a8-ifb-bw1000-8x-vllm-018) |
 |                                                                               | INT8 W8A8 | 0.18 | K100_AI | 8 | IFB | [**``>_``**](#glm-47-channel-int8-w8a8-ifb-k100_ai-8x-vllm-018) |
 
 ## 启动命令
+
+### GLM-4.7-Channel-INT8-w8a8 IFB BW1100 8x vLLM 0.21
+
+```bash
+export VLLM_USE_MODELSCOPE=1
+
+vllm serve hygon/GLM-4.7-Channel-INT8-w8a8 \
+  -tp 8 \
+  -q slimquant_marlin \
+  --dtype bfloat16 \
+  --disable-cascade-attn \
+  --max-model-len 74000 \
+  --max-num-batched-tokens 8192 \
+  --speculative-config.method mtp \
+  --speculative-config.num_speculative_tokens 2 \
+  --speculative-config.quantization slimquant_marlin \
+  --compilation-config.cudagraph_mode PIECEWISE \
+  --attention-backend FLASH_ATTN_CUSTOM
+```
+
+### GLM-4.7-Channel-INT8-w8a8 IFB BW1000 8x vLLM 0.21
+
+```bash
+export VLLM_USE_MODELSCOPE=1
+
+vllm serve hygon/GLM-4.7-Channel-INT8-w8a8 \
+  -tp 8 \
+  -q slimquant_marlin \
+  --dtype bfloat16 \
+  --disable-cascade-attn \
+  --max-model-len 74000 \
+  --max-num-batched-tokens 8192 \
+  --speculative-config.method mtp \
+  --speculative-config.num_speculative_tokens 2 \
+  --speculative-config.quantization slimquant_marlin \
+  --compilation-config.cudagraph_mode PIECEWISE \
+  --attention-backend FLASH_ATTN_CUSTOM
+```
+
+### GLM-4.7-Channel-INT8-w8a8 IFB K100_AI 8x vLLM 0.21
+
+```bash
+export VLLM_USE_MODELSCOPE=1
+export VLLM_HCU_USE_CUSTOM_QUANTIZATION_GEMM=0
+export VLLM_HCU_USE_CUSTOM_OPS=0
+
+vllm serve hygon/GLM-4.7-Channel-INT8-w8a8 \
+  -tp 8 \
+  -q slimquant_marlin \
+  --trust-remote-code \
+  --dtype bfloat16 \
+  --disable-cascade-attn \
+  --max-model-len 74000 \
+  --max-num-batched-tokens 8192 \
+  --speculative-config.method mtp \
+  --speculative-config.num_speculative_tokens 2 \
+  --compilation-config.cudagraph_mode PIECEWISE
+```
 
 ### GLM-4.7-Channel-INT8-w8a8 IFB BW1100 8x vLLM 0.18
 
@@ -105,4 +166,5 @@ curl http://localhost:8000/v1/chat/completions \
   "max_tokens": 128
   }'
 ```
+
 


### PR DESCRIPTION
## Summary
- add GLM-4.7 W8A8 vLLM 0.21 deployment entries for BW1100, BW1000, and K100_AI
- derive commands from vLLM 0.18 examples
- replace VLLM_HCU_USE_CUSTOM_FLASH_ATTN env with --attention-backend FLASH_ATTN_CUSTOM for 0.21 commands

## Validation
- verified new table rows and command blocks locally
- verified existing vLLM 0.18 entries remain present