### PR TITLE
docs: fix Qwen2-VL-2B version ordering

### DIFF
--- a/docs/model-deployment/vllm/qwen2-vl.md
+++ b/docs/model-deployment/vllm/qwen2-vl.md
@@ -9,13 +9,13 @@ Qwen2-VL 是阿里通义千问视觉语言模型系列，支持图像、视频�
 | 模型权重 | 量化方式 | vLLM 版本 | 推荐硬件 | 卡数 | 部署方式 | 启动命令 |
 | -------- | -------- | --------- | -------- | ---- | -------- | -------- |
 | [Qwen/Qwen2-VL-2B](https://www.modelscope.cn/models/Qwen/Qwen2-VL-2B) | BF16 | 0.21 | BW1100 | 1 | IFB | [**`>_`**](#qwen2-vl-2b-ifb-bw1100-1x-vllm-021) |
-|  | BF16 | 0.18 | BW1100 | 1 | IFB | [**`>_`**](#qwen2-vl-2b-ifb-bw1100-1x-vllm-018) |
-|  | BF16 | 0.18-hotfix | BW1100 | 1 | IFB | [**`>_`**](#qwen2-vl-2b-ifb-bw1100-1x-vllm-018-hotfix) |
 |  | BF16 | 0.21 | BW1000 | 1 | IFB | [**`>_`**](#qwen2-vl-2b-ifb-bw1000-1x-vllm-021) |
-|                                                                               | BF16 | 0.18 | BW1000 | 1 | IFB | [**`>_`**](#qwen2-vl-2b-ifb-bw1000-1x-vllm-018) |
-|  | BF16 | 0.18-hotfix | BW1000 | 1 | IFB | [**`>_`**](#qwen2-vl-2b-ifb-bw1000-1x-vllm-018-hotfix) |
 |  | BF16 | 0.21 | K100_AI | 1 | IFB | [**`>_`**](#qwen2-vl-2b-ifb-k100_ai-1x-vllm-021) |
-|                                                                               | BF16 | 0.18 | K100_AI | 1 | IFB | [**`>_`**](#qwen2-vl-2b-ifb-k100_ai-1x-vllm-018) |
+|  | BF16 | 0.18 | BW1100 | 1 | IFB | [**`>_`**](#qwen2-vl-2b-ifb-bw1100-1x-vllm-018) |
+|  | BF16 | 0.18 | BW1000 | 1 | IFB | [**`>_`**](#qwen2-vl-2b-ifb-bw1000-1x-vllm-018) |
+|  | BF16 | 0.18 | K100_AI | 1 | IFB | [**`>_`**](#qwen2-vl-2b-ifb-k100_ai-1x-vllm-018) |
+|  | BF16 | 0.18-hotfix | BW1100 | 1 | IFB | [**`>_`**](#qwen2-vl-2b-ifb-bw1100-1x-vllm-018-hotfix) |
+|  | BF16 | 0.18-hotfix | BW1000 | 1 | IFB | [**`>_`**](#qwen2-vl-2b-ifb-bw1000-1x-vllm-018-hotfix) |
 |  | BF16 | 0.18-hotfix | K100_AI | 1 | IFB | [**`>_`**](#qwen2-vl-2b-ifb-k100_ai-1x-vllm-018-hotfix) |
 
 ## 启动命令
@@ -35,66 +35,8 @@ vllm serve Qwen/Qwen2-VL-2B \
     --kv-cache-dtype fp8_e4m3 \
     --attention-backend FLASH_ATTN_CUSTOM
 ```
-### Qwen2-VL-2B IFB BW1100 1x vLLM 0.18
 
-```bash
-export VLLM_HCU_USE_CUSTOM_FLASH_ATTN=1
-export VLLM_HCU_USE_CUSTOM_TOPK_TOPP_SAMPLER=1
-
-vllm serve Qwen/Qwen2-VL-2B \
-    -tp 1 \
-    --trust-remote-code \
-    --gpu-memory-utilization 0.95 \
-    --chat-template-content-format openai \
-    --chat-template qwen2_vl_openai_chat_template.jinja \
-    --allowed-local-media-path /path-to/VL_data/
-```
-
-### Qwen2-VL-2B IFB BW1100 1x vLLM 0.18-hotfix
-
-```bash
-export VLLM_HCU_USE_PD_SPLIT=1
-
-vllm serve Qwen/Qwen2-VL-2B \
-    -tp 1 \
-    --trust-remote-code \
-    --gpu-memory-utilization 0.95 \
-    --chat-template-content-format openai \
-    --chat-template qwen2_vl_openai_chat_template.jinja \
-    --allowed-local-media-path /path-to/VL_data/ \
-    --kv-cache-dtype fp8_e4m3 \
-    --attention-backend FLASH_ATTN_CUSTOM
-```
 ### Qwen2-VL-2B IFB BW1000 1x vLLM 0.21
-
-```bash
-export VLLM_HCU_USE_PD_SPLIT=1
-
-vllm serve Qwen/Qwen2-VL-2B \
-    -tp 1 \
-    --trust-remote-code \
-    --gpu-memory-utilization 0.95 \
-    --chat-template-content-format openai \
-    --chat-template qwen2_vl_openai_chat_template.jinja \
-    --allowed-local-media-path /path-to/VL_data/ \
-    --attention-backend FLASH_ATTN_CUSTOM
-```
-### Qwen2-VL-2B IFB BW1000 1x vLLM 0.18
-
-```bash
-export VLLM_HCU_USE_CUSTOM_FLASH_ATTN=1
-export VLLM_HCU_USE_CUSTOM_TOPK_TOPP_SAMPLER=1
-
-vllm serve Qwen/Qwen2-VL-2B \
-    -tp 1 \
-    --trust-remote-code \
-    --gpu-memory-utilization 0.95 \
-    --chat-template-content-format openai \
-    --chat-template qwen2_vl_openai_chat_template.jinja \
-    --allowed-local-media-path /path-to/VL_data/
-```
-
-### Qwen2-VL-2B IFB BW1000 1x vLLM 0.18-hotfix
 
 ```bash
 export VLLM_HCU_USE_PD_SPLIT=1
@@ -122,6 +64,34 @@ vllm serve Qwen/Qwen2-VL-2B \
     --chat-template qwen2_vl_openai_chat_template.jinja \
     --allowed-local-media-path /path-to/VL_data/
 ```
+### Qwen2-VL-2B IFB BW1100 1x vLLM 0.18
+
+```bash
+export VLLM_HCU_USE_CUSTOM_FLASH_ATTN=1
+export VLLM_HCU_USE_CUSTOM_TOPK_TOPP_SAMPLER=1
+
+vllm serve Qwen/Qwen2-VL-2B \
+    -tp 1 \
+    --trust-remote-code \
+    --gpu-memory-utilization 0.95 \
+    --chat-template-content-format openai \
+    --chat-template qwen2_vl_openai_chat_template.jinja \
+    --allowed-local-media-path /path-to/VL_data/
+```
+### Qwen2-VL-2B IFB BW1000 1x vLLM 0.18
+
+```bash
+export VLLM_HCU_USE_CUSTOM_FLASH_ATTN=1
+export VLLM_HCU_USE_CUSTOM_TOPK_TOPP_SAMPLER=1
+
+vllm serve Qwen/Qwen2-VL-2B \
+    -tp 1 \
+    --trust-remote-code \
+    --gpu-memory-utilization 0.95 \
+    --chat-template-content-format openai \
+    --chat-template qwen2_vl_openai_chat_template.jinja \
+    --allowed-local-media-path /path-to/VL_data/
+```
 ### Qwen2-VL-2B IFB K100_AI 1x vLLM 0.18
 
 ```bash
@@ -137,6 +107,35 @@ vllm serve Qwen/Qwen2-VL-2B \
     --allowed-local-media-path /path-to/VL_data/
 ```
 
+### Qwen2-VL-2B IFB BW1100 1x vLLM 0.18-hotfix
+
+```bash
+export VLLM_HCU_USE_PD_SPLIT=1
+
+vllm serve Qwen/Qwen2-VL-2B \
+    -tp 1 \
+    --trust-remote-code \
+    --gpu-memory-utilization 0.95 \
+    --chat-template-content-format openai \
+    --chat-template qwen2_vl_openai_chat_template.jinja \
+    --allowed-local-media-path /path-to/VL_data/ \
+    --kv-cache-dtype fp8_e4m3 \
+    --attention-backend FLASH_ATTN_CUSTOM
+```
+### Qwen2-VL-2B IFB BW1000 1x vLLM 0.18-hotfix
+
+```bash
+export VLLM_HCU_USE_PD_SPLIT=1
+
+vllm serve Qwen/Qwen2-VL-2B \
+    -tp 1 \
+    --trust-remote-code \
+    --gpu-memory-utilization 0.95 \
+    --chat-template-content-format openai \
+    --chat-template qwen2_vl_openai_chat_template.jinja \
+    --allowed-local-media-path /path-to/VL_data/ \
+    --attention-backend FLASH_ATTN_CUSTOM
+```
 ### Qwen2-VL-2B IFB K100_AI 1x vLLM 0.18-hotfix
 
 ```bash
@@ -211,3 +210,4 @@ curl http://localhost:8000/v1/chat/completions \
 ### PD 分离
 
 暂无。
+

--- a/docs/model-deployment/vllm/qwen2-vl.md
+++ b/docs/model-deployment/vllm/qwen2-vl.md
@@ -23,15 +23,12 @@ Qwen2-VL 是阿里通义千问视觉语言模型系列，支持图像、视频�
 ### Qwen2-VL-2B IFB BW1100 1x vLLM 0.21
 
 ```bash
-export VLLM_HCU_USE_PD_SPLIT=1
-
 vllm serve Qwen/Qwen2-VL-2B \
     -tp 1 \
     --trust-remote-code \
     --gpu-memory-utilization 0.95 \
     --chat-template-content-format openai \
     --chat-template qwen2_vl_openai_chat_template.jinja \
-    --allowed-local-media-path /path-to/VL_data/ \
     --kv-cache-dtype fp8_e4m3 \
     --attention-backend FLASH_ATTN_CUSTOM
 ```
@@ -39,15 +36,12 @@ vllm serve Qwen/Qwen2-VL-2B \
 ### Qwen2-VL-2B IFB BW1000 1x vLLM 0.21
 
 ```bash
-export VLLM_HCU_USE_PD_SPLIT=1
-
 vllm serve Qwen/Qwen2-VL-2B \
     -tp 1 \
     --trust-remote-code \
     --gpu-memory-utilization 0.95 \
     --chat-template-content-format openai \
     --chat-template qwen2_vl_openai_chat_template.jinja \
-    --allowed-local-media-path /path-to/VL_data/ \
     --attention-backend FLASH_ATTN_CUSTOM
 ```
 ### Qwen2-VL-2B IFB K100_AI 1x vLLM 0.21
@@ -61,8 +55,7 @@ vllm serve Qwen/Qwen2-VL-2B \
     --trust-remote-code \
     --gpu-memory-utilization 0.95 \
     --chat-template-content-format openai \
-    --chat-template qwen2_vl_openai_chat_template.jinja \
-    --allowed-local-media-path /path-to/VL_data/
+    --chat-template qwen2_vl_openai_chat_template.jinja
 ```
 ### Qwen2-VL-2B IFB BW1100 1x vLLM 0.18
 
@@ -210,4 +203,5 @@ curl http://localhost:8000/v1/chat/completions \
 ### PD 分离
 
 暂无。
+
 

--- a/docs/model-deployment/vllm/qwen2-vl.md
+++ b/docs/model-deployment/vllm/qwen2-vl.md
@@ -28,7 +28,6 @@ vllm serve Qwen/Qwen2-VL-2B \
     --trust-remote-code \
     --gpu-memory-utilization 0.95 \
     --chat-template-content-format openai \
-    --chat-template qwen2_vl_openai_chat_template.jinja \
     --kv-cache-dtype fp8_e4m3 \
     --attention-backend FLASH_ATTN_CUSTOM
 ```
@@ -41,7 +40,6 @@ vllm serve Qwen/Qwen2-VL-2B \
     --trust-remote-code \
     --gpu-memory-utilization 0.95 \
     --chat-template-content-format openai \
-    --chat-template qwen2_vl_openai_chat_template.jinja \
     --attention-backend FLASH_ATTN_CUSTOM
 ```
 ### Qwen2-VL-2B IFB K100_AI 1x vLLM 0.21
@@ -54,8 +52,7 @@ vllm serve Qwen/Qwen2-VL-2B \
     -tp 1 \
     --trust-remote-code \
     --gpu-memory-utilization 0.95 \
-    --chat-template-content-format openai \
-    --chat-template qwen2_vl_openai_chat_template.jinja
+    --chat-template-content-format openai
 ```
 ### Qwen2-VL-2B IFB BW1100 1x vLLM 0.18
 
@@ -203,5 +200,6 @@ curl http://localhost:8000/v1/chat/completions \
 ### PD 分离
 
 暂无。
+
 
 


### PR DESCRIPTION
## Summary
- reorder Qwen/Qwen2-VL-2B vLLM rows by version first, then hardware
- reorder matching command sections to keep table and command order aligned

## Validation
- checked table and command headings are ordered as 0.21, 0.18, 0.18-hotfix with BW1100/BW1000/K100_AI within each version