### PR TITLE
docs: update Qwen3-VL 235B BW1000 v0.21 commands

### DIFF
--- a/docs/model-deployment/vllm/qwen3-vl.md
+++ b/docs/model-deployment/vllm/qwen3-vl.md
@@ -711,8 +711,8 @@ vllm serve Qwen/Qwen3-VL-30B-A3B-Instruct \
 ### Qwen3-VL-30B-A3B-Instruct IFB BW1000 2x vLLM 0.21
 
 ```bash
-export VLLM_HCU_USE_PD_SPLIT=1
-export VLLM_USE_MODELSCOPE=1
+export VLLM_ROCM_USE_AITER=0
+
 vllm serve Qwen/Qwen3-VL-30B-A3B-Instruct \
   -tp 2 \
   --trust-remote-code \

--- a/docs/model-deployment/vllm/qwen3-vl.md
+++ b/docs/model-deployment/vllm/qwen3-vl.md
@@ -987,14 +987,37 @@ vllm serve Qwen/Qwen3-VL-235B-A22B-Instruct \
 ```
 ### Qwen3-VL-235B-A22B-Instruct IFB BW1000 16x vLLM 0.21
 
+主节点
+
 ```bash
-export VLLM_HCU_USE_PD_SPLIT=1
-export VLLM_USE_MODELSCOPE=1
+export VLLM_ROCM_USE_AITER_MOE=0
+
 vllm serve Qwen/Qwen3-VL-235B-A22B-Instruct \
   -tp 8 \
   -pp 2 \
   --trust-remote-code \
-  --attention-backend FLASH_ATTN_CUSTOM
+  --attention-backend FLASH_ATTN_CUSTOM \
+  --nnodes 2 \
+  --node-rank 0 \
+  --master-addr <主节点ip> \
+  --hf-overrides '{"architectures": ["Qwen3VLMoeForConditionalGeneration"], "text_config": {"architectures": ["Qwen3VLMoeForConditionalGeneration"]}}'
+```
+
+从节点
+
+```bash
+export VLLM_ROCM_USE_AITER_MOE=0
+
+vllm serve Qwen/Qwen3-VL-235B-A22B-Instruct \
+  -tp 8 \
+  -pp 2 \
+  --trust-remote-code \
+  --attention-backend FLASH_ATTN_CUSTOM \
+  --nnodes 2 \
+  --node-rank 1 \
+  --master-addr <主节点ip> \
+  --headless \
+  --hf-overrides '{"architectures": ["Qwen3VLMoeForConditionalGeneration"], "text_config": {"architectures": ["Qwen3VLMoeForConditionalGeneration"]}}'
 ```
 ### Qwen3-VL-235B-A22B-Instruct IFB BW1000 16x vLLM 0.18
 ```bash
@@ -1085,14 +1108,37 @@ vllm serve Qwen/Qwen3-VL-235B-A22B-Thinking \
 ```
 ### Qwen3-VL-235B-A22B-Thinking IFB BW1000 16x vLLM 0.21
 
+主节点
+
 ```bash
-export VLLM_HCU_USE_PD_SPLIT=1
-export VLLM_USE_MODELSCOPE=1
+export VLLM_ROCM_USE_AITER_MOE=0
+
 vllm serve Qwen/Qwen3-VL-235B-A22B-Thinking \
   -tp 8 \
   -pp 2 \
   --trust-remote-code \
-  --attention-backend FLASH_ATTN_CUSTOM
+  --attention-backend FLASH_ATTN_CUSTOM \
+  --nnodes 2 \
+  --node-rank 0 \
+  --master-addr <主节点ip> \
+  --hf-overrides '{"architectures": ["Qwen3VLMoeForConditionalGeneration"], "text_config": {"architectures": ["Qwen3VLMoeForConditionalGeneration"]}}'
+```
+
+从节点
+
+```bash
+export VLLM_ROCM_USE_AITER_MOE=0
+
+vllm serve Qwen/Qwen3-VL-235B-A22B-Thinking \
+  -tp 8 \
+  -pp 2 \
+  --trust-remote-code \
+  --attention-backend FLASH_ATTN_CUSTOM \
+  --nnodes 2 \
+  --node-rank 1 \
+  --master-addr <主节点ip> \
+  --headless \
+  --hf-overrides '{"architectures": ["Qwen3VLMoeForConditionalGeneration"], "text_config": {"architectures": ["Qwen3VLMoeForConditionalGeneration"]}}'
 ```
 ### Qwen3-VL-235B-A22B-Thinking IFB BW1000 16x vLLM 0.18
 ```bash

--- a/docs/model-deployment/vllm/qwen3-vl.md
+++ b/docs/model-deployment/vllm/qwen3-vl.md
@@ -21,131 +21,109 @@ Qwen3-VL 是阿里云推出的新一代多模态视觉语言模型（Vision-Lang
 | 模型权重 | 量化方式 | vLLM 版本 | 推荐硬件 | 卡数 | 部署方式 | 启动命令 |
 | -------- | -------- | --------- | -------- | ---- | -------- | -------- |
 | [Qwen/Qwen3-VL-2B-Instruct](https://www.modelscope.cn/models/Qwen/Qwen3-VL-2B-Instruct) | BF16 | 0.21 | BW1100 | 1x | IFB | [**`>_`**](#qwen3-vl-2b-instruct-ifb-bw1100-1x-vllm-021) |
-|  | BF16 | 0.18 | BW1100  | 1x | IFB | [**`>_`**](#qwen3-vl-2b-instruct-ifb-bw1100-1x-vllm-018) |
-|  | BF16 | 0.18-hotfix | BW1100 | 1x | IFB | [**`>_`**](#qwen3-vl-2b-instruct-ifb-bw1100-1x-vllm-018-hotfix) |
 |  | BF16 | 0.21 | BW1000 | 1x | IFB | [**`>_`**](#qwen3-vl-2b-instruct-ifb-bw1000-1x-vllm-021) |
-|                                                                               | BF16      | 0.18 | BW1000  | 1x | IFB | [**`>_`**](#qwen3-vl-2b-instruct-ifb-bw1000-1x-vllm-018) |
-|  | BF16 | 0.18-hotfix | BW1000 | 1x | IFB | [**`>_`**](#qwen3-vl-2b-instruct-ifb-bw1000-1x-vllm-018-hotfix) |
 |  | BF16 | 0.21 | K100_AI | 1x | IFB | [**`>_`**](#qwen3-vl-2b-instruct-ifb-k100_ai-1x-vllm-021) |
-|                                                                               | BF16      | 0.18 | K100_AI | 1x | IFB | [**`>_`**](#qwen3-vl-2b-instruct-ifb-k100_ai-1x-vllm-018) |
+|  | BF16 | 0.18 | BW1100 | 1x | IFB | [**`>_`**](#qwen3-vl-2b-instruct-ifb-bw1100-1x-vllm-018) |
+|  | BF16 | 0.18 | BW1000 | 1x | IFB | [**`>_`**](#qwen3-vl-2b-instruct-ifb-bw1000-1x-vllm-018) |
+|  | BF16 | 0.18 | K100_AI | 1x | IFB | [**`>_`**](#qwen3-vl-2b-instruct-ifb-k100_ai-1x-vllm-018) |
+|  | BF16 | 0.18-hotfix | BW1100 | 1x | IFB | [**`>_`**](#qwen3-vl-2b-instruct-ifb-bw1100-1x-vllm-018-hotfix) |
+|  | BF16 | 0.18-hotfix | BW1000 | 1x | IFB | [**`>_`**](#qwen3-vl-2b-instruct-ifb-bw1000-1x-vllm-018-hotfix) |
 |  | BF16 | 0.18-hotfix | K100_AI | 1x | IFB | [**`>_`**](#qwen3-vl-2b-instruct-ifb-k100_ai-1x-vllm-018-hotfix) |
 | [Qwen/Qwen3-VL-2B-Thinking](https://www.modelscope.cn/models/Qwen/Qwen3-VL-2B-Thinking) | BF16 | 0.21 | BW1100 | 1x | IFB | [**`>_`**](#qwen3-vl-2b-thinking-ifb-bw1100-1x-vllm-021) |
-|  | BF16 | 0.18 | BW1100  | 1x | IFB | [**`>_`**](#qwen3-vl-2b-thinking-ifb-bw1100-1x-vllm-018) |
-|  | BF16 | 0.18-hotfix | BW1100 | 1x | IFB | [**`>_`**](#qwen3-vl-2b-thinking-ifb-bw1100-1x-vllm-018-hotfix) |
 |  | BF16 | 0.21 | BW1000 | 1x | IFB | [**`>_`**](#qwen3-vl-2b-thinking-ifb-bw1000-1x-vllm-021) |
-|                                                                               | BF16      | 0.18 | BW1000  | 1x | IFB | [**`>_`**](#qwen3-vl-2b-thinking-ifb-bw1000-1x-vllm-018) |
-|  | BF16 | 0.18-hotfix | BW1000 | 1x | IFB | [**`>_`**](#qwen3-vl-2b-thinking-ifb-bw1000-1x-vllm-018-hotfix) |
 |  | BF16 | 0.21 | K100_AI | 1x | IFB | [**`>_`**](#qwen3-vl-2b-thinking-ifb-k100_ai-1x-vllm-021) |
-|                                                                               | BF16      | 0.18 | K100_AI | 1x | IFB | [**`>_`**](#qwen3-vl-2b-thinking-ifb-k100_ai-1x-vllm-018) |
+|  | BF16 | 0.18 | BW1100 | 1x | IFB | [**`>_`**](#qwen3-vl-2b-thinking-ifb-bw1100-1x-vllm-018) |
+|  | BF16 | 0.18 | BW1000 | 1x | IFB | [**`>_`**](#qwen3-vl-2b-thinking-ifb-bw1000-1x-vllm-018) |
+|  | BF16 | 0.18 | K100_AI | 1x | IFB | [**`>_`**](#qwen3-vl-2b-thinking-ifb-k100_ai-1x-vllm-018) |
+|  | BF16 | 0.18-hotfix | BW1100 | 1x | IFB | [**`>_`**](#qwen3-vl-2b-thinking-ifb-bw1100-1x-vllm-018-hotfix) |
+|  | BF16 | 0.18-hotfix | BW1000 | 1x | IFB | [**`>_`**](#qwen3-vl-2b-thinking-ifb-bw1000-1x-vllm-018-hotfix) |
 |  | BF16 | 0.18-hotfix | K100_AI | 1x | IFB | [**`>_`**](#qwen3-vl-2b-thinking-ifb-k100_ai-1x-vllm-018-hotfix) |
 | [Qwen/Qwen3-VL-4B-Instruct](https://www.modelscope.cn/models/Qwen/Qwen3-VL-4B-Instruct) | BF16 | 0.21 | BW1100 | 1x | IFB | [**`>_`**](#qwen3-vl-4b-instruct-ifb-bw1100-1x-vllm-021) |
-|  | BF16 | 0.18 | BW1100  | 1x | IFB | [**`>_`**](#qwen3-vl-4b-instruct-ifb-bw1100-1x-vllm-018) |
-|  | BF16 | 0.18-hotfix | BW1100 | 1x | IFB | [**`>_`**](#qwen3-vl-4b-instruct-ifb-bw1100-1x-vllm-018-hotfix) |
 |  | BF16 | 0.21 | BW1000 | 1x | IFB | [**`>_`**](#qwen3-vl-4b-instruct-ifb-bw1000-1x-vllm-021) |
-|                                                                               | BF16      | 0.18 | BW1000  | 1x | IFB | [**`>_`**](#qwen3-vl-4b-instruct-ifb-bw1000-1x-vllm-018) |
-|  | BF16 | 0.18-hotfix | BW1000 | 1x | IFB | [**`>_`**](#qwen3-vl-4b-instruct-ifb-bw1000-1x-vllm-018-hotfix) |
 |  | BF16 | 0.21 | K100_AI | 1x | IFB | [**`>_`**](#qwen3-vl-4b-instruct-ifb-k100_ai-1x-vllm-021) |
-|                                                                               | BF16      | 0.18 | K100_AI | 1x | IFB | [**`>_`**](#qwen3-vl-4b-instruct-ifb-k100_ai-1x-vllm-018) |
+|  | BF16 | 0.18 | BW1100 | 1x | IFB | [**`>_`**](#qwen3-vl-4b-instruct-ifb-bw1100-1x-vllm-018) |
+|  | BF16 | 0.18 | BW1000 | 1x | IFB | [**`>_`**](#qwen3-vl-4b-instruct-ifb-bw1000-1x-vllm-018) |
+|  | BF16 | 0.18 | K100_AI | 1x | IFB | [**`>_`**](#qwen3-vl-4b-instruct-ifb-k100_ai-1x-vllm-018) |
+|  | BF16 | 0.18-hotfix | BW1100 | 1x | IFB | [**`>_`**](#qwen3-vl-4b-instruct-ifb-bw1100-1x-vllm-018-hotfix) |
+|  | BF16 | 0.18-hotfix | BW1000 | 1x | IFB | [**`>_`**](#qwen3-vl-4b-instruct-ifb-bw1000-1x-vllm-018-hotfix) |
 |  | BF16 | 0.18-hotfix | K100_AI | 1x | IFB | [**`>_`**](#qwen3-vl-4b-instruct-ifb-k100_ai-1x-vllm-018-hotfix) |
 | [Qwen/Qwen3-VL-4B-Thinking](https://www.modelscope.cn/models/Qwen/Qwen3-VL-4B-Thinking) | BF16 | 0.21 | BW1100 | 1x | IFB | [**`>_`**](#qwen3-vl-4b-thinking-ifb-bw1100-1x-vllm-021) |
-|  | BF16 | 0.18 | BW1100  | 1x | IFB | [**`>_`**](#qwen3-vl-4b-thinking-ifb-bw1100-1x-vllm-018) |
-|  | BF16 | 0.18-hotfix | BW1100 | 1x | IFB | [**`>_`**](#qwen3-vl-4b-thinking-ifb-bw1100-1x-vllm-018-hotfix) |
 |  | BF16 | 0.21 | BW1000 | 1x | IFB | [**`>_`**](#qwen3-vl-4b-thinking-ifb-bw1000-1x-vllm-021) |
-|                                                                               | BF16      | 0.18 | BW1000  | 1x | IFB | [**`>_`**](#qwen3-vl-4b-thinking-ifb-bw1000-1x-vllm-018) |
-|  | BF16 | 0.18-hotfix | BW1000 | 1x | IFB | [**`>_`**](#qwen3-vl-4b-thinking-ifb-bw1000-1x-vllm-018-hotfix) |
 |  | BF16 | 0.21 | K100_AI | 1x | IFB | [**`>_`**](#qwen3-vl-4b-thinking-ifb-k100_ai-1x-vllm-021) |
-|                                                                               | BF16      | 0.18 | K100_AI | 1x | IFB | [**`>_`**](#qwen3-vl-4b-thinking-ifb-k100_ai-1x-vllm-018) |
+|  | BF16 | 0.18 | BW1100 | 1x | IFB | [**`>_`**](#qwen3-vl-4b-thinking-ifb-bw1100-1x-vllm-018) |
+|  | BF16 | 0.18 | BW1000 | 1x | IFB | [**`>_`**](#qwen3-vl-4b-thinking-ifb-bw1000-1x-vllm-018) |
+|  | BF16 | 0.18 | K100_AI | 1x | IFB | [**`>_`**](#qwen3-vl-4b-thinking-ifb-k100_ai-1x-vllm-018) |
+|  | BF16 | 0.18-hotfix | BW1100 | 1x | IFB | [**`>_`**](#qwen3-vl-4b-thinking-ifb-bw1100-1x-vllm-018-hotfix) |
+|  | BF16 | 0.18-hotfix | BW1000 | 1x | IFB | [**`>_`**](#qwen3-vl-4b-thinking-ifb-bw1000-1x-vllm-018-hotfix) |
 |  | BF16 | 0.18-hotfix | K100_AI | 1x | IFB | [**`>_`**](#qwen3-vl-4b-thinking-ifb-k100_ai-1x-vllm-018-hotfix) |
 | [Qwen/Qwen3-VL-8B-Instruct](https://www.modelscope.cn/models/Qwen/Qwen3-VL-8B-Instruct) | BF16 | 0.21 | BW1100 | 1x | IFB | [**`>_`**](#qwen3-vl-8b-instruct-ifb-bw1100-1x-vllm-021) |
-|  | BF16 | 0.18 | BW1100  | 1x | IFB | [**`>_`**](#qwen3-vl-8b-instruct-ifb-bw1100-1x-vllm-018) |
-|  | BF16 | 0.18-hotfix | BW1100 | 1x | IFB | [**`>_`**](#qwen3-vl-8b-instruct-ifb-bw1100-1x-vllm-018-hotfix) |
 |  | BF16 | 0.21 | BW1000 | 1x | IFB | [**`>_`**](#qwen3-vl-8b-instruct-ifb-bw1000-1x-vllm-021) |
-|                                                                               | BF16      | 0.18 | BW1000  | 1x | IFB | [**`>_`**](#qwen3-vl-8b-instruct-ifb-bw1000-1x-vllm-018) |
-|  | BF16 | 0.18-hotfix | BW1000 | 1x | IFB | [**`>_`**](#qwen3-vl-8b-instruct-ifb-bw1000-1x-vllm-018-hotfix) |
 |  | BF16 | 0.21 | K100_AI | 1x | IFB | [**`>_`**](#qwen3-vl-8b-instruct-ifb-k100_ai-1x-vllm-021) |
-|                                                                               | BF16      | 0.18 | K100_AI | 1x | IFB | [**`>_`**](#qwen3-vl-8b-instruct-ifb-k100_ai-1x-vllm-018) |
+|  | BF16 | 0.18 | BW1100 | 1x | IFB | [**`>_`**](#qwen3-vl-8b-instruct-ifb-bw1100-1x-vllm-018) |
+|  | BF16 | 0.18 | BW1000 | 1x | IFB | [**`>_`**](#qwen3-vl-8b-instruct-ifb-bw1000-1x-vllm-018) |
+|  | BF16 | 0.18 | K100_AI | 1x | IFB | [**`>_`**](#qwen3-vl-8b-instruct-ifb-k100_ai-1x-vllm-018) |
+|  | BF16 | 0.18-hotfix | BW1100 | 1x | IFB | [**`>_`**](#qwen3-vl-8b-instruct-ifb-bw1100-1x-vllm-018-hotfix) |
+|  | BF16 | 0.18-hotfix | BW1000 | 1x | IFB | [**`>_`**](#qwen3-vl-8b-instruct-ifb-bw1000-1x-vllm-018-hotfix) |
 |  | BF16 | 0.18-hotfix | K100_AI | 1x | IFB | [**`>_`**](#qwen3-vl-8b-instruct-ifb-k100_ai-1x-vllm-018-hotfix) |
 | [Qwen/Qwen3-VL-8B-Thinking](https://www.modelscope.cn/models/Qwen/Qwen3-VL-8B-Thinking) | BF16 | 0.21 | BW1100 | 1x | IFB | [**`>_`**](#qwen3-vl-8b-thinking-ifb-bw1100-1x-vllm-021) |
-|  | BF16 | 0.18 | BW1100  | 1x | IFB | [**`>_`**](#qwen3-vl-8b-thinking-ifb-bw1100-1x-vllm-018) |
-|  | BF16 | 0.18-hotfix | BW1100 | 1x | IFB | [**`>_`**](#qwen3-vl-8b-thinking-ifb-bw1100-1x-vllm-018-hotfix) |
 |  | BF16 | 0.21 | BW1000 | 1x | IFB | [**`>_`**](#qwen3-vl-8b-thinking-ifb-bw1000-1x-vllm-021) |
-|                                                                               | BF16      | 0.18 | BW1000  | 1x | IFB | [**`>_`**](#qwen3-vl-8b-thinking-ifb-bw1000-1x-vllm-018) |
-|  | BF16 | 0.18-hotfix | BW1000 | 1x | IFB | [**`>_`**](#qwen3-vl-8b-thinking-ifb-bw1000-1x-vllm-018-hotfix) |
 |  | BF16 | 0.21 | K100_AI | 1x | IFB | [**`>_`**](#qwen3-vl-8b-thinking-ifb-k100_ai-1x-vllm-021) |
-|                                                                               | BF16      | 0.18 | K100_AI | 1x | IFB | [**`>_`**](#qwen3-vl-8b-thinking-ifb-k100_ai-1x-vllm-018) |
+|  | BF16 | 0.18 | BW1100 | 1x | IFB | [**`>_`**](#qwen3-vl-8b-thinking-ifb-bw1100-1x-vllm-018) |
+|  | BF16 | 0.18 | BW1000 | 1x | IFB | [**`>_`**](#qwen3-vl-8b-thinking-ifb-bw1000-1x-vllm-018) |
+|  | BF16 | 0.18 | K100_AI | 1x | IFB | [**`>_`**](#qwen3-vl-8b-thinking-ifb-k100_ai-1x-vllm-018) |
+|  | BF16 | 0.18-hotfix | BW1100 | 1x | IFB | [**`>_`**](#qwen3-vl-8b-thinking-ifb-bw1100-1x-vllm-018-hotfix) |
+|  | BF16 | 0.18-hotfix | BW1000 | 1x | IFB | [**`>_`**](#qwen3-vl-8b-thinking-ifb-bw1000-1x-vllm-018-hotfix) |
 |  | BF16 | 0.18-hotfix | K100_AI | 1x | IFB | [**`>_`**](#qwen3-vl-8b-thinking-ifb-k100_ai-1x-vllm-018-hotfix) |
 | [Qwen/Qwen3-VL-30B-A3B-Instruct](https://www.modelscope.cn/models/Qwen/Qwen3-VL-30B-A3B-Instruct) | BF16 | 0.21 | BW1100 | 1x | IFB | [**`>_`**](#qwen3-vl-30b-a3b-instruct-ifb-bw1100-1x-vllm-021) |
-|  | BF16 | 0.18 | BW1100  | 1x | IFB | [**`>_`**](#qwen3-vl-30b-a3b-instruct-ifb-bw1100-1x-vllm-018) |
-|  | BF16 | 0.18-hotfix | BW1100 | 1x | IFB | [**`>_`**](#qwen3-vl-30b-a3b-instruct-ifb-bw1100-1x-vllm-018-hotfix) |
 |  | BF16 | 0.21 | BW1000 | 2x | IFB | [**`>_`**](#qwen3-vl-30b-a3b-instruct-ifb-bw1000-2x-vllm-021) |
-|                                                                               | BF16      | 0.18 | BW1000  | 2x | IFB | [**`>_`**](#qwen3-vl-30b-a3b-instruct-ifb-bw1000-2x-vllm-018) |
-|  | BF16 | 0.18-hotfix | BW1000 | 2x | IFB | [**`>_`**](#qwen3-vl-30b-a3b-instruct-ifb-bw1000-2x-vllm-018-hotfix) |
 |  | BF16 | 0.21 | K100_AI | 2x | IFB | [**`>_`**](#qwen3-vl-30b-a3b-instruct-ifb-k100_ai-2x-vllm-021) |
-|                                                                               | BF16      | 0.18 | K100_AI | 2x | IFB | [**`>_`**](#qwen3-vl-30b-a3b-instruct-ifb-k100_ai-2x-vllm-018) |
+|  | BF16 | 0.18 | BW1100 | 1x | IFB | [**`>_`**](#qwen3-vl-30b-a3b-instruct-ifb-bw1100-1x-vllm-018) |
+|  | BF16 | 0.18 | BW1000 | 2x | IFB | [**`>_`**](#qwen3-vl-30b-a3b-instruct-ifb-bw1000-2x-vllm-018) |
+|  | BF16 | 0.18 | K100_AI | 2x | IFB | [**`>_`**](#qwen3-vl-30b-a3b-instruct-ifb-k100_ai-2x-vllm-018) |
+|  | BF16 | 0.18-hotfix | BW1100 | 1x | IFB | [**`>_`**](#qwen3-vl-30b-a3b-instruct-ifb-bw1100-1x-vllm-018-hotfix) |
+|  | BF16 | 0.18-hotfix | BW1000 | 2x | IFB | [**`>_`**](#qwen3-vl-30b-a3b-instruct-ifb-bw1000-2x-vllm-018-hotfix) |
 |  | BF16 | 0.18-hotfix | K100_AI | 2x | IFB | [**`>_`**](#qwen3-vl-30b-a3b-instruct-ifb-k100_ai-2x-vllm-018-hotfix) |
 | [Qwen/Qwen3-VL-30B-A3B-Thinking](https://www.modelscope.cn/models/Qwen/Qwen3-VL-30B-A3B-Thinking) | BF16 | 0.21 | BW1100 | 1x | IFB | [**`>_`**](#qwen3-vl-30b-a3b-thinking-ifb-bw1100-1x-vllm-021) |
-|  | BF16 | 0.18 | BW1100  | 1x | IFB | [**`>_`**](#qwen3-vl-30b-a3b-thinking-ifb-bw1100-1x-vllm-018) |
-|  | BF16 | 0.18-hotfix | BW1100 | 1x | IFB | [**`>_`**](#qwen3-vl-30b-a3b-thinking-ifb-bw1100-1x-vllm-018-hotfix) |
 |  | BF16 | 0.21 | BW1000 | 2x | IFB | [**`>_`**](#qwen3-vl-30b-a3b-thinking-ifb-bw1000-2x-vllm-021) |
-|                                                                               | BF16      | 0.18 | BW1000  | 2x | IFB | [**`>_`**](#qwen3-vl-30b-a3b-thinking-ifb-bw1000-2x-vllm-018) |
-|  | BF16 | 0.18-hotfix | BW1000 | 2x | IFB | [**`>_`**](#qwen3-vl-30b-a3b-thinking-ifb-bw1000-2x-vllm-018-hotfix) |
 |  | BF16 | 0.21 | K100_AI | 2x | IFB | [**`>_`**](#qwen3-vl-30b-a3b-thinking-ifb-k100_ai-2x-vllm-021) |
-|                                                                               | BF16      | 0.18 | K100_AI | 2x | IFB | [**`>_`**](#qwen3-vl-30b-a3b-thinking-ifb-k100_ai-2x-vllm-018) |
+|  | BF16 | 0.18 | BW1100 | 1x | IFB | [**`>_`**](#qwen3-vl-30b-a3b-thinking-ifb-bw1100-1x-vllm-018) |
+|  | BF16 | 0.18 | BW1000 | 2x | IFB | [**`>_`**](#qwen3-vl-30b-a3b-thinking-ifb-bw1000-2x-vllm-018) |
+|  | BF16 | 0.18 | K100_AI | 2x | IFB | [**`>_`**](#qwen3-vl-30b-a3b-thinking-ifb-k100_ai-2x-vllm-018) |
+|  | BF16 | 0.18-hotfix | BW1100 | 1x | IFB | [**`>_`**](#qwen3-vl-30b-a3b-thinking-ifb-bw1100-1x-vllm-018-hotfix) |
+|  | BF16 | 0.18-hotfix | BW1000 | 2x | IFB | [**`>_`**](#qwen3-vl-30b-a3b-thinking-ifb-bw1000-2x-vllm-018-hotfix) |
 |  | BF16 | 0.18-hotfix | K100_AI | 2x | IFB | [**`>_`**](#qwen3-vl-30b-a3b-thinking-ifb-k100_ai-2x-vllm-018-hotfix) |
 | [Qwen/Qwen3-VL-32B-Instruct](https://www.modelscope.cn/models/Qwen/Qwen3-VL-32B-Instruct) | BF16 | 0.21 | BW1100 | 1x | IFB | [**`>_`**](#qwen3-vl-32b-instruct-ifb-bw1100-1x-vllm-021) |
-|  | BF16 | 0.18 | BW1100 | 1x | IFB | [**`>_`**](#qwen3-vl-32b-instruct-ifb-bw1100-1x-vllm-018) |
-|  | BF16 | 0.18-hotfix | BW1100 | 1x | IFB | [**`>_`**](#qwen3-vl-32b-instruct-ifb-bw1100-1x-vllm-018-hotfix) |
 |  | BF16 | 0.21 | BW1000 | 2x | IFB | [**`>_`**](#qwen3-vl-32b-instruct-ifb-bw1000-2x-vllm-021) |
-|                                                                               | BF16 | 0.18 | BW1000 | 2x | IFB | [**`>_`**](#qwen3-vl-32b-instruct-ifb-bw1000-2x-vllm-018) |
-|  | BF16 | 0.18-hotfix | BW1000 | 2x | IFB | [**`>_`**](#qwen3-vl-32b-instruct-ifb-bw1000-2x-vllm-018-hotfix) |
 |  | BF16 | 0.21 | K100_AI | 2x | IFB | [**`>_`**](#qwen3-vl-32b-instruct-ifb-k100_ai-2x-vllm-021) |
-|                                                                               | BF16 | 0.18 | K100_AI | 2x | IFB | [**`>_`**](#qwen3-vl-32b-instruct-ifb-k100_ai-2x-vllm-018) |
+|  | BF16 | 0.18 | BW1100 | 1x | IFB | [**`>_`**](#qwen3-vl-32b-instruct-ifb-bw1100-1x-vllm-018) |
+|  | BF16 | 0.18 | BW1000 | 2x | IFB | [**`>_`**](#qwen3-vl-32b-instruct-ifb-bw1000-2x-vllm-018) |
+|  | BF16 | 0.18 | K100_AI | 2x | IFB | [**`>_`**](#qwen3-vl-32b-instruct-ifb-k100_ai-2x-vllm-018) |
+|  | BF16 | 0.18-hotfix | BW1100 | 1x | IFB | [**`>_`**](#qwen3-vl-32b-instruct-ifb-bw1100-1x-vllm-018-hotfix) |
+|  | BF16 | 0.18-hotfix | BW1000 | 2x | IFB | [**`>_`**](#qwen3-vl-32b-instruct-ifb-bw1000-2x-vllm-018-hotfix) |
 |  | BF16 | 0.18-hotfix | K100_AI | 2x | IFB | [**`>_`**](#qwen3-vl-32b-instruct-ifb-k100_ai-2x-vllm-018-hotfix) |
 | [Qwen/Qwen3-VL-235B-A22B-Instruct](https://www.modelscope.cn/models/Qwen/Qwen3-VL-235B-A22B-Instruct) | BF16 | 0.21 | BW1100 | 8x | IFB | [**`>_`**](#qwen3-vl-235b-a22b-instruct-ifb-bw1100-8x-vllm-021) |
-|  | BF16 | 0.18 | BW1100  | 8x  | IFB | [**`>_`**](#qwen3-vl-235b-a22b-instruct-ifb-bw1100-8x-vllm-018) |
-|  | BF16 | 0.18-hotfix | BW1100 | 8x | IFB | [**`>_`**](#qwen3-vl-235b-a22b-instruct-ifb-bw1100-8x-vllm-018-hotfix) |
 |  | BF16 | 0.21 | BW1000 | 16x | IFB | [**`>_`**](#qwen3-vl-235b-a22b-instruct-ifb-bw1000-16x-vllm-021) |
-|                                                                               | BF16      | 0.18 | BW1000  | 16x | IFB | [**`>_`**](#qwen3-vl-235b-a22b-instruct-ifb-bw1000-16x-vllm-018) |
-|  | BF16 | 0.18-hotfix | BW1000 | 16x | IFB | [**`>_`**](#qwen3-vl-235b-a22b-instruct-ifb-bw1000-16x-vllm-018-hotfix) |
 |  | BF16 | 0.21 | K100_AI | 16x | IFB | [**`>_`**](#qwen3-vl-235b-a22b-instruct-ifb-k100_ai-16x-vllm-021) |
-|                                                                               | BF16      | 0.18 | K100_AI | 16x | IFB | [**`>_`**](#qwen3-vl-235b-a22b-instruct-ifb-k100_ai-16x-vllm-018) |
+|  | BF16 | 0.18 | BW1100 | 8x | IFB | [**`>_`**](#qwen3-vl-235b-a22b-instruct-ifb-bw1100-8x-vllm-018) |
+|  | BF16 | 0.18 | BW1000 | 16x | IFB | [**`>_`**](#qwen3-vl-235b-a22b-instruct-ifb-bw1000-16x-vllm-018) |
+|  | BF16 | 0.18 | K100_AI | 16x | IFB | [**`>_`**](#qwen3-vl-235b-a22b-instruct-ifb-k100_ai-16x-vllm-018) |
+|  | BF16 | 0.18-hotfix | BW1100 | 8x | IFB | [**`>_`**](#qwen3-vl-235b-a22b-instruct-ifb-bw1100-8x-vllm-018-hotfix) |
+|  | BF16 | 0.18-hotfix | BW1000 | 16x | IFB | [**`>_`**](#qwen3-vl-235b-a22b-instruct-ifb-bw1000-16x-vllm-018-hotfix) |
 |  | BF16 | 0.18-hotfix | K100_AI | 16x | IFB | [**`>_`**](#qwen3-vl-235b-a22b-instruct-ifb-k100_ai-16x-vllm-018-hotfix) |
 | [Qwen/Qwen3-VL-235B-A22B-Thinking](https://www.modelscope.cn/models/Qwen/Qwen3-VL-235B-A22B-Thinking) | BF16 | 0.21 | BW1100 | 8x | IFB | [**`>_`**](#qwen3-vl-235b-a22b-thinking-ifb-bw1100-8x-vllm-021) |
-|  | BF16 | 0.18 | BW1100  | 8x  | IFB | [**`>_`**](#qwen3-vl-235b-a22b-thinking-ifb-bw1100-8x-vllm-018) |
-|  | BF16 | 0.18-hotfix | BW1100 | 8x | IFB | [**`>_`**](#qwen3-vl-235b-a22b-thinking-ifb-bw1100-8x-vllm-018-hotfix) |
 |  | BF16 | 0.21 | BW1000 | 16x | IFB | [**`>_`**](#qwen3-vl-235b-a22b-thinking-ifb-bw1000-16x-vllm-021) |
-|                                                                               | BF16      | 0.18 | BW1000  | 16x | IFB | [**`>_`**](#qwen3-vl-235b-a22b-thinking-ifb-bw1000-16x-vllm-018) |
-|  | BF16 | 0.18-hotfix | BW1000 | 16x | IFB | [**`>_`**](#qwen3-vl-235b-a22b-thinking-ifb-bw1000-16x-vllm-018-hotfix) |
 |  | BF16 | 0.21 | K100_AI | 16x | IFB | [**`>_`**](#qwen3-vl-235b-a22b-thinking-ifb-k100_ai-16x-vllm-021) |
-|                                                                               | BF16      | 0.18 | K100_AI | 16x | IFB | [**`>_`**](#qwen3-vl-235b-a22b-thinking-ifb-k100_ai-16x-vllm-018) |
+|  | BF16 | 0.18 | BW1100 | 8x | IFB | [**`>_`**](#qwen3-vl-235b-a22b-thinking-ifb-bw1100-8x-vllm-018) |
+|  | BF16 | 0.18 | BW1000 | 16x | IFB | [**`>_`**](#qwen3-vl-235b-a22b-thinking-ifb-bw1000-16x-vllm-018) |
+|  | BF16 | 0.18 | K100_AI | 16x | IFB | [**`>_`**](#qwen3-vl-235b-a22b-thinking-ifb-k100_ai-16x-vllm-018) |
+|  | BF16 | 0.18-hotfix | BW1100 | 8x | IFB | [**`>_`**](#qwen3-vl-235b-a22b-thinking-ifb-bw1100-8x-vllm-018-hotfix) |
+|  | BF16 | 0.18-hotfix | BW1000 | 16x | IFB | [**`>_`**](#qwen3-vl-235b-a22b-thinking-ifb-bw1000-16x-vllm-018-hotfix) |
 |  | BF16 | 0.18-hotfix | K100_AI | 16x | IFB | [**`>_`**](#qwen3-vl-235b-a22b-thinking-ifb-k100_ai-16x-vllm-018-hotfix) |
-
 ---
 
 ## 启动命令
 
 ### Qwen3-VL-2B-Instruct IFB BW1100 1x vLLM 0.21
-
-```bash
-export VLLM_HCU_USE_PD_SPLIT=1
-export VLLM_USE_MODELSCOPE=1
-vllm serve Qwen/Qwen3-VL-2B-Instruct \
-  -tp 1 \
-  --trust-remote-code \
-  --kv-cache-dtype fp8_e4m3 \
-  --attention-backend FLASH_ATTN_CUSTOM
-```
-### Qwen3-VL-2B-Instruct IFB BW1100 1x vLLM 0.18
-```bash
-export VLLM_USE_MODELSCOPE=1
-export VLLM_HCU_USE_PD_SPLIT=1
-export VLLM_HCU_USE_CUSTOM_FLASH_ATTN=1
-vllm serve Qwen/Qwen3-VL-2B-Instruct \
-  -tp 1 \
-  --trust-remote-code 
-```
-
-### Qwen3-VL-2B-Instruct IFB BW1100 1x vLLM 0.18-hotfix
 
 ```bash
 export VLLM_HCU_USE_PD_SPLIT=1
@@ -166,7 +144,17 @@ vllm serve Qwen/Qwen3-VL-2B-Instruct \
   --trust-remote-code \
   --attention-backend FLASH_ATTN_CUSTOM
 ```
-### Qwen3-VL-2B-Instruct IFB BW1000 1x vLLM 0.18
+### Qwen3-VL-2B-Instruct IFB K100_AI 1x vLLM 0.21
+
+```bash
+export VLLM_HCU_USE_CUSTOM_QUANTIZATION_GEMM=0
+export VLLM_HCU_USE_CUSTOM_OPS=0
+export VLLM_USE_MODELSCOPE=1
+vllm serve Qwen/Qwen3-VL-2B-Instruct \
+  -tp 1 \
+  --trust-remote-code 
+```
+### Qwen3-VL-2B-Instruct IFB BW1100 1x vLLM 0.18
 ```bash
 export VLLM_USE_MODELSCOPE=1
 export VLLM_HCU_USE_PD_SPLIT=1
@@ -175,23 +163,11 @@ vllm serve Qwen/Qwen3-VL-2B-Instruct \
   -tp 1 \
   --trust-remote-code 
 ```
-
-### Qwen3-VL-2B-Instruct IFB BW1000 1x vLLM 0.18-hotfix
-
+### Qwen3-VL-2B-Instruct IFB BW1000 1x vLLM 0.18
 ```bash
+export VLLM_USE_MODELSCOPE=1
 export VLLM_HCU_USE_PD_SPLIT=1
-export VLLM_USE_MODELSCOPE=1
-vllm serve Qwen/Qwen3-VL-2B-Instruct \
-  -tp 1 \
-  --trust-remote-code \
-  --attention-backend FLASH_ATTN_CUSTOM
-```
-### Qwen3-VL-2B-Instruct IFB K100_AI 1x vLLM 0.21
-
-```bash
-export VLLM_HCU_USE_CUSTOM_QUANTIZATION_GEMM=0
-export VLLM_HCU_USE_CUSTOM_OPS=0
-export VLLM_USE_MODELSCOPE=1
+export VLLM_HCU_USE_CUSTOM_FLASH_ATTN=1
 vllm serve Qwen/Qwen3-VL-2B-Instruct \
   -tp 1 \
   --trust-remote-code 
@@ -205,7 +181,27 @@ vllm serve Qwen/Qwen3-VL-2B-Instruct \
   -tp 1 \
   --trust-remote-code 
 ```
+### Qwen3-VL-2B-Instruct IFB BW1100 1x vLLM 0.18-hotfix
 
+```bash
+export VLLM_HCU_USE_PD_SPLIT=1
+export VLLM_USE_MODELSCOPE=1
+vllm serve Qwen/Qwen3-VL-2B-Instruct \
+  -tp 1 \
+  --trust-remote-code \
+  --kv-cache-dtype fp8_e4m3 \
+  --attention-backend FLASH_ATTN_CUSTOM
+```
+### Qwen3-VL-2B-Instruct IFB BW1000 1x vLLM 0.18-hotfix
+
+```bash
+export VLLM_HCU_USE_PD_SPLIT=1
+export VLLM_USE_MODELSCOPE=1
+vllm serve Qwen/Qwen3-VL-2B-Instruct \
+  -tp 1 \
+  --trust-remote-code \
+  --attention-backend FLASH_ATTN_CUSTOM
+```
 ### Qwen3-VL-2B-Instruct IFB K100_AI 1x vLLM 0.18-hotfix
 
 ```bash
@@ -227,48 +223,7 @@ vllm serve Qwen/Qwen3-VL-2B-Thinking \
   --kv-cache-dtype fp8_e4m3 \
   --attention-backend FLASH_ATTN_CUSTOM
 ```
-### Qwen3-VL-2B-Thinking IFB BW1100 1x vLLM 0.18
-```bash
-export VLLM_USE_MODELSCOPE=1
-export VLLM_HCU_USE_PD_SPLIT=1
-export VLLM_HCU_USE_CUSTOM_FLASH_ATTN=1
-vllm serve Qwen/Qwen3-VL-2B-Thinking \
-  -tp 1 \
-  --trust-remote-code 
-```
-
-### Qwen3-VL-2B-Thinking IFB BW1100 1x vLLM 0.18-hotfix
-
-```bash
-export VLLM_HCU_USE_PD_SPLIT=1
-export VLLM_USE_MODELSCOPE=1
-vllm serve Qwen/Qwen3-VL-2B-Thinking \
-  -tp 1 \
-  --trust-remote-code \
-  --kv-cache-dtype fp8_e4m3 \
-  --attention-backend FLASH_ATTN_CUSTOM
-```
 ### Qwen3-VL-2B-Thinking IFB BW1000 1x vLLM 0.21
-
-```bash
-export VLLM_HCU_USE_PD_SPLIT=1
-export VLLM_USE_MODELSCOPE=1
-vllm serve Qwen/Qwen3-VL-2B-Thinking \
-  -tp 1 \
-  --trust-remote-code \
-  --attention-backend FLASH_ATTN_CUSTOM
-```
-### Qwen3-VL-2B-Thinking IFB BW1000 1x vLLM 0.18
-```bash
-export VLLM_USE_MODELSCOPE=1
-export VLLM_HCU_USE_PD_SPLIT=1
-export VLLM_HCU_USE_CUSTOM_FLASH_ATTN=1
-vllm serve Qwen/Qwen3-VL-2B-Thinking \
-  -tp 1 \
-  --trust-remote-code 
-```
-
-### Qwen3-VL-2B-Thinking IFB BW1000 1x vLLM 0.18-hotfix
 
 ```bash
 export VLLM_HCU_USE_PD_SPLIT=1
@@ -288,6 +243,24 @@ vllm serve Qwen/Qwen3-VL-2B-Thinking \
   -tp 1 \
   --trust-remote-code 
 ```
+### Qwen3-VL-2B-Thinking IFB BW1100 1x vLLM 0.18
+```bash
+export VLLM_USE_MODELSCOPE=1
+export VLLM_HCU_USE_PD_SPLIT=1
+export VLLM_HCU_USE_CUSTOM_FLASH_ATTN=1
+vllm serve Qwen/Qwen3-VL-2B-Thinking \
+  -tp 1 \
+  --trust-remote-code 
+```
+### Qwen3-VL-2B-Thinking IFB BW1000 1x vLLM 0.18
+```bash
+export VLLM_USE_MODELSCOPE=1
+export VLLM_HCU_USE_PD_SPLIT=1
+export VLLM_HCU_USE_CUSTOM_FLASH_ATTN=1
+vllm serve Qwen/Qwen3-VL-2B-Thinking \
+  -tp 1 \
+  --trust-remote-code 
+```
 ### Qwen3-VL-2B-Thinking IFB K100_AI 1x vLLM 0.18
 ```bash
 export VLLM_HCU_USE_CUSTOM_QUANTIZATION_GEMM=0
@@ -297,7 +270,27 @@ vllm serve Qwen/Qwen3-VL-2B-Thinking \
   -tp 1 \
   --trust-remote-code 
 ```
+### Qwen3-VL-2B-Thinking IFB BW1100 1x vLLM 0.18-hotfix
 
+```bash
+export VLLM_HCU_USE_PD_SPLIT=1
+export VLLM_USE_MODELSCOPE=1
+vllm serve Qwen/Qwen3-VL-2B-Thinking \
+  -tp 1 \
+  --trust-remote-code \
+  --kv-cache-dtype fp8_e4m3 \
+  --attention-backend FLASH_ATTN_CUSTOM
+```
+### Qwen3-VL-2B-Thinking IFB BW1000 1x vLLM 0.18-hotfix
+
+```bash
+export VLLM_HCU_USE_PD_SPLIT=1
+export VLLM_USE_MODELSCOPE=1
+vllm serve Qwen/Qwen3-VL-2B-Thinking \
+  -tp 1 \
+  --trust-remote-code \
+  --attention-backend FLASH_ATTN_CUSTOM
+```
 ### Qwen3-VL-2B-Thinking IFB K100_AI 1x vLLM 0.18-hotfix
 
 ```bash
@@ -319,48 +312,7 @@ vllm serve Qwen/Qwen3-VL-4B-Instruct \
   --kv-cache-dtype fp8_e4m3 \
   --attention-backend FLASH_ATTN_CUSTOM
 ```
-### Qwen3-VL-4B-Instruct IFB BW1100 1x vLLM 0.18
-```bash
-export VLLM_USE_MODELSCOPE=1
-export VLLM_HCU_USE_PD_SPLIT=1
-export VLLM_HCU_USE_CUSTOM_FLASH_ATTN=1
-vllm serve Qwen/Qwen3-VL-4B-Instruct \
-  -tp 1 \
-  --trust-remote-code 
-```
-
-### Qwen3-VL-4B-Instruct IFB BW1100 1x vLLM 0.18-hotfix
-
-```bash
-export VLLM_HCU_USE_PD_SPLIT=1
-export VLLM_USE_MODELSCOPE=1
-vllm serve Qwen/Qwen3-VL-4B-Instruct \
-  -tp 1 \
-  --trust-remote-code \
-  --kv-cache-dtype fp8_e4m3 \
-  --attention-backend FLASH_ATTN_CUSTOM
-```
 ### Qwen3-VL-4B-Instruct IFB BW1000 1x vLLM 0.21
-
-```bash
-export VLLM_HCU_USE_PD_SPLIT=1
-export VLLM_USE_MODELSCOPE=1
-vllm serve Qwen/Qwen3-VL-4B-Instruct \
-  -tp 1 \
-  --trust-remote-code \
-  --attention-backend FLASH_ATTN_CUSTOM
-```
-### Qwen3-VL-4B-Instruct IFB BW1000 1x vLLM 0.18
-```bash
-export VLLM_USE_MODELSCOPE=1
-export VLLM_HCU_USE_PD_SPLIT=1
-export VLLM_HCU_USE_CUSTOM_FLASH_ATTN=1
-vllm serve Qwen/Qwen3-VL-4B-Instruct \
-  -tp 1 \
-  --trust-remote-code 
-```
-
-### Qwen3-VL-4B-Instruct IFB BW1000 1x vLLM 0.18-hotfix
 
 ```bash
 export VLLM_HCU_USE_PD_SPLIT=1
@@ -380,6 +332,24 @@ vllm serve Qwen/Qwen3-VL-4B-Instruct \
   -tp 1 \
   --trust-remote-code 
 ```
+### Qwen3-VL-4B-Instruct IFB BW1100 1x vLLM 0.18
+```bash
+export VLLM_USE_MODELSCOPE=1
+export VLLM_HCU_USE_PD_SPLIT=1
+export VLLM_HCU_USE_CUSTOM_FLASH_ATTN=1
+vllm serve Qwen/Qwen3-VL-4B-Instruct \
+  -tp 1 \
+  --trust-remote-code 
+```
+### Qwen3-VL-4B-Instruct IFB BW1000 1x vLLM 0.18
+```bash
+export VLLM_USE_MODELSCOPE=1
+export VLLM_HCU_USE_PD_SPLIT=1
+export VLLM_HCU_USE_CUSTOM_FLASH_ATTN=1
+vllm serve Qwen/Qwen3-VL-4B-Instruct \
+  -tp 1 \
+  --trust-remote-code 
+```
 ### Qwen3-VL-4B-Instruct IFB K100_AI 1x vLLM 0.18
 ```bash
 export VLLM_HCU_USE_CUSTOM_QUANTIZATION_GEMM=0
@@ -389,7 +359,27 @@ vllm serve Qwen/Qwen3-VL-4B-Instruct \
   -tp 1 \
   --trust-remote-code 
 ```
+### Qwen3-VL-4B-Instruct IFB BW1100 1x vLLM 0.18-hotfix
 
+```bash
+export VLLM_HCU_USE_PD_SPLIT=1
+export VLLM_USE_MODELSCOPE=1
+vllm serve Qwen/Qwen3-VL-4B-Instruct \
+  -tp 1 \
+  --trust-remote-code \
+  --kv-cache-dtype fp8_e4m3 \
+  --attention-backend FLASH_ATTN_CUSTOM
+```
+### Qwen3-VL-4B-Instruct IFB BW1000 1x vLLM 0.18-hotfix
+
+```bash
+export VLLM_HCU_USE_PD_SPLIT=1
+export VLLM_USE_MODELSCOPE=1
+vllm serve Qwen/Qwen3-VL-4B-Instruct \
+  -tp 1 \
+  --trust-remote-code \
+  --attention-backend FLASH_ATTN_CUSTOM
+```
 ### Qwen3-VL-4B-Instruct IFB K100_AI 1x vLLM 0.18-hotfix
 
 ```bash
@@ -411,48 +401,7 @@ vllm serve Qwen/Qwen3-VL-4B-Thinking \
   --kv-cache-dtype fp8_e4m3 \
   --attention-backend FLASH_ATTN_CUSTOM
 ```
-### Qwen3-VL-4B-Thinking IFB BW1100 1x vLLM 0.18
-```bash
-export VLLM_USE_MODELSCOPE=1
-export VLLM_HCU_USE_PD_SPLIT=1
-export VLLM_HCU_USE_CUSTOM_FLASH_ATTN=1
-vllm serve Qwen/Qwen3-VL-4B-Thinking \
-  -tp 1 \
-  --trust-remote-code 
-```
-
-### Qwen3-VL-4B-Thinking IFB BW1100 1x vLLM 0.18-hotfix
-
-```bash
-export VLLM_HCU_USE_PD_SPLIT=1
-export VLLM_USE_MODELSCOPE=1
-vllm serve Qwen/Qwen3-VL-4B-Thinking \
-  -tp 1 \
-  --trust-remote-code \
-  --kv-cache-dtype fp8_e4m3 \
-  --attention-backend FLASH_ATTN_CUSTOM
-```
 ### Qwen3-VL-4B-Thinking IFB BW1000 1x vLLM 0.21
-
-```bash
-export VLLM_HCU_USE_PD_SPLIT=1
-export VLLM_USE_MODELSCOPE=1
-vllm serve Qwen/Qwen3-VL-4B-Thinking \
-  -tp 1 \
-  --trust-remote-code \
-  --attention-backend FLASH_ATTN_CUSTOM
-```
-### Qwen3-VL-4B-Thinking IFB BW1000 1x vLLM 0.18
-```bash
-export VLLM_USE_MODELSCOPE=1
-export VLLM_HCU_USE_PD_SPLIT=1
-export VLLM_HCU_USE_CUSTOM_FLASH_ATTN=1
-vllm serve Qwen/Qwen3-VL-4B-Thinking \
-  -tp 1 \
-  --trust-remote-code 
-```
-
-### Qwen3-VL-4B-Thinking IFB BW1000 1x vLLM 0.18-hotfix
 
 ```bash
 export VLLM_HCU_USE_PD_SPLIT=1
@@ -472,6 +421,24 @@ vllm serve Qwen/Qwen3-VL-4B-Thinking \
   -tp 1 \
   --trust-remote-code 
 ```
+### Qwen3-VL-4B-Thinking IFB BW1100 1x vLLM 0.18
+```bash
+export VLLM_USE_MODELSCOPE=1
+export VLLM_HCU_USE_PD_SPLIT=1
+export VLLM_HCU_USE_CUSTOM_FLASH_ATTN=1
+vllm serve Qwen/Qwen3-VL-4B-Thinking \
+  -tp 1 \
+  --trust-remote-code 
+```
+### Qwen3-VL-4B-Thinking IFB BW1000 1x vLLM 0.18
+```bash
+export VLLM_USE_MODELSCOPE=1
+export VLLM_HCU_USE_PD_SPLIT=1
+export VLLM_HCU_USE_CUSTOM_FLASH_ATTN=1
+vllm serve Qwen/Qwen3-VL-4B-Thinking \
+  -tp 1 \
+  --trust-remote-code 
+```
 ### Qwen3-VL-4B-Thinking IFB K100_AI 1x vLLM 0.18
 ```bash
 export VLLM_HCU_USE_CUSTOM_QUANTIZATION_GEMM=0
@@ -481,7 +448,27 @@ vllm serve Qwen/Qwen3-VL-4B-Thinking \
   -tp 1 \
   --trust-remote-code 
 ```
+### Qwen3-VL-4B-Thinking IFB BW1100 1x vLLM 0.18-hotfix
 
+```bash
+export VLLM_HCU_USE_PD_SPLIT=1
+export VLLM_USE_MODELSCOPE=1
+vllm serve Qwen/Qwen3-VL-4B-Thinking \
+  -tp 1 \
+  --trust-remote-code \
+  --kv-cache-dtype fp8_e4m3 \
+  --attention-backend FLASH_ATTN_CUSTOM
+```
+### Qwen3-VL-4B-Thinking IFB BW1000 1x vLLM 0.18-hotfix
+
+```bash
+export VLLM_HCU_USE_PD_SPLIT=1
+export VLLM_USE_MODELSCOPE=1
+vllm serve Qwen/Qwen3-VL-4B-Thinking \
+  -tp 1 \
+  --trust-remote-code \
+  --attention-backend FLASH_ATTN_CUSTOM
+```
 ### Qwen3-VL-4B-Thinking IFB K100_AI 1x vLLM 0.18-hotfix
 
 ```bash
@@ -503,48 +490,7 @@ vllm serve Qwen/Qwen3-VL-8B-Instruct \
   --kv-cache-dtype fp8_e4m3 \
   --attention-backend FLASH_ATTN_CUSTOM
 ```
-### Qwen3-VL-8B-Instruct IFB BW1100 1x vLLM 0.18
-```bash
-export VLLM_USE_MODELSCOPE=1
-export VLLM_HCU_USE_PD_SPLIT=1
-export VLLM_HCU_USE_CUSTOM_FLASH_ATTN=1
-vllm serve Qwen/Qwen3-VL-8B-Instruct \
-  -tp 1 \
-  --trust-remote-code 
-```
-
-### Qwen3-VL-8B-Instruct IFB BW1100 1x vLLM 0.18-hotfix
-
-```bash
-export VLLM_HCU_USE_PD_SPLIT=1
-export VLLM_USE_MODELSCOPE=1
-vllm serve Qwen/Qwen3-VL-8B-Instruct \
-  -tp 1 \
-  --trust-remote-code \
-  --kv-cache-dtype fp8_e4m3 \
-  --attention-backend FLASH_ATTN_CUSTOM
-```
 ### Qwen3-VL-8B-Instruct IFB BW1000 1x vLLM 0.21
-
-```bash
-export VLLM_HCU_USE_PD_SPLIT=1
-export VLLM_USE_MODELSCOPE=1
-vllm serve Qwen/Qwen3-VL-8B-Instruct \
-  -tp 1 \
-  --trust-remote-code \
-  --attention-backend FLASH_ATTN_CUSTOM
-```
-### Qwen3-VL-8B-Instruct IFB BW1000 1x vLLM 0.18
-```bash
-export VLLM_USE_MODELSCOPE=1
-export VLLM_HCU_USE_PD_SPLIT=1
-export VLLM_HCU_USE_CUSTOM_FLASH_ATTN=1
-vllm serve Qwen/Qwen3-VL-8B-Instruct \
-  -tp 1 \
-  --trust-remote-code 
-```
-
-### Qwen3-VL-8B-Instruct IFB BW1000 1x vLLM 0.18-hotfix
 
 ```bash
 export VLLM_HCU_USE_PD_SPLIT=1
@@ -564,6 +510,24 @@ vllm serve Qwen/Qwen3-VL-8B-Instruct \
   -tp 1 \
   --trust-remote-code 
 ```
+### Qwen3-VL-8B-Instruct IFB BW1100 1x vLLM 0.18
+```bash
+export VLLM_USE_MODELSCOPE=1
+export VLLM_HCU_USE_PD_SPLIT=1
+export VLLM_HCU_USE_CUSTOM_FLASH_ATTN=1
+vllm serve Qwen/Qwen3-VL-8B-Instruct \
+  -tp 1 \
+  --trust-remote-code 
+```
+### Qwen3-VL-8B-Instruct IFB BW1000 1x vLLM 0.18
+```bash
+export VLLM_USE_MODELSCOPE=1
+export VLLM_HCU_USE_PD_SPLIT=1
+export VLLM_HCU_USE_CUSTOM_FLASH_ATTN=1
+vllm serve Qwen/Qwen3-VL-8B-Instruct \
+  -tp 1 \
+  --trust-remote-code 
+```
 ### Qwen3-VL-8B-Instruct IFB K100_AI 1x vLLM 0.18
 ```bash
 export VLLM_HCU_USE_CUSTOM_QUANTIZATION_GEMM=0
@@ -573,7 +537,27 @@ vllm serve Qwen/Qwen3-VL-8B-Instruct \
   -tp 1 \
   --trust-remote-code 
 ```
+### Qwen3-VL-8B-Instruct IFB BW1100 1x vLLM 0.18-hotfix
 
+```bash
+export VLLM_HCU_USE_PD_SPLIT=1
+export VLLM_USE_MODELSCOPE=1
+vllm serve Qwen/Qwen3-VL-8B-Instruct \
+  -tp 1 \
+  --trust-remote-code \
+  --kv-cache-dtype fp8_e4m3 \
+  --attention-backend FLASH_ATTN_CUSTOM
+```
+### Qwen3-VL-8B-Instruct IFB BW1000 1x vLLM 0.18-hotfix
+
+```bash
+export VLLM_HCU_USE_PD_SPLIT=1
+export VLLM_USE_MODELSCOPE=1
+vllm serve Qwen/Qwen3-VL-8B-Instruct \
+  -tp 1 \
+  --trust-remote-code \
+  --attention-backend FLASH_ATTN_CUSTOM
+```
 ### Qwen3-VL-8B-Instruct IFB K100_AI 1x vLLM 0.18-hotfix
 
 ```bash
@@ -595,48 +579,7 @@ vllm serve Qwen/Qwen3-VL-8B-Thinking \
   --kv-cache-dtype fp8_e4m3 \
   --attention-backend FLASH_ATTN_CUSTOM
 ```
-### Qwen3-VL-8B-Thinking IFB BW1100 1x vLLM 0.18
-```bash
-export VLLM_USE_MODELSCOPE=1
-export VLLM_HCU_USE_PD_SPLIT=1
-export VLLM_HCU_USE_CUSTOM_FLASH_ATTN=1
-vllm serve Qwen/Qwen3-VL-8B-Thinking \
-  -tp 1 \
-  --trust-remote-code 
-```
-
-### Qwen3-VL-8B-Thinking IFB BW1100 1x vLLM 0.18-hotfix
-
-```bash
-export VLLM_HCU_USE_PD_SPLIT=1
-export VLLM_USE_MODELSCOPE=1
-vllm serve Qwen/Qwen3-VL-8B-Thinking \
-  -tp 1 \
-  --trust-remote-code \
-  --kv-cache-dtype fp8_e4m3 \
-  --attention-backend FLASH_ATTN_CUSTOM
-```
 ### Qwen3-VL-8B-Thinking IFB BW1000 1x vLLM 0.21
-
-```bash
-export VLLM_HCU_USE_PD_SPLIT=1
-export VLLM_USE_MODELSCOPE=1
-vllm serve Qwen/Qwen3-VL-8B-Thinking \
-  -tp 1 \
-  --trust-remote-code \
-  --attention-backend FLASH_ATTN_CUSTOM
-```
-### Qwen3-VL-8B-Thinking IFB BW1000 1x vLLM 0.18
-```bash
-export VLLM_USE_MODELSCOPE=1
-export VLLM_HCU_USE_PD_SPLIT=1
-export VLLM_HCU_USE_CUSTOM_FLASH_ATTN=1
-vllm serve Qwen/Qwen3-VL-8B-Thinking \
-  -tp 1 \
-  --trust-remote-code 
-```
-
-### Qwen3-VL-8B-Thinking IFB BW1000 1x vLLM 0.18-hotfix
 
 ```bash
 export VLLM_HCU_USE_PD_SPLIT=1
@@ -656,6 +599,24 @@ vllm serve Qwen/Qwen3-VL-8B-Thinking \
   -tp 1 \
   --trust-remote-code 
 ```
+### Qwen3-VL-8B-Thinking IFB BW1100 1x vLLM 0.18
+```bash
+export VLLM_USE_MODELSCOPE=1
+export VLLM_HCU_USE_PD_SPLIT=1
+export VLLM_HCU_USE_CUSTOM_FLASH_ATTN=1
+vllm serve Qwen/Qwen3-VL-8B-Thinking \
+  -tp 1 \
+  --trust-remote-code 
+```
+### Qwen3-VL-8B-Thinking IFB BW1000 1x vLLM 0.18
+```bash
+export VLLM_USE_MODELSCOPE=1
+export VLLM_HCU_USE_PD_SPLIT=1
+export VLLM_HCU_USE_CUSTOM_FLASH_ATTN=1
+vllm serve Qwen/Qwen3-VL-8B-Thinking \
+  -tp 1 \
+  --trust-remote-code 
+```
 ### Qwen3-VL-8B-Thinking IFB K100_AI 1x vLLM 0.18
 ```bash
 export VLLM_HCU_USE_CUSTOM_QUANTIZATION_GEMM=0
@@ -665,7 +626,27 @@ vllm serve Qwen/Qwen3-VL-8B-Thinking \
   -tp 1 \
   --trust-remote-code 
 ```
+### Qwen3-VL-8B-Thinking IFB BW1100 1x vLLM 0.18-hotfix
 
+```bash
+export VLLM_HCU_USE_PD_SPLIT=1
+export VLLM_USE_MODELSCOPE=1
+vllm serve Qwen/Qwen3-VL-8B-Thinking \
+  -tp 1 \
+  --trust-remote-code \
+  --kv-cache-dtype fp8_e4m3 \
+  --attention-backend FLASH_ATTN_CUSTOM
+```
+### Qwen3-VL-8B-Thinking IFB BW1000 1x vLLM 0.18-hotfix
+
+```bash
+export VLLM_HCU_USE_PD_SPLIT=1
+export VLLM_USE_MODELSCOPE=1
+vllm serve Qwen/Qwen3-VL-8B-Thinking \
+  -tp 1 \
+  --trust-remote-code \
+  --attention-backend FLASH_ATTN_CUSTOM
+```
 ### Qwen3-VL-8B-Thinking IFB K100_AI 1x vLLM 0.18-hotfix
 
 ```bash
@@ -687,52 +668,11 @@ vllm serve Qwen/Qwen3-VL-30B-A3B-Instruct \
   --kv-cache-dtype fp8_e4m3 \
   --attention-backend FLASH_ATTN_CUSTOM
 ```
-### Qwen3-VL-30B-A3B-Instruct IFB BW1100 1x vLLM 0.18
-```bash
-export VLLM_USE_MODELSCOPE=1
-export VLLM_HCU_USE_PD_SPLIT=1
-export VLLM_HCU_USE_CUSTOM_FLASH_ATTN=1
-vllm serve Qwen/Qwen3-VL-30B-A3B-Instruct \
-  -tp 1 \
-  --trust-remote-code 
-```
-
-### Qwen3-VL-30B-A3B-Instruct IFB BW1100 1x vLLM 0.18-hotfix
-
-```bash
-export VLLM_HCU_USE_PD_SPLIT=1
-export VLLM_USE_MODELSCOPE=1
-vllm serve Qwen/Qwen3-VL-30B-A3B-Instruct \
-  -tp 1 \
-  --trust-remote-code \
-  --kv-cache-dtype fp8_e4m3 \
-  --attention-backend FLASH_ATTN_CUSTOM
-```
 ### Qwen3-VL-30B-A3B-Instruct IFB BW1000 2x vLLM 0.21
 
 ```bash
 export VLLM_ROCM_USE_AITER=0
 
-vllm serve Qwen/Qwen3-VL-30B-A3B-Instruct \
-  -tp 2 \
-  --trust-remote-code \
-  --attention-backend FLASH_ATTN_CUSTOM
-```
-### Qwen3-VL-30B-A3B-Instruct IFB BW1000 2x vLLM 0.18
-```bash
-export VLLM_USE_MODELSCOPE=1
-export VLLM_HCU_USE_PD_SPLIT=1
-export VLLM_HCU_USE_CUSTOM_FLASH_ATTN=1
-vllm serve Qwen/Qwen3-VL-30B-A3B-Instruct \
-  -tp 2 \
-  --trust-remote-code 
-```
-
-### Qwen3-VL-30B-A3B-Instruct IFB BW1000 2x vLLM 0.18-hotfix
-
-```bash
-export VLLM_HCU_USE_PD_SPLIT=1
-export VLLM_USE_MODELSCOPE=1
 vllm serve Qwen/Qwen3-VL-30B-A3B-Instruct \
   -tp 2 \
   --trust-remote-code \
@@ -748,6 +688,24 @@ vllm serve Qwen/Qwen3-VL-30B-A3B-Instruct \
   -tp 2 \
   --trust-remote-code 
 ```
+### Qwen3-VL-30B-A3B-Instruct IFB BW1100 1x vLLM 0.18
+```bash
+export VLLM_USE_MODELSCOPE=1
+export VLLM_HCU_USE_PD_SPLIT=1
+export VLLM_HCU_USE_CUSTOM_FLASH_ATTN=1
+vllm serve Qwen/Qwen3-VL-30B-A3B-Instruct \
+  -tp 1 \
+  --trust-remote-code 
+```
+### Qwen3-VL-30B-A3B-Instruct IFB BW1000 2x vLLM 0.18
+```bash
+export VLLM_USE_MODELSCOPE=1
+export VLLM_HCU_USE_PD_SPLIT=1
+export VLLM_HCU_USE_CUSTOM_FLASH_ATTN=1
+vllm serve Qwen/Qwen3-VL-30B-A3B-Instruct \
+  -tp 2 \
+  --trust-remote-code 
+```
 ### Qwen3-VL-30B-A3B-Instruct IFB K100_AI 2x vLLM 0.18
 ```bash
 export VLLM_HCU_USE_CUSTOM_QUANTIZATION_GEMM=0
@@ -757,7 +715,27 @@ vllm serve Qwen/Qwen3-VL-30B-A3B-Instruct \
   -tp 2 \
   --trust-remote-code 
 ```
+### Qwen3-VL-30B-A3B-Instruct IFB BW1100 1x vLLM 0.18-hotfix
 
+```bash
+export VLLM_HCU_USE_PD_SPLIT=1
+export VLLM_USE_MODELSCOPE=1
+vllm serve Qwen/Qwen3-VL-30B-A3B-Instruct \
+  -tp 1 \
+  --trust-remote-code \
+  --kv-cache-dtype fp8_e4m3 \
+  --attention-backend FLASH_ATTN_CUSTOM
+```
+### Qwen3-VL-30B-A3B-Instruct IFB BW1000 2x vLLM 0.18-hotfix
+
+```bash
+export VLLM_HCU_USE_PD_SPLIT=1
+export VLLM_USE_MODELSCOPE=1
+vllm serve Qwen/Qwen3-VL-30B-A3B-Instruct \
+  -tp 2 \
+  --trust-remote-code \
+  --attention-backend FLASH_ATTN_CUSTOM
+```
 ### Qwen3-VL-30B-A3B-Instruct IFB K100_AI 2x vLLM 0.18-hotfix
 
 ```bash
@@ -779,48 +757,7 @@ vllm serve Qwen/Qwen3-VL-30B-A3B-Thinking \
   --kv-cache-dtype fp8_e4m3 \
   --attention-backend FLASH_ATTN_CUSTOM
 ```
-### Qwen3-VL-30B-A3B-Thinking IFB BW1100 1x vLLM 0.18
-```bash
-export VLLM_USE_MODELSCOPE=1
-export VLLM_HCU_USE_PD_SPLIT=1
-export VLLM_HCU_USE_CUSTOM_FLASH_ATTN=1
-vllm serve Qwen/Qwen3-VL-30B-A3B-Thinking \
-  -tp 1 \
-  --trust-remote-code 
-```
-
-### Qwen3-VL-30B-A3B-Thinking IFB BW1100 1x vLLM 0.18-hotfix
-
-```bash
-export VLLM_HCU_USE_PD_SPLIT=1
-export VLLM_USE_MODELSCOPE=1
-vllm serve Qwen/Qwen3-VL-30B-A3B-Thinking \
-  -tp 1 \
-  --trust-remote-code \
-  --kv-cache-dtype fp8_e4m3 \
-  --attention-backend FLASH_ATTN_CUSTOM
-```
 ### Qwen3-VL-30B-A3B-Thinking IFB BW1000 2x vLLM 0.21
-
-```bash
-export VLLM_HCU_USE_PD_SPLIT=1
-export VLLM_USE_MODELSCOPE=1
-vllm serve Qwen/Qwen3-VL-30B-A3B-Thinking \
-  -tp 2 \
-  --trust-remote-code \
-  --attention-backend FLASH_ATTN_CUSTOM
-```
-### Qwen3-VL-30B-A3B-Thinking IFB BW1000 2x vLLM 0.18
-```bash
-export VLLM_USE_MODELSCOPE=1
-export VLLM_HCU_USE_PD_SPLIT=1
-export VLLM_HCU_USE_CUSTOM_FLASH_ATTN=1
-vllm serve Qwen/Qwen3-VL-30B-A3B-Thinking \
-  -tp 2 \
-  --trust-remote-code 
-```
-
-### Qwen3-VL-30B-A3B-Thinking IFB BW1000 2x vLLM 0.18-hotfix
 
 ```bash
 export VLLM_HCU_USE_PD_SPLIT=1
@@ -840,6 +777,24 @@ vllm serve Qwen/Qwen3-VL-30B-A3B-Thinking \
   -tp 2 \
   --trust-remote-code 
 ```
+### Qwen3-VL-30B-A3B-Thinking IFB BW1100 1x vLLM 0.18
+```bash
+export VLLM_USE_MODELSCOPE=1
+export VLLM_HCU_USE_PD_SPLIT=1
+export VLLM_HCU_USE_CUSTOM_FLASH_ATTN=1
+vllm serve Qwen/Qwen3-VL-30B-A3B-Thinking \
+  -tp 1 \
+  --trust-remote-code 
+```
+### Qwen3-VL-30B-A3B-Thinking IFB BW1000 2x vLLM 0.18
+```bash
+export VLLM_USE_MODELSCOPE=1
+export VLLM_HCU_USE_PD_SPLIT=1
+export VLLM_HCU_USE_CUSTOM_FLASH_ATTN=1
+vllm serve Qwen/Qwen3-VL-30B-A3B-Thinking \
+  -tp 2 \
+  --trust-remote-code 
+```
 ### Qwen3-VL-30B-A3B-Thinking IFB K100_AI 2x vLLM 0.18
 ```bash
 export VLLM_HCU_USE_CUSTOM_QUANTIZATION_GEMM=0
@@ -849,7 +804,27 @@ vllm serve Qwen/Qwen3-VL-30B-A3B-Thinking \
   -tp 2 \
   --trust-remote-code 
 ```
+### Qwen3-VL-30B-A3B-Thinking IFB BW1100 1x vLLM 0.18-hotfix
 
+```bash
+export VLLM_HCU_USE_PD_SPLIT=1
+export VLLM_USE_MODELSCOPE=1
+vllm serve Qwen/Qwen3-VL-30B-A3B-Thinking \
+  -tp 1 \
+  --trust-remote-code \
+  --kv-cache-dtype fp8_e4m3 \
+  --attention-backend FLASH_ATTN_CUSTOM
+```
+### Qwen3-VL-30B-A3B-Thinking IFB BW1000 2x vLLM 0.18-hotfix
+
+```bash
+export VLLM_HCU_USE_PD_SPLIT=1
+export VLLM_USE_MODELSCOPE=1
+vllm serve Qwen/Qwen3-VL-30B-A3B-Thinking \
+  -tp 2 \
+  --trust-remote-code \
+  --attention-backend FLASH_ATTN_CUSTOM
+```
 ### Qwen3-VL-30B-A3B-Thinking IFB K100_AI 2x vLLM 0.18-hotfix
 
 ```bash
@@ -871,48 +846,7 @@ vllm serve Qwen/Qwen3-VL-32B-Instruct \
   --kv-cache-dtype fp8_e4m3 \
   --attention-backend FLASH_ATTN_CUSTOM
 ```
-### Qwen3-VL-32B-Instruct IFB BW1100 1x vLLM 0.18
-```bash
-export VLLM_USE_MODELSCOPE=1
-export VLLM_HCU_USE_PD_SPLIT=1
-export VLLM_HCU_USE_CUSTOM_FLASH_ATTN=1
-vllm serve Qwen/Qwen3-VL-32B-Instruct \
-  -tp 1 \
-  --trust-remote-code 
-```
-
-### Qwen3-VL-32B-Instruct IFB BW1100 1x vLLM 0.18-hotfix
-
-```bash
-export VLLM_HCU_USE_PD_SPLIT=1
-export VLLM_USE_MODELSCOPE=1
-vllm serve Qwen/Qwen3-VL-32B-Instruct \
-  -tp 1 \
-  --trust-remote-code \
-  --kv-cache-dtype fp8_e4m3 \
-  --attention-backend FLASH_ATTN_CUSTOM
-```
 ### Qwen3-VL-32B-Instruct IFB BW1000 2x vLLM 0.21
-
-```bash
-export VLLM_HCU_USE_PD_SPLIT=1
-export VLLM_USE_MODELSCOPE=1
-vllm serve Qwen/Qwen3-VL-32B-Instruct \
-  -tp 2 \
-  --trust-remote-code \
-  --attention-backend FLASH_ATTN_CUSTOM
-```
-### Qwen3-VL-32B-Instruct IFB BW1000 2x vLLM 0.18
-```bash
-export VLLM_USE_MODELSCOPE=1
-export VLLM_HCU_USE_PD_SPLIT=1
-export VLLM_HCU_USE_CUSTOM_FLASH_ATTN=1
-vllm serve Qwen/Qwen3-VL-32B-Instruct \
-  -tp 2 \
-  --trust-remote-code 
-```
-
-### Qwen3-VL-32B-Instruct IFB BW1000 2x vLLM 0.18-hotfix
 
 ```bash
 export VLLM_HCU_USE_PD_SPLIT=1
@@ -932,6 +866,24 @@ vllm serve Qwen/Qwen3-VL-32B-Instruct \
   -tp 2 \
   --trust-remote-code 
 ```
+### Qwen3-VL-32B-Instruct IFB BW1100 1x vLLM 0.18
+```bash
+export VLLM_USE_MODELSCOPE=1
+export VLLM_HCU_USE_PD_SPLIT=1
+export VLLM_HCU_USE_CUSTOM_FLASH_ATTN=1
+vllm serve Qwen/Qwen3-VL-32B-Instruct \
+  -tp 1 \
+  --trust-remote-code 
+```
+### Qwen3-VL-32B-Instruct IFB BW1000 2x vLLM 0.18
+```bash
+export VLLM_USE_MODELSCOPE=1
+export VLLM_HCU_USE_PD_SPLIT=1
+export VLLM_HCU_USE_CUSTOM_FLASH_ATTN=1
+vllm serve Qwen/Qwen3-VL-32B-Instruct \
+  -tp 2 \
+  --trust-remote-code 
+```
 ### Qwen3-VL-32B-Instruct IFB K100_AI 2x vLLM 0.18
 ```bash
 export VLLM_HCU_USE_CUSTOM_QUANTIZATION_GEMM=0
@@ -941,7 +893,27 @@ vllm serve Qwen/Qwen3-VL-32B-Instruct \
   -tp 2 \
   --trust-remote-code 
 ```
+### Qwen3-VL-32B-Instruct IFB BW1100 1x vLLM 0.18-hotfix
 
+```bash
+export VLLM_HCU_USE_PD_SPLIT=1
+export VLLM_USE_MODELSCOPE=1
+vllm serve Qwen/Qwen3-VL-32B-Instruct \
+  -tp 1 \
+  --trust-remote-code \
+  --kv-cache-dtype fp8_e4m3 \
+  --attention-backend FLASH_ATTN_CUSTOM
+```
+### Qwen3-VL-32B-Instruct IFB BW1000 2x vLLM 0.18-hotfix
+
+```bash
+export VLLM_HCU_USE_PD_SPLIT=1
+export VLLM_USE_MODELSCOPE=1
+vllm serve Qwen/Qwen3-VL-32B-Instruct \
+  -tp 2 \
+  --trust-remote-code \
+  --attention-backend FLASH_ATTN_CUSTOM
+```
 ### Qwen3-VL-32B-Instruct IFB K100_AI 2x vLLM 0.18-hotfix
 
 ```bash
@@ -953,28 +925,6 @@ vllm serve Qwen/Qwen3-VL-32B-Instruct \
   --trust-remote-code 
 ```
 ### Qwen3-VL-235B-A22B-Instruct IFB BW1100 8x vLLM 0.21
-
-```bash
-export VLLM_HCU_USE_PD_SPLIT=1
-export VLLM_USE_MODELSCOPE=1
-vllm serve Qwen/Qwen3-VL-235B-A22B-Instruct \
-  -tp 8 \
-  --trust-remote-code \
-  --kv-cache-dtype fp8_e4m3 \
-  --attention-backend FLASH_ATTN_CUSTOM
-```
-### Qwen3-VL-235B-A22B-Instruct IFB BW1100 8x vLLM 0.18
-
-```bash
-export VLLM_USE_MODELSCOPE=1
-export VLLM_HCU_USE_PD_SPLIT=1
-export VLLM_HCU_USE_CUSTOM_FLASH_ATTN=1
-vllm serve Qwen/Qwen3-VL-235B-A22B-Instruct \
-  -tp 8 \
-  --trust-remote-code 
-```
-
-### Qwen3-VL-235B-A22B-Instruct IFB BW1100 8x vLLM 0.18-hotfix
 
 ```bash
 export VLLM_HCU_USE_PD_SPLIT=1
@@ -1019,34 +969,32 @@ vllm serve Qwen/Qwen3-VL-235B-A22B-Instruct \
   --headless \
   --hf-overrides '{"architectures": ["Qwen3VLMoeForConditionalGeneration"], "text_config": {"architectures": ["Qwen3VLMoeForConditionalGeneration"]}}'
 ```
-### Qwen3-VL-235B-A22B-Instruct IFB BW1000 16x vLLM 0.18
-```bash
-export VLLM_USE_MODELSCOPE=1
-export VLLM_HCU_USE_PD_SPLIT=1
-export VLLM_HCU_USE_CUSTOM_FLASH_ATTN=1
-vllm serve Qwen/Qwen3-VL-235B-A22B-Instruct \
-  -tp 8 \
-  -pp 2 \
-  --trust-remote-code 
-```
-
-### Qwen3-VL-235B-A22B-Instruct IFB BW1000 16x vLLM 0.18-hotfix
-
-```bash
-export VLLM_HCU_USE_PD_SPLIT=1
-export VLLM_USE_MODELSCOPE=1
-vllm serve Qwen/Qwen3-VL-235B-A22B-Instruct \
-  -tp 8 \
-  -pp 2 \
-  --trust-remote-code \
-  --attention-backend FLASH_ATTN_CUSTOM
-```
 ### Qwen3-VL-235B-A22B-Instruct IFB K100_AI 16x vLLM 0.21
 
 ```bash
 export VLLM_HCU_USE_CUSTOM_QUANTIZATION_GEMM=0
 export VLLM_HCU_USE_CUSTOM_OPS=0
 export VLLM_USE_MODELSCOPE=1
+vllm serve Qwen/Qwen3-VL-235B-A22B-Instruct \
+  -tp 8 \
+  -pp 2 \
+  --trust-remote-code 
+```
+### Qwen3-VL-235B-A22B-Instruct IFB BW1100 8x vLLM 0.18
+
+```bash
+export VLLM_USE_MODELSCOPE=1
+export VLLM_HCU_USE_PD_SPLIT=1
+export VLLM_HCU_USE_CUSTOM_FLASH_ATTN=1
+vllm serve Qwen/Qwen3-VL-235B-A22B-Instruct \
+  -tp 8 \
+  --trust-remote-code 
+```
+### Qwen3-VL-235B-A22B-Instruct IFB BW1000 16x vLLM 0.18
+```bash
+export VLLM_USE_MODELSCOPE=1
+export VLLM_HCU_USE_PD_SPLIT=1
+export VLLM_HCU_USE_CUSTOM_FLASH_ATTN=1
 vllm serve Qwen/Qwen3-VL-235B-A22B-Instruct \
   -tp 8 \
   -pp 2 \
@@ -1062,7 +1010,28 @@ vllm serve Qwen/Qwen3-VL-235B-A22B-Instruct \
   -pp 2 \
   --trust-remote-code 
 ```
+### Qwen3-VL-235B-A22B-Instruct IFB BW1100 8x vLLM 0.18-hotfix
 
+```bash
+export VLLM_HCU_USE_PD_SPLIT=1
+export VLLM_USE_MODELSCOPE=1
+vllm serve Qwen/Qwen3-VL-235B-A22B-Instruct \
+  -tp 8 \
+  --trust-remote-code \
+  --kv-cache-dtype fp8_e4m3 \
+  --attention-backend FLASH_ATTN_CUSTOM
+```
+### Qwen3-VL-235B-A22B-Instruct IFB BW1000 16x vLLM 0.18-hotfix
+
+```bash
+export VLLM_HCU_USE_PD_SPLIT=1
+export VLLM_USE_MODELSCOPE=1
+vllm serve Qwen/Qwen3-VL-235B-A22B-Instruct \
+  -tp 8 \
+  -pp 2 \
+  --trust-remote-code \
+  --attention-backend FLASH_ATTN_CUSTOM
+```
 ### Qwen3-VL-235B-A22B-Instruct IFB K100_AI 16x vLLM 0.18-hotfix
 
 ```bash
@@ -1075,27 +1044,6 @@ vllm serve Qwen/Qwen3-VL-235B-A22B-Instruct \
   --trust-remote-code 
 ```
 ### Qwen3-VL-235B-A22B-Thinking IFB BW1100 8x vLLM 0.21
-
-```bash
-export VLLM_HCU_USE_PD_SPLIT=1
-export VLLM_USE_MODELSCOPE=1
-vllm serve Qwen/Qwen3-VL-235B-A22B-Thinking \
-  -tp 8 \
-  --trust-remote-code \
-  --kv-cache-dtype fp8_e4m3 \
-  --attention-backend FLASH_ATTN_CUSTOM
-```
-### Qwen3-VL-235B-A22B-Thinking IFB BW1100 8x vLLM 0.18
-```bash
-export VLLM_USE_MODELSCOPE=1
-export VLLM_HCU_USE_PD_SPLIT=1
-export VLLM_HCU_USE_CUSTOM_FLASH_ATTN=1
-vllm serve Qwen/Qwen3-VL-235B-A22B-Thinking \
-  -tp 8 \
-  --trust-remote-code 
-```
-
-### Qwen3-VL-235B-A22B-Thinking IFB BW1100 8x vLLM 0.18-hotfix
 
 ```bash
 export VLLM_HCU_USE_PD_SPLIT=1
@@ -1140,34 +1088,31 @@ vllm serve Qwen/Qwen3-VL-235B-A22B-Thinking \
   --headless \
   --hf-overrides '{"architectures": ["Qwen3VLMoeForConditionalGeneration"], "text_config": {"architectures": ["Qwen3VLMoeForConditionalGeneration"]}}'
 ```
-### Qwen3-VL-235B-A22B-Thinking IFB BW1000 16x vLLM 0.18
-```bash
-export VLLM_USE_MODELSCOPE=1
-export VLLM_HCU_USE_PD_SPLIT=1
-export VLLM_HCU_USE_CUSTOM_FLASH_ATTN=1
-vllm serve Qwen/Qwen3-VL-235B-A22B-Thinking \
-  -tp 8 \
-  -pp 2 \
-  --trust-remote-code 
-```
-
-### Qwen3-VL-235B-A22B-Thinking IFB BW1000 16x vLLM 0.18-hotfix
-
-```bash
-export VLLM_HCU_USE_PD_SPLIT=1
-export VLLM_USE_MODELSCOPE=1
-vllm serve Qwen/Qwen3-VL-235B-A22B-Thinking \
-  -tp 8 \
-  -pp 2 \
-  --trust-remote-code \
-  --attention-backend FLASH_ATTN_CUSTOM
-```
 ### Qwen3-VL-235B-A22B-Thinking IFB K100_AI 16x vLLM 0.21
 
 ```bash
 export VLLM_HCU_USE_CUSTOM_QUANTIZATION_GEMM=0
 export VLLM_HCU_USE_CUSTOM_OPS=0
 export VLLM_USE_MODELSCOPE=1
+vllm serve Qwen/Qwen3-VL-235B-A22B-Thinking \
+  -tp 8 \
+  -pp 2 \
+  --trust-remote-code 
+```
+### Qwen3-VL-235B-A22B-Thinking IFB BW1100 8x vLLM 0.18
+```bash
+export VLLM_USE_MODELSCOPE=1
+export VLLM_HCU_USE_PD_SPLIT=1
+export VLLM_HCU_USE_CUSTOM_FLASH_ATTN=1
+vllm serve Qwen/Qwen3-VL-235B-A22B-Thinking \
+  -tp 8 \
+  --trust-remote-code 
+```
+### Qwen3-VL-235B-A22B-Thinking IFB BW1000 16x vLLM 0.18
+```bash
+export VLLM_USE_MODELSCOPE=1
+export VLLM_HCU_USE_PD_SPLIT=1
+export VLLM_HCU_USE_CUSTOM_FLASH_ATTN=1
 vllm serve Qwen/Qwen3-VL-235B-A22B-Thinking \
   -tp 8 \
   -pp 2 \
@@ -1183,7 +1128,28 @@ vllm serve Qwen/Qwen3-VL-235B-A22B-Thinking \
   -pp 2 \
   --trust-remote-code 
 ```
+### Qwen3-VL-235B-A22B-Thinking IFB BW1100 8x vLLM 0.18-hotfix
 
+```bash
+export VLLM_HCU_USE_PD_SPLIT=1
+export VLLM_USE_MODELSCOPE=1
+vllm serve Qwen/Qwen3-VL-235B-A22B-Thinking \
+  -tp 8 \
+  --trust-remote-code \
+  --kv-cache-dtype fp8_e4m3 \
+  --attention-backend FLASH_ATTN_CUSTOM
+```
+### Qwen3-VL-235B-A22B-Thinking IFB BW1000 16x vLLM 0.18-hotfix
+
+```bash
+export VLLM_HCU_USE_PD_SPLIT=1
+export VLLM_USE_MODELSCOPE=1
+vllm serve Qwen/Qwen3-VL-235B-A22B-Thinking \
+  -tp 8 \
+  -pp 2 \
+  --trust-remote-code \
+  --attention-backend FLASH_ATTN_CUSTOM
+```
 ### Qwen3-VL-235B-A22B-Thinking IFB K100_AI 16x vLLM 0.18-hotfix
 
 ```bash
@@ -1195,6 +1161,7 @@ vllm serve Qwen/Qwen3-VL-235B-A22B-Thinking \
   -pp 2 \
   --trust-remote-code 
 ```
+
 ## API 调用
 
 ### IFB
@@ -1332,3 +1299,4 @@ response = client.chat.completions.create(
 ```
 
 ---
+


### PR DESCRIPTION
## Summary
- Update Qwen3-VL-235B-A22B-Instruct v0.21 BW1000 16x command to two-node master/worker launch commands.
- Update Qwen3-VL-235B-A22B-Thinking v0.21 BW1000 16x command to the same two-node layout.
- Add VLLM_ROCM_USE_AITER_MOE=0 and hf-overrides for Qwen3VLMoeForConditionalGeneration.

## Verification
- Checked both target sections have master and worker commands, two vllm serve commands, node-rank 0/1, --headless on worker, and two hf-overrides entries.
- Checked the updated v0.21 BW1000 sections no longer contain VLLM_HCU_USE_PD_SPLIT or VLLM_USE_MODELSCOPE.