### PR TITLE
docs: fix Qwen2.5-VL version ordering

### DIFF
--- a/docs/model-deployment/vllm/qwen2.5-vl.md
+++ b/docs/model-deployment/vllm/qwen2.5-vl.md
@@ -141,7 +141,6 @@ vllm serve Qwen/Qwen2.5-VL-32B-Instruct \
 ```bash
 vllm serve Qwen/Qwen2.5-VL-72B-Instruct \
   -tp 4 \
-  --host 0.0.0.0 \
   --trust-remote-code \
   --enable-chunked-prefill \
   --kv-cache-dtype fp8_e4m3 \
@@ -154,7 +153,6 @@ vllm serve Qwen/Qwen2.5-VL-72B-Instruct \
 ```bash
 vllm serve Qwen/Qwen2.5-VL-72B-Instruct \
   -tp 4 \
-  --host 0.0.0.0 \
   --trust-remote-code \
   --enable-chunked-prefill \
   --max-model-len 32768 \
@@ -165,7 +163,6 @@ vllm serve Qwen/Qwen2.5-VL-72B-Instruct \
 
 ```bash
 vllm serve Qwen/Qwen2.5-VL-72B-Instruct \
-  --host 0.0.0.0 \
   -tp 8 \
   --trust-remote-code \
   --enable-chunked-prefill \

--- a/docs/model-deployment/vllm/qwen2.5-vl.md
+++ b/docs/model-deployment/vllm/qwen2.5-vl.md
@@ -17,10 +17,15 @@ Qwen2.5-VL 是阿里通义千问视觉语言模型系列，支持图像、视频
 |  | BF16 | 0.18-hotfix | BW1100 | 1 | IFB | [**`>_`**](#qwen25-vl-32b-instruct-ifb-bw1100-1x-vllm-018-hotfix) |
 |  | BF16 | 0.18-hotfix | BW1000 | 2 | IFB | [**`>_`**](#qwen25-vl-32b-instruct-ifb-bw1000-2x-vllm-018-hotfix) |
 |  | BF16 | 0.18-hotfix | K100_AI | 4 | IFB | [**`>_`**](#qwen25-vl-32b-instruct-ifb-k100_ai-4x-vllm-018-hotfix) |
-| [Qwen/Qwen2.5-VL-72B-Instruct](https://www.modelscope.cn/models/Qwen/Qwen2.5-VL-72B-Instruct) | BF16 | [0.18](../docker_images.md) | BW1100 | 4 | IFB | [**`>_`**](#qwen25-vl-72b-instruct-ifb-bw1100-4x-vllm-018) |
+| [Qwen/Qwen2.5-VL-72B-Instruct](https://www.modelscope.cn/models/Qwen/Qwen2.5-VL-72B-Instruct) | BF16 | 0.21 | BW1100 | 4 | IFB | [**`>_`**](#qwen25-vl-72b-instruct-ifb-bw1100-4x-vllm-021) |
+|  | BF16 | 0.21 | BW1000 | 4 | IFB | [**`>_`**](#qwen25-vl-72b-instruct-ifb-bw1000-4x-vllm-021) |
+|  | BF16 | 0.21 | K100_AI | 8 | IFB | [**`>_`**](#qwen25-vl-72b-instruct-ifb-k100_ai-8x-vllm-021) |
+|  | BF16 | [0.18](../docker_images.md) | BW1100 | 4 | IFB | [**`>_`**](#qwen25-vl-72b-instruct-ifb-bw1100-4x-vllm-018) |
 |  | BF16 | [0.18](../docker_images.md) | BW1000 | 4 | IFB | [**`>_`**](#qwen25-vl-72b-instruct-ifb-bw1000-4x-vllm-018) |
 |  | BF16 | [0.18](../docker_images.md) | K100_AI | 8 | IFB | [**`>_`**](#qwen25-vl-72b-instruct-ifb-k100_ai-8x-vllm-018) |
-| hygon/Qwen2.5-VL-72B-Instruct-quantized.w8a8| INT8 W8A8 | [0.18](../docker_images.md) | BW1100 | 4 | IFB | [**`>_`**](#qwen25-vl-72b-instruct-quantizedw8a8-ifb-bw1100-4x-vllm-018) |
+| hygon/Qwen2.5-VL-72B-Instruct-quantized.w8a8| INT8 W8A8 | 0.21 | BW1100 | 4 | IFB | [**`>_`**](#qwen25-vl-72b-instruct-quantizedw8a8-ifb-bw1100-4x-vllm-021) |
+|  | INT8 W8A8 | 0.21 | BW1000 | 4 | IFB | [**`>_`**](#qwen25-vl-72b-instruct-quantizedw8a8-ifb-bw1000-4x-vllm-021) |
+|  | INT8 W8A8 | [0.18](../docker_images.md) | BW1100 | 4 | IFB | [**`>_`**](#qwen25-vl-72b-instruct-quantizedw8a8-ifb-bw1100-4x-vllm-018) |
 |  | INT8 W8A8 | [0.18](../docker_images.md) | BW1000 | 4 | IFB | [**`>_`**](#qwen25-vl-72b-instruct-quantizedw8a8-ifb-bw1000-4x-vllm-018) |
 
 ## 启动命令
@@ -131,6 +136,43 @@ vllm serve Qwen/Qwen2.5-VL-32B-Instruct \
     --allowed-local-media-path /path-to/VL_data/ \
 ```
 
+### Qwen2.5-VL-72B-Instruct IFB BW1100 4x vLLM 0.21
+
+```bash
+vllm serve Qwen/Qwen2.5-VL-72B-Instruct \
+  -tp 4 \
+  --host 0.0.0.0 \
+  --trust-remote-code \
+  --enable-chunked-prefill \
+  --kv-cache-dtype fp8_e4m3 \
+  --max-model-len 32768 \
+  --attention-backend FLASH_ATTN_CUSTOM
+```
+
+### Qwen2.5-VL-72B-Instruct IFB BW1000 4x vLLM 0.21
+
+```bash
+vllm serve Qwen/Qwen2.5-VL-72B-Instruct \
+  -tp 4 \
+  --host 0.0.0.0 \
+  --trust-remote-code \
+  --enable-chunked-prefill \
+  --max-model-len 32768 \
+  --attention-backend FLASH_ATTN_CUSTOM
+```
+
+### Qwen2.5-VL-72B-Instruct IFB K100_AI 8x vLLM 0.21
+
+```bash
+vllm serve Qwen/Qwen2.5-VL-72B-Instruct \
+  --host 0.0.0.0 \
+  -tp 8 \
+  --trust-remote-code \
+  --enable-chunked-prefill \
+  --max-model-len 32768 \
+  --attention-backend FLASH_ATTN_CUSTOM
+```
+
 ### Qwen2.5-VL-72B-Instruct IFB BW1100 4x vLLM 0.18
 
 ```bash
@@ -175,6 +217,32 @@ vllm serve Qwen/Qwen2.5-VL-72B-Instruct \
   --trust-remote-code \
   --enable-chunked-prefill \
   --max-model-len 32768
+```
+
+### Qwen2.5-VL-72B-Instruct-quantized.w8a8 IFB BW1100 4x vLLM 0.21
+
+```bash
+vllm serve hygon/Qwen2.5-VL-72B-Instruct-quantized.w8a8 \
+  -tp 4 \
+  --trust-remote-code \
+  --enable-chunked-prefill \
+  --max-model-len 40960 \
+  -q slimquant_marlin \
+  --attention-backend FLASH_ATTN_CUSTOM \
+  --allowed-local-media-path
+```
+
+### Qwen2.5-VL-72B-Instruct-quantized.w8a8 IFB BW1000 4x vLLM 0.21
+
+```bash
+vllm serve hygon/Qwen2.5-VL-72B-Instruct-quantized.w8a8 \
+  -tp 4 \
+  --trust-remote-code \
+  --enable-chunked-prefill \
+  --max-model-len 40960 \
+  -q slimquant_marlin \
+  --attention-backend FLASH_ATTN_CUSTOM \
+  --allowed-local-media-path
 ```
 
 ### Qwen2.5-VL-72B-Instruct-quantized.w8a8 IFB BW1100 4x vLLM 0.18

--- a/docs/model-deployment/vllm/qwen2.5-vl.md
+++ b/docs/model-deployment/vllm/qwen2.5-vl.md
@@ -8,15 +8,15 @@ Qwen2.5-VL 是阿里通义千问视觉语言模型系列，支持图像、视频
 
 | 模型权重 | 量化方式 | vLLM 版本 | 推荐硬件 | 卡数 | 部署方式 | 启动命令 |
 | -------- | -------- | --------- | -------- | ---- | -------- | -------- |
-| [Qwen/Qwen2.5-VL-32B-Instruct](https://www.modelscope.cn/models/Qwen/Qwen2.5-VL-32B-Instruct) | BF16 | 0.21 | BW1000 | 2 | IFB | [**`>_`**](#qwen25-vl-32b-instruct-ifb-bw1000-2x-vllm-021) |
+| [Qwen/Qwen2.5-VL-32B-Instruct](https://www.modelscope.cn/models/Qwen/Qwen2.5-VL-32B-Instruct) | BF16 | 0.21 | BW1100 | 1 | IFB | [**`>_`**](#qwen25-vl-32b-instruct-ifb-bw1100-1x-vllm-021) |
+|  | BF16 | 0.21 | BW1000 | 2 | IFB | [**`>_`**](#qwen25-vl-32b-instruct-ifb-bw1000-2x-vllm-021) |
+|  | BF16 | 0.21 | K100_AI | 4 | IFB | [**`>_`**](#qwen25-vl-32b-instruct-ifb-k100_ai-4x-vllm-021) |
+|  | BF16 | 0.18 | BW1100 | 1 | IFB | [**`>_`**](#qwen25-vl-32b-instruct-ifb-bw1100-1x-vllm-018) |
 |  | BF16 | 0.18 | BW1000 | 2 | IFB | [**`>_`**](#qwen25-vl-32b-instruct-ifb-bw1000-2x-vllm-018) |
+|  | BF16 | 0.18 | K100_AI | 4 | IFB | [**`>_`**](#qwen25-vl-32b-instruct-ifb-k100_ai-4x-vllm-018) |
+|  | BF16 | 0.18-hotfix | BW1100 | 1 | IFB | [**`>_`**](#qwen25-vl-32b-instruct-ifb-bw1100-1x-vllm-018-hotfix) |
 |  | BF16 | 0.18-hotfix | BW1000 | 2 | IFB | [**`>_`**](#qwen25-vl-32b-instruct-ifb-bw1000-2x-vllm-018-hotfix) |
-|  | BF16 | 0.21 | BW1100 | 1 | IFB | [**\`>_\`**](#qwen25-vl-32b-instruct-ifb-bw1100-1x-vllm-021) |
-|                                                                               | BF16 | 0.18 | BW1100 | 1 | IFB | [**\`>_\`**](#qwen25-vl-32b-instruct-ifb-bw1100-1x-vllm-018) |
-|  | BF16 | 0.18-hotfix | BW1100 | 1 | IFB | [**\`>_\`**](#qwen25-vl-32b-instruct-ifb-bw1100-1x-vllm-018-hotfix) |
-|  | BF16 | 0.21 | K100_AI | 4 | IFB | [**\`>_\`**](#qwen25-vl-32b-instruct-ifb-k100_ai-4x-vllm-021) |
-|                                                                               | BF16 | 0.18 | K100_AI | 4 | IFB | [**\`>_\`**](#qwen25-vl-32b-instruct-ifb-k100_ai-4x-vllm-018) |
-|  | BF16 | 0.18-hotfix | K100_AI | 4 | IFB | [**\`>_\`**](#qwen25-vl-32b-instruct-ifb-k100_ai-4x-vllm-018-hotfix) |
+|  | BF16 | 0.18-hotfix | K100_AI | 4 | IFB | [**`>_`**](#qwen25-vl-32b-instruct-ifb-k100_ai-4x-vllm-018-hotfix) |
 | [Qwen/Qwen2.5-VL-72B-Instruct](https://www.modelscope.cn/models/Qwen/Qwen2.5-VL-72B-Instruct) | BF16 | [0.18](../docker_images.md) | BW1100 | 4 | IFB | [**`>_`**](#qwen25-vl-72b-instruct-ifb-bw1100-4x-vllm-018) |
 |  | BF16 | [0.18](../docker_images.md) | BW1000 | 4 | IFB | [**`>_`**](#qwen25-vl-72b-instruct-ifb-bw1000-4x-vllm-018) |
 |  | BF16 | [0.18](../docker_images.md) | K100_AI | 8 | IFB | [**`>_`**](#qwen25-vl-72b-instruct-ifb-k100_ai-8x-vllm-018) |
@@ -25,40 +25,6 @@ Qwen2.5-VL 是阿里通义千问视觉语言模型系列，支持图像、视频
 
 ## 启动命令
 
-### Qwen2.5-VL-32B-Instruct IFB BW1000 2x vLLM 0.21
-
-```bash
-export VLLM_HCU_USE_PD_SPLIT=1
-
-vllm serve Qwen/Qwen2.5-VL-32B-Instruct \
-    -tp 2 \
-    --trust-remote-code \
-    --allowed-local-media-path /path-to/VL_data/ \
-    --attention-backend FLASH_ATTN_CUSTOM
-```
-### Qwen2.5-VL-32B-Instruct IFB BW1000 2x vLLM 0.18
-
-```bash
-export VLLM_HCU_USE_CUSTOM_FLASH_ATTN=1
-export VLLM_HCU_USE_CUSTOM_TOPK_TOPP_SAMPLER=1
-
-vllm serve Qwen/Qwen2.5-VL-32B-Instruct \
-    -tp 2 \
-    --trust-remote-code \
-    --allowed-local-media-path /path-to/VL_data/ \
-```
-
-### Qwen2.5-VL-32B-Instruct IFB BW1000 2x vLLM 0.18-hotfix
-
-```bash
-export VLLM_HCU_USE_PD_SPLIT=1
-
-vllm serve Qwen/Qwen2.5-VL-32B-Instruct \
-    -tp 2 \
-    --trust-remote-code \
-    --allowed-local-media-path /path-to/VL_data/ \
-    --attention-backend FLASH_ATTN_CUSTOM
-```
 ### Qwen2.5-VL-32B-Instruct IFB BW1100 1x vLLM 0.21
 
 ```bash
@@ -73,6 +39,27 @@ vllm serve Qwen/Qwen2.5-VL-32B-Instruct \
     --kv-cache-dtype fp8_e4m3 \
     --attention-backend FLASH_ATTN_CUSTOM
 ```
+### Qwen2.5-VL-32B-Instruct IFB BW1000 2x vLLM 0.21
+
+```bash
+export VLLM_HCU_USE_PD_SPLIT=1
+
+vllm serve Qwen/Qwen2.5-VL-32B-Instruct \
+    -tp 2 \
+    --trust-remote-code \
+    --allowed-local-media-path /path-to/VL_data/ \
+    --attention-backend FLASH_ATTN_CUSTOM
+```
+### Qwen2.5-VL-32B-Instruct IFB K100_AI 4x vLLM 0.21
+
+```bash
+export VLLM_HCU_USE_CUSTOM_QUANTIZATION_GEMM=0
+export VLLM_HCU_USE_CUSTOM_OPS=0
+vllm serve Qwen/Qwen2.5-VL-32B-Instruct \
+    -tp 4 \
+    --trust-remote-code \
+    --allowed-local-media-path /path-to/VL_data/ \
+```
 ### Qwen2.5-VL-32B-Instruct IFB BW1100 1x vLLM 0.18
 
 ```bash
@@ -86,6 +73,28 @@ vllm serve Qwen/Qwen2.5-VL-32B-Instruct \
     --allowed-local-media-path /path-to/VL_data/ \
 ```
 
+### Qwen2.5-VL-32B-Instruct IFB BW1000 2x vLLM 0.18
+
+```bash
+export VLLM_HCU_USE_CUSTOM_FLASH_ATTN=1
+export VLLM_HCU_USE_CUSTOM_TOPK_TOPP_SAMPLER=1
+
+vllm serve Qwen/Qwen2.5-VL-32B-Instruct \
+    -tp 2 \
+    --trust-remote-code \
+    --allowed-local-media-path /path-to/VL_data/ \
+```
+
+### Qwen2.5-VL-32B-Instruct IFB K100_AI 4x vLLM 0.18
+
+```bash
+export VLLM_HCU_USE_CUSTOM_QUANTIZATION_GEMM=0
+export VLLM_HCU_USE_CUSTOM_OPS=0
+vllm serve Qwen/Qwen2.5-VL-32B-Instruct \
+    -tp 4 \
+    --trust-remote-code \
+    --allowed-local-media-path /path-to/VL_data/ \
+```
 ### Qwen2.5-VL-32B-Instruct IFB BW1100 1x vLLM 0.18-hotfix
 
 ```bash
@@ -100,25 +109,17 @@ vllm serve Qwen/Qwen2.5-VL-32B-Instruct \
     --kv-cache-dtype fp8_e4m3 \
     --attention-backend FLASH_ATTN_CUSTOM
 ```
-### Qwen2.5-VL-32B-Instruct IFB K100_AI 4x vLLM 0.21
+
+### Qwen2.5-VL-32B-Instruct IFB BW1000 2x vLLM 0.18-hotfix
 
 ```bash
-export VLLM_HCU_USE_CUSTOM_QUANTIZATION_GEMM=0
-export VLLM_HCU_USE_CUSTOM_OPS=0
-vllm serve Qwen/Qwen2.5-VL-32B-Instruct \
-    -tp 4 \
-    --trust-remote-code \
-    --allowed-local-media-path /path-to/VL_data/ \
-```
-### Qwen2.5-VL-32B-Instruct IFB K100_AI 4x vLLM 0.18
+export VLLM_HCU_USE_PD_SPLIT=1
 
-```bash
-export VLLM_HCU_USE_CUSTOM_QUANTIZATION_GEMM=0
-export VLLM_HCU_USE_CUSTOM_OPS=0
 vllm serve Qwen/Qwen2.5-VL-32B-Instruct \
-    -tp 4 \
+    -tp 2 \
     --trust-remote-code \
     --allowed-local-media-path /path-to/VL_data/ \
+    --attention-backend FLASH_ATTN_CUSTOM
 ```
 
 ### Qwen2.5-VL-32B-Instruct IFB K100_AI 4x vLLM 0.18-hotfix
@@ -252,3 +253,4 @@ curl http://localhost:8000/v1/chat/completions \
 ### PD 分离
 
 暂无。
+

--- a/docs/model-deployment/vllm/qwen2.5-vl.md
+++ b/docs/model-deployment/vllm/qwen2.5-vl.md
@@ -28,8 +28,6 @@ Qwen2.5-VL 是阿里通义千问视觉语言模型系列，支持图像、视频
 ### Qwen2.5-VL-32B-Instruct IFB BW1100 1x vLLM 0.21
 
 ```bash
-export VLLM_HCU_USE_PD_SPLIT=1
-
 vllm serve Qwen/Qwen2.5-VL-32B-Instruct \
     -tp 1 \
     --trust-remote-code \
@@ -42,8 +40,6 @@ vllm serve Qwen/Qwen2.5-VL-32B-Instruct \
 ### Qwen2.5-VL-32B-Instruct IFB BW1000 2x vLLM 0.21
 
 ```bash
-export VLLM_HCU_USE_PD_SPLIT=1
-
 vllm serve Qwen/Qwen2.5-VL-32B-Instruct \
     -tp 2 \
     --trust-remote-code \

--- a/docs/model-deployment/vllm/qwen2.5-vl.md
+++ b/docs/model-deployment/vllm/qwen2.5-vl.md
@@ -43,6 +43,7 @@ vllm serve Qwen/Qwen2.5-VL-32B-Instruct \
 vllm serve Qwen/Qwen2.5-VL-32B-Instruct \
     -tp 2 \
     --trust-remote-code \
+    --max-model-len 32768 \
     --allowed-local-media-path /path-to/VL_data/ \
     --attention-backend FLASH_ATTN_CUSTOM
 ```
@@ -54,6 +55,7 @@ export VLLM_HCU_USE_CUSTOM_OPS=0
 vllm serve Qwen/Qwen2.5-VL-32B-Instruct \
     -tp 4 \
     --trust-remote-code \
+    --max-model-len 32768 \
     --allowed-local-media-path /path-to/VL_data/ \
 ```
 ### Qwen2.5-VL-32B-Instruct IFB BW1100 1x vLLM 0.18


### PR DESCRIPTION
## Summary
- Reorder Qwen/Qwen2.5-VL-32B-Instruct rows by vLLM version first, then hardware order.
- Reorder matching launch command sections to align with the table.
- No 0.15 entries are present in qwen2.5-vl.md, so no 0.15 command block was changed.

## Verification
- Checked 32B table row order and heading order locally.