### PR TITLE
docs: update Qwen3-VL 30B BW1000 moe backend

### DIFF
--- a/docs/model-deployment/vllm/qwen3-vl.md
+++ b/docs/model-deployment/vllm/qwen3-vl.md
@@ -660,13 +660,12 @@ vllm serve Qwen/Qwen3-VL-8B-Thinking \
 ### Qwen3-VL-30B-A3B-Instruct IFB BW1100 1x vLLM 0.21
 
 ```bash
-export VLLM_HCU_USE_PD_SPLIT=1
-export VLLM_USE_MODELSCOPE=1
 vllm serve Qwen/Qwen3-VL-30B-A3B-Instruct \
   -tp 1 \
   --trust-remote-code \
   --kv-cache-dtype fp8_e4m3 \
-  --attention-backend FLASH_ATTN_CUSTOM
+  --attention-backend FLASH_ATTN_CUSTOM \
+  --moe-backend aiter
 ```
 ### Qwen3-VL-30B-A3B-Instruct IFB BW1000 2x vLLM 0.21
 

--- a/docs/model-deployment/vllm/qwen3-vl.md
+++ b/docs/model-deployment/vllm/qwen3-vl.md
@@ -671,12 +671,11 @@ vllm serve Qwen/Qwen3-VL-30B-A3B-Instruct \
 ### Qwen3-VL-30B-A3B-Instruct IFB BW1000 2x vLLM 0.21
 
 ```bash
-export VLLM_ROCM_USE_AITER=0
-
 vllm serve Qwen/Qwen3-VL-30B-A3B-Instruct \
   -tp 2 \
   --trust-remote-code \
-  --attention-backend FLASH_ATTN_CUSTOM
+  --attention-backend FLASH_ATTN_CUSTOM \
+  --moe-backend aiter
 ```
 ### Qwen3-VL-30B-A3B-Instruct IFB K100_AI 2x vLLM 0.21
 


### PR DESCRIPTION
## Summary
- Update Qwen3-VL-30B-A3B-Instruct v0.21 BW1000 command to use --moe-backend aiter.
- Remove the VLLM_ROCM_USE_AITER environment variable from that command block.

## Verification
- Checked the target command block matches the requested vllm serve command exactly.
- Checked no old VLLM_ROCM_USE_AITER, VLLM_HCU_USE_PD_SPLIT, or VLLM_USE_MODELSCOPE env remains in the target section.