### PR TITLE
docs: add Kimi-K2.5 vLLM 0.21 BW1000

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,7 +288,7 @@
     <tr>
       <td rowspan="2">Kimi-K2.5</td>
       <td>vLLM</td>
-      <td align="center">-</td><td align="center">-</td><td align="center"><a href="docs/model-deployment/vllm/kimi-k2.5.md">✅</a></td>
+      <td align="center">-</td><td align="center"><a href="docs/model-deployment/vllm/kimi-k2.5.md">✅</a></td><td align="center"><a href="docs/model-deployment/vllm/kimi-k2.5.md">✅</a></td>
     </tr>
     <tr>
       <td>SGLang</td>
@@ -445,3 +445,4 @@
 ## 🤝 贡献
 
 欢迎提交 Issue 和 PR！详见 [CONTRIBUTING.md](CONTRIBUTING.md)。
+

--- a/docs/model-deployment/vllm/kimi-k2.5.md
+++ b/docs/model-deployment/vllm/kimi-k2.5.md
@@ -9,6 +9,7 @@ Kimi-K2.5 是月之暗面（Moonshot AI）推出的新一代大语言模型，�
 | 模型权重 | 量化方式 | vLLM 版本 | 推荐硬件 | 卡数 | 部署方式 | 启动命令 |
 | -------- | -------- | --------- | -------- | ---- | -------- | -------- |
 | [moonshotai/Kimi-K2.5](https://www.modelscope.cn/models/moonshotai/Kimi-K2.5) | INT4 W4A16 | 0.21 | BW1100 | 8 | IFB | [**`>_`**](#kimi-k25-ifb-bw1100-8x-vllm-021) |
+| [moonshotai/Kimi-K2.5](https://www.modelscope.cn/models/moonshotai/Kimi-K2.5) | INT4 W4A16 | 0.21 | BW1000 | 8 | IFB | [**`>_`**](#kimi-k25-ifb-bw1000-8x-vllm-021) |
 | [moonshotai/Kimi-K2.5](https://www.modelscope.cn/models/moonshotai/Kimi-K2.5) | INT4 W4A16 | 0.18 | BW1100 | 8 | IFB | [**`>_`**](#kimi-k25-ifb-bw1100-8x-vllm-015) |
 | [moonshotai/Kimi-K2.5](https://www.modelscope.cn/models/moonshotai/Kimi-K2.5) | INT4 W4A16 | 0.15 | BW1100 | 8 | IFB | [**`>_`**](#kimi-k25-ifb-bw1100-8x-vllm-015) |
 
@@ -27,6 +28,20 @@ vllm serve moonshotai/Kimi-K2.5 \
     --max-num-batched-tokens 16384 \
     --kv-cache-dtype fp8_e4m3 \
     --moe-backend aiter
+```
+
+### Kimi-K2.5 IFB BW1000 8x vLLM 0.21
+
+```bash
+vllm serve moonshotai/Kimi-K2.5 \
+  -tp 8 \
+  --trust-remote-code \
+  --dtype bfloat16 \
+  --max-model-len 65536 \
+  --enable-prefix-caching \
+  --gpu-memory-utilization 0.90 \
+  --max-num-batched-tokens 16384 \
+  --moe-backend aiter
 ```
 
 ### Kimi-K2.5 IFB BW1100 8x vLLM 0.18
@@ -92,3 +107,4 @@ curl http://localhost:8000/v1/chat/completions \
       "max_tokens": 400
   }'
 ```
+


### PR DESCRIPTION
## Summary
- add moonshotai/Kimi-K2.5 vLLM 0.21 BW1000 8-card IFB command
- update README support matrix for vLLM BW1000

## Validation
- checked generated Kimi-K2.5 BW1000 command keeps user-provided parameters and does not add --kv-cache-dtype