### PR TITLE
docs: reorder Qwen2 vLLM versions

### DIFF
--- a/docs/model-deployment/vllm/qwen2.md
+++ b/docs/model-deployment/vllm/qwen2.md
@@ -9,49 +9,49 @@ Qwen2 是阿里通义千问开源大语言模型系列，支持多种参数规�
 | 模型权重 | 量化方式 | vLLM 版本 | 推荐硬件 | 卡数 | 部署方式 | 启动命令 |
 | -------- | -------- | --------- | -------- | ---- | -------- | -------- |
 | [Qwen/Qwen2-0.5B-Instruct](https://www.modelscope.cn/models/Qwen/Qwen2-0.5B-Instruct) | BF16 | 0.21 | BW1100 | 1 | IFB | [**`>_`**](#qwen2-05b-instruct-ifb-bw1100-1x-vllm-021) |
-|  | BF16 | 0.18 | BW1100  | 1 | IFB | [**`>_`**](#qwen2-05b-instruct-ifb-bw1100-1x-vllm-018) |
-|  | BF16 | 0.18-hotfix | BW1100 | 1 | IFB | [**`>_`**](#qwen2-05b-instruct-ifb-bw1100-1x-vllm-018-hotfix) |
 |  | BF16 | 0.21 | BW1000 | 1 | IFB | [**`>_`**](#qwen2-05b-instruct-ifb-bw1000-1x-vllm-021) |
-|                                                                               | BF16      | 0.18 | BW1000  | 1 | IFB | [**`>_`**](#qwen2-05b-instruct-ifb-bw1000-1x-vllm-018) |
-|  | BF16 | 0.18-hotfix | BW1000 | 1 | IFB | [**`>_`**](#qwen2-05b-instruct-ifb-bw1000-1x-vllm-018-hotfix) |
 |  | BF16 | 0.21 | K100_AI | 1 | IFB | [**`>_`**](#qwen2-05b-instruct-ifb-k100_ai-1x-vllm-021) |
-|                                                                               | BF16      | 0.18 | K100_AI | 1 | IFB | [**`>_`**](#qwen2-05b-instruct-ifb-k100_ai-1x-vllm-018) |
+|  | BF16 | 0.18 | BW1100 | 1 | IFB | [**`>_`**](#qwen2-05b-instruct-ifb-bw1100-1x-vllm-018) |
+|  | BF16 | 0.18 | BW1000 | 1 | IFB | [**`>_`**](#qwen2-05b-instruct-ifb-bw1000-1x-vllm-018) |
+|  | BF16 | 0.18 | K100_AI | 1 | IFB | [**`>_`**](#qwen2-05b-instruct-ifb-k100_ai-1x-vllm-018) |
+|  | BF16 | 0.18-hotfix | BW1100 | 1 | IFB | [**`>_`**](#qwen2-05b-instruct-ifb-bw1100-1x-vllm-018-hotfix) |
+|  | BF16 | 0.18-hotfix | BW1000 | 1 | IFB | [**`>_`**](#qwen2-05b-instruct-ifb-bw1000-1x-vllm-018-hotfix) |
 |  | BF16 | 0.18-hotfix | K100_AI | 1 | IFB | [**`>_`**](#qwen2-05b-instruct-ifb-k100_ai-1x-vllm-018-hotfix) |
 | [Qwen/Qwen2-1.5B-Instruct](https://www.modelscope.cn/models/Qwen/Qwen2-1.5B-Instruct) | BF16 | 0.21 | BW1100 | 1 | IFB | [**`>_`**](#qwen2-15b-instruct-ifb-bw1100-1x-vllm-021) |
-|  | BF16 | 0.18 | BW1100  | 1 | IFB | [**`>_`**](#qwen2-15b-instruct-ifb-bw1100-1x-vllm-018) |
-|  | BF16 | 0.18-hotfix | BW1100 | 1 | IFB | [**`>_`**](#qwen2-15b-instruct-ifb-bw1100-1x-vllm-018-hotfix) |
 |  | BF16 | 0.21 | BW1000 | 1 | IFB | [**`>_`**](#qwen2-15b-instruct-ifb-bw1000-1x-vllm-021) |
-|                                                                               | BF16      | 0.18 | BW1000  | 1 | IFB | [**`>_`**](#qwen2-15b-instruct-ifb-bw1000-1x-vllm-018) |
-|  | BF16 | 0.18-hotfix | BW1000 | 1 | IFB | [**`>_`**](#qwen2-15b-instruct-ifb-bw1000-1x-vllm-018-hotfix) |
 |  | BF16 | 0.21 | K100_AI | 1 | IFB | [**`>_`**](#qwen2-15b-instruct-ifb-k100_ai-1x-vllm-021) |
-|                                                                               | BF16      | 0.18 | K100_AI | 1 | IFB | [**`>_`**](#qwen2-15b-instruct-ifb-k100_ai-1x-vllm-018) |
+|  | BF16 | 0.18 | BW1100 | 1 | IFB | [**`>_`**](#qwen2-15b-instruct-ifb-bw1100-1x-vllm-018) |
+|  | BF16 | 0.18 | BW1000 | 1 | IFB | [**`>_`**](#qwen2-15b-instruct-ifb-bw1000-1x-vllm-018) |
+|  | BF16 | 0.18 | K100_AI | 1 | IFB | [**`>_`**](#qwen2-15b-instruct-ifb-k100_ai-1x-vllm-018) |
+|  | BF16 | 0.18-hotfix | BW1100 | 1 | IFB | [**`>_`**](#qwen2-15b-instruct-ifb-bw1100-1x-vllm-018-hotfix) |
+|  | BF16 | 0.18-hotfix | BW1000 | 1 | IFB | [**`>_`**](#qwen2-15b-instruct-ifb-bw1000-1x-vllm-018-hotfix) |
 |  | BF16 | 0.18-hotfix | K100_AI | 1 | IFB | [**`>_`**](#qwen2-15b-instruct-ifb-k100_ai-1x-vllm-018-hotfix) |
 | [Qwen/Qwen2-7B-Instruct](https://www.modelscope.cn/models/Qwen/Qwen2-7B-Instruct) | BF16 | 0.21 | BW1100 | 1 | IFB | [**`>_`**](#qwen2-7b-instruct-ifb-bw1100-1x-vllm-021) |
-|  | BF16 | 0.18 | BW1100  | 1 | IFB | [**`>_`**](#qwen2-7b-instruct-ifb-bw1100-1x-vllm-018) |
-|  | BF16 | 0.18-hotfix | BW1100 | 1 | IFB | [**`>_`**](#qwen2-7b-instruct-ifb-bw1100-1x-vllm-018-hotfix) |
 |  | BF16 | 0.21 | BW1000 | 1 | IFB | [**`>_`**](#qwen2-7b-instruct-ifb-bw1000-1x-vllm-021) |
-|                                                                               | BF16      | 0.18 | BW1000  | 1 | IFB | [**`>_`**](#qwen2-7b-instruct-ifb-bw1000-1x-vllm-018) |
-|  | BF16 | 0.18-hotfix | BW1000 | 1 | IFB | [**`>_`**](#qwen2-7b-instruct-ifb-bw1000-1x-vllm-018-hotfix) |
 |  | BF16 | 0.21 | K100_AI | 1 | IFB | [**`>_`**](#qwen2-7b-instruct-ifb-k100_ai-1x-vllm-021) |
-|                                                                               | BF16      | 0.18 | K100_AI | 1 | IFB | [**`>_`**](#qwen2-7b-instruct-ifb-k100_ai-1x-vllm-018) |
+|  | BF16 | 0.18 | BW1100 | 1 | IFB | [**`>_`**](#qwen2-7b-instruct-ifb-bw1100-1x-vllm-018) |
+|  | BF16 | 0.18 | BW1000 | 1 | IFB | [**`>_`**](#qwen2-7b-instruct-ifb-bw1000-1x-vllm-018) |
+|  | BF16 | 0.18 | K100_AI | 1 | IFB | [**`>_`**](#qwen2-7b-instruct-ifb-k100_ai-1x-vllm-018) |
+|  | BF16 | 0.18-hotfix | BW1100 | 1 | IFB | [**`>_`**](#qwen2-7b-instruct-ifb-bw1100-1x-vllm-018-hotfix) |
+|  | BF16 | 0.18-hotfix | BW1000 | 1 | IFB | [**`>_`**](#qwen2-7b-instruct-ifb-bw1000-1x-vllm-018-hotfix) |
 |  | BF16 | 0.18-hotfix | K100_AI | 1 | IFB | [**`>_`**](#qwen2-7b-instruct-ifb-k100_ai-1x-vllm-018-hotfix) |
 | [Qwen/Qwen2-57B-A14B-Instruct](https://www.modelscope.cn/models/Qwen/Qwen2-57B-A14B-Instruct) | BF16 | 0.21 | BW1100 | 2 | IFB | [**`>_`**](#qwen2-57b-a14b-instruct-ifb-bw1100-2x-vllm-021) |
-|  | BF16 | 0.18 | BW1100  | 2 | IFB | [**`>_`**](#qwen2-57b-a14b-instruct-ifb-bw1100-2x-vllm-018) |
-|  | BF16 | 0.18-hotfix | BW1100 | 2 | IFB | [**`>_`**](#qwen2-57b-a14b-instruct-ifb-bw1100-2x-vllm-018-hotfix) |
 |  | BF16 | 0.21 | BW1000 | 4 | IFB | [**`>_`**](#qwen2-57b-a14b-instruct-ifb-bw1000-4x-vllm-021) |
-|                                                                               | BF16      | 0.18 | BW1000  | 4 | IFB | [**`>_`**](#qwen2-57b-a14b-instruct-ifb-bw1000-4x-vllm-018) |
-|  | BF16 | 0.18-hotfix | BW1000 | 4 | IFB | [**`>_`**](#qwen2-57b-a14b-instruct-ifb-bw1000-4x-vllm-018-hotfix) |
 |  | BF16 | 0.21 | K100_AI | 4 | IFB | [**`>_`**](#qwen2-57b-a14b-instruct-ifb-k100_ai-4x-vllm-021) |
-|                                                                               | BF16      | 0.18 | K100_AI | 4 | IFB | [**`>_`**](#qwen2-57b-a14b-instruct-ifb-k100_ai-4x-vllm-018) |
+|  | BF16 | 0.18 | BW1100 | 2 | IFB | [**`>_`**](#qwen2-57b-a14b-instruct-ifb-bw1100-2x-vllm-018) |
+|  | BF16 | 0.18 | BW1000 | 4 | IFB | [**`>_`**](#qwen2-57b-a14b-instruct-ifb-bw1000-4x-vllm-018) |
+|  | BF16 | 0.18 | K100_AI | 4 | IFB | [**`>_`**](#qwen2-57b-a14b-instruct-ifb-k100_ai-4x-vllm-018) |
+|  | BF16 | 0.18-hotfix | BW1100 | 2 | IFB | [**`>_`**](#qwen2-57b-a14b-instruct-ifb-bw1100-2x-vllm-018-hotfix) |
+|  | BF16 | 0.18-hotfix | BW1000 | 4 | IFB | [**`>_`**](#qwen2-57b-a14b-instruct-ifb-bw1000-4x-vllm-018-hotfix) |
 |  | BF16 | 0.18-hotfix | K100_AI | 4 | IFB | [**`>_`**](#qwen2-57b-a14b-instruct-ifb-k100_ai-4x-vllm-018-hotfix) |
 | [Qwen/Qwen2-72B-Instruct](https://www.modelscope.cn/models/Qwen/Qwen2-72B-Instruct) | BF16 | 0.21 | BW1100 | 2 | IFB | [**`>_`**](#qwen2-72b-instruct-ifb-bw1100-2x-vllm-021) |
-|  | BF16 | 0.18 | BW1100  | 2 | IFB | [**`>_`**](#qwen2-72b-instruct-ifb-bw1100-2x-vllm-018) |
-|  | BF16 | 0.18-hotfix | BW1100 | 2 | IFB | [**`>_`**](#qwen2-72b-instruct-ifb-bw1100-2x-vllm-018-hotfix) |
 |  | BF16 | 0.21 | BW1000 | 4 | IFB | [**`>_`**](#qwen2-72b-instruct-ifb-bw1000-4x-vllm-021) |
-|                                                                               | BF16      | 0.18 | BW1000  | 4 | IFB | [**`>_`**](#qwen2-72b-instruct-ifb-bw1000-4x-vllm-018) |
-|  | BF16 | 0.18-hotfix | BW1000 | 4 | IFB | [**`>_`**](#qwen2-72b-instruct-ifb-bw1000-4x-vllm-018-hotfix) |
 |  | BF16 | 0.21 | K100_AI | 4 | IFB | [**`>_`**](#qwen2-72b-instruct-ifb-k100_ai-4x-vllm-021) |
-|                                                                               | BF16      | 0.18 | K100_AI | 4 | IFB | [**`>_`**](#qwen2-72b-instruct-ifb-k100_ai-4x-vllm-018) |
+|  | BF16 | 0.18 | BW1100 | 2 | IFB | [**`>_`**](#qwen2-72b-instruct-ifb-bw1100-2x-vllm-018) |
+|  | BF16 | 0.18 | BW1000 | 4 | IFB | [**`>_`**](#qwen2-72b-instruct-ifb-bw1000-4x-vllm-018) |
+|  | BF16 | 0.18 | K100_AI | 4 | IFB | [**`>_`**](#qwen2-72b-instruct-ifb-k100_ai-4x-vllm-018) |
+|  | BF16 | 0.18-hotfix | BW1100 | 2 | IFB | [**`>_`**](#qwen2-72b-instruct-ifb-bw1100-2x-vllm-018-hotfix) |
+|  | BF16 | 0.18-hotfix | BW1000 | 4 | IFB | [**`>_`**](#qwen2-72b-instruct-ifb-bw1000-4x-vllm-018-hotfix) |
 |  | BF16 | 0.18-hotfix | K100_AI | 4 | IFB | [**`>_`**](#qwen2-72b-instruct-ifb-k100_ai-4x-vllm-018-hotfix) |
 
 ## 启动命令
@@ -68,11 +68,59 @@ vllm serve Qwen/Qwen2-0.5B-Instruct \
   --kv-cache-dtype fp8_e4m3 \
   --attention-backend FLASH_ATTN_CUSTOM
 ```
+
+### Qwen2-0.5B-Instruct IFB BW1000 1x vLLM 0.21
+
+```bash
+export VLLM_HCU_USE_PD_SPLIT=1
+export VLLM_USE_MODELSCOPE=1
+
+vllm serve Qwen/Qwen2-0.5B-Instruct \
+  -tp 1 \
+  --trust-remote-code \
+  --attention-backend FLASH_ATTN_CUSTOM
+```
+
+### Qwen2-0.5B-Instruct IFB K100_AI 1x vLLM 0.21
+
+```bash
+export VLLM_HCU_USE_CUSTOM_QUANTIZATION_GEMM=0
+export VLLM_HCU_USE_CUSTOM_OPS=0
+export VLLM_USE_MODELSCOPE=1
+
+vllm serve Qwen/Qwen2-0.5B-Instruct \
+  -tp 1 \
+  --trust-remote-code
+```
+
 ### Qwen2-0.5B-Instruct IFB BW1100 1x vLLM 0.18
 ```bash
 export VLLM_USE_MODELSCOPE=1
 export VLLM_HCU_USE_PD_SPLIT=1
 export VLLM_HCU_USE_CUSTOM_FLASH_ATTN=1
+
+vllm serve Qwen/Qwen2-0.5B-Instruct \
+  -tp 1 \
+  --trust-remote-code
+```
+
+### Qwen2-0.5B-Instruct IFB BW1000 1x vLLM 0.18
+```bash
+export VLLM_USE_MODELSCOPE=1
+export VLLM_HCU_USE_PD_SPLIT=1
+export VLLM_HCU_USE_CUSTOM_FLASH_ATTN=1
+
+vllm serve Qwen/Qwen2-0.5B-Instruct \
+  -tp 1 \
+  --trust-remote-code
+```
+
+### Qwen2-0.5B-Instruct IFB K100_AI 1x vLLM 0.18
+```bash
+export VLLM_HCU_USE_CUSTOM_QUANTIZATION_GEMM=0
+export VLLM_HCU_USE_CUSTOM_OPS=0
+export VLLM_USE_MODELSCOPE=1
+export VLLM_HCU_USE_PD_SPLIT=1
 
 vllm serve Qwen/Qwen2-0.5B-Instruct \
   -tp 1 \
@@ -91,27 +139,6 @@ vllm serve Qwen/Qwen2-0.5B-Instruct \
   --kv-cache-dtype fp8_e4m3 \
   --attention-backend FLASH_ATTN_CUSTOM
 ```
-### Qwen2-0.5B-Instruct IFB BW1000 1x vLLM 0.21
-
-```bash
-export VLLM_HCU_USE_PD_SPLIT=1
-export VLLM_USE_MODELSCOPE=1
-
-vllm serve Qwen/Qwen2-0.5B-Instruct \
-  -tp 1 \
-  --trust-remote-code \
-  --attention-backend FLASH_ATTN_CUSTOM
-```
-### Qwen2-0.5B-Instruct IFB BW1000 1x vLLM 0.18
-```bash
-export VLLM_USE_MODELSCOPE=1
-export VLLM_HCU_USE_PD_SPLIT=1
-export VLLM_HCU_USE_CUSTOM_FLASH_ATTN=1
-
-vllm serve Qwen/Qwen2-0.5B-Instruct \
-  -tp 1 \
-  --trust-remote-code
-```
 
 ### Qwen2-0.5B-Instruct IFB BW1000 1x vLLM 0.18-hotfix
 
@@ -123,28 +150,6 @@ vllm serve Qwen/Qwen2-0.5B-Instruct \
   -tp 1 \
   --trust-remote-code \
   --attention-backend FLASH_ATTN_CUSTOM
-```
-### Qwen2-0.5B-Instruct IFB K100_AI 1x vLLM 0.21
-
-```bash
-export VLLM_HCU_USE_CUSTOM_QUANTIZATION_GEMM=0
-export VLLM_HCU_USE_CUSTOM_OPS=0
-export VLLM_USE_MODELSCOPE=1
-
-vllm serve Qwen/Qwen2-0.5B-Instruct \
-  -tp 1 \
-  --trust-remote-code
-```
-### Qwen2-0.5B-Instruct IFB K100_AI 1x vLLM 0.18
-```bash
-export VLLM_HCU_USE_CUSTOM_QUANTIZATION_GEMM=0
-export VLLM_HCU_USE_CUSTOM_OPS=0
-export VLLM_USE_MODELSCOPE=1
-export VLLM_HCU_USE_PD_SPLIT=1
-
-vllm serve Qwen/Qwen2-0.5B-Instruct \
-  -tp 1 \
-  --trust-remote-code
 ```
 
 ### Qwen2-0.5B-Instruct IFB K100_AI 1x vLLM 0.18-hotfix
@@ -158,6 +163,7 @@ vllm serve Qwen/Qwen2-0.5B-Instruct \
   -tp 1 \
   --trust-remote-code
 ```
+
 ### Qwen2-1.5B-Instruct IFB BW1100 1x vLLM 0.21
 
 ```bash
@@ -170,11 +176,59 @@ vllm serve Qwen/Qwen2-1.5B-Instruct \
   --kv-cache-dtype fp8_e4m3 \
   --attention-backend FLASH_ATTN_CUSTOM
 ```
+
+### Qwen2-1.5B-Instruct IFB BW1000 1x vLLM 0.21
+
+```bash
+export VLLM_HCU_USE_PD_SPLIT=1
+export VLLM_USE_MODELSCOPE=1
+
+vllm serve Qwen/Qwen2-1.5B-Instruct \
+  -tp 1 \
+  --trust-remote-code \
+  --attention-backend FLASH_ATTN_CUSTOM
+```
+
+### Qwen2-1.5B-Instruct IFB K100_AI 1x vLLM 0.21
+
+```bash
+export VLLM_HCU_USE_CUSTOM_QUANTIZATION_GEMM=0
+export VLLM_HCU_USE_CUSTOM_OPS=0
+export VLLM_USE_MODELSCOPE=1
+
+vllm serve Qwen/Qwen2-1.5B-Instruct \
+  -tp 1 \
+  --trust-remote-code
+```
+
 ### Qwen2-1.5B-Instruct IFB BW1100 1x vLLM 0.18
 ```bash
 export VLLM_USE_MODELSCOPE=1
 export VLLM_HCU_USE_PD_SPLIT=1
 export VLLM_HCU_USE_CUSTOM_FLASH_ATTN=1
+
+vllm serve Qwen/Qwen2-1.5B-Instruct \
+  -tp 1 \
+  --trust-remote-code
+```
+
+### Qwen2-1.5B-Instruct IFB BW1000 1x vLLM 0.18
+```bash
+export VLLM_USE_MODELSCOPE=1
+export VLLM_HCU_USE_PD_SPLIT=1
+export VLLM_HCU_USE_CUSTOM_FLASH_ATTN=1
+
+vllm serve Qwen/Qwen2-1.5B-Instruct \
+  -tp 1 \
+  --trust-remote-code
+```
+
+### Qwen2-1.5B-Instruct IFB K100_AI 1x vLLM 0.18
+```bash
+export VLLM_HCU_USE_CUSTOM_QUANTIZATION_GEMM=0
+export VLLM_HCU_USE_CUSTOM_OPS=0
+export VLLM_USE_MODELSCOPE=1
+export VLLM_HCU_USE_PD_SPLIT=1
 
 vllm serve Qwen/Qwen2-1.5B-Instruct \
   -tp 1 \
@@ -193,27 +247,6 @@ vllm serve Qwen/Qwen2-1.5B-Instruct \
   --kv-cache-dtype fp8_e4m3 \
   --attention-backend FLASH_ATTN_CUSTOM
 ```
-### Qwen2-1.5B-Instruct IFB BW1000 1x vLLM 0.21
-
-```bash
-export VLLM_HCU_USE_PD_SPLIT=1
-export VLLM_USE_MODELSCOPE=1
-
-vllm serve Qwen/Qwen2-1.5B-Instruct \
-  -tp 1 \
-  --trust-remote-code \
-  --attention-backend FLASH_ATTN_CUSTOM
-```
-### Qwen2-1.5B-Instruct IFB BW1000 1x vLLM 0.18
-```bash
-export VLLM_USE_MODELSCOPE=1
-export VLLM_HCU_USE_PD_SPLIT=1
-export VLLM_HCU_USE_CUSTOM_FLASH_ATTN=1
-
-vllm serve Qwen/Qwen2-1.5B-Instruct \
-  -tp 1 \
-  --trust-remote-code
-```
 
 ### Qwen2-1.5B-Instruct IFB BW1000 1x vLLM 0.18-hotfix
 
@@ -225,28 +258,6 @@ vllm serve Qwen/Qwen2-1.5B-Instruct \
   -tp 1 \
   --trust-remote-code \
   --attention-backend FLASH_ATTN_CUSTOM
-```
-### Qwen2-1.5B-Instruct IFB K100_AI 1x vLLM 0.21
-
-```bash
-export VLLM_HCU_USE_CUSTOM_QUANTIZATION_GEMM=0
-export VLLM_HCU_USE_CUSTOM_OPS=0
-export VLLM_USE_MODELSCOPE=1
-
-vllm serve Qwen/Qwen2-1.5B-Instruct \
-  -tp 1 \
-  --trust-remote-code
-```
-### Qwen2-1.5B-Instruct IFB K100_AI 1x vLLM 0.18
-```bash
-export VLLM_HCU_USE_CUSTOM_QUANTIZATION_GEMM=0
-export VLLM_HCU_USE_CUSTOM_OPS=0
-export VLLM_USE_MODELSCOPE=1
-export VLLM_HCU_USE_PD_SPLIT=1
-
-vllm serve Qwen/Qwen2-1.5B-Instruct \
-  -tp 1 \
-  --trust-remote-code
 ```
 
 ### Qwen2-1.5B-Instruct IFB K100_AI 1x vLLM 0.18-hotfix
@@ -260,6 +271,7 @@ vllm serve Qwen/Qwen2-1.5B-Instruct \
   -tp 1 \
   --trust-remote-code
 ```
+
 ### Qwen2-7B-Instruct IFB BW1100 1x vLLM 0.21
 
 ```bash
@@ -272,11 +284,59 @@ vllm serve Qwen/Qwen2-7B-Instruct \
   --kv-cache-dtype fp8_e4m3 \
   --attention-backend FLASH_ATTN_CUSTOM
 ```
+
+### Qwen2-7B-Instruct IFB BW1000 1x vLLM 0.21
+
+```bash
+export VLLM_HCU_USE_PD_SPLIT=1
+export VLLM_USE_MODELSCOPE=1
+
+vllm serve Qwen/Qwen2-7B-Instruct \
+  -tp 1 \
+  --trust-remote-code \
+  --attention-backend FLASH_ATTN_CUSTOM
+```
+
+### Qwen2-7B-Instruct IFB K100_AI 1x vLLM 0.21
+
+```bash
+export VLLM_HCU_USE_CUSTOM_QUANTIZATION_GEMM=0
+export VLLM_HCU_USE_CUSTOM_OPS=0
+export VLLM_USE_MODELSCOPE=1
+
+vllm serve Qwen/Qwen2-7B-Instruct \
+  -tp 1 \
+  --trust-remote-code
+```
+
 ### Qwen2-7B-Instruct IFB BW1100 1x vLLM 0.18
 ```bash
 export VLLM_USE_MODELSCOPE=1
 export VLLM_HCU_USE_PD_SPLIT=1
 export VLLM_HCU_USE_CUSTOM_FLASH_ATTN=1
+
+vllm serve Qwen/Qwen2-7B-Instruct \
+  -tp 1 \
+  --trust-remote-code
+```
+
+### Qwen2-7B-Instruct IFB BW1000 1x vLLM 0.18
+```bash
+export VLLM_USE_MODELSCOPE=1
+export VLLM_HCU_USE_PD_SPLIT=1
+export VLLM_HCU_USE_CUSTOM_FLASH_ATTN=1
+
+vllm serve Qwen/Qwen2-7B-Instruct \
+  -tp 1 \
+  --trust-remote-code
+```
+
+### Qwen2-7B-Instruct IFB K100_AI 1x vLLM 0.18
+```bash
+export VLLM_HCU_USE_CUSTOM_QUANTIZATION_GEMM=0
+export VLLM_HCU_USE_CUSTOM_OPS=0
+export VLLM_USE_MODELSCOPE=1
+export VLLM_HCU_USE_PD_SPLIT=1
 
 vllm serve Qwen/Qwen2-7B-Instruct \
   -tp 1 \
@@ -295,27 +355,6 @@ vllm serve Qwen/Qwen2-7B-Instruct \
   --kv-cache-dtype fp8_e4m3 \
   --attention-backend FLASH_ATTN_CUSTOM
 ```
-### Qwen2-7B-Instruct IFB BW1000 1x vLLM 0.21
-
-```bash
-export VLLM_HCU_USE_PD_SPLIT=1
-export VLLM_USE_MODELSCOPE=1
-
-vllm serve Qwen/Qwen2-7B-Instruct \
-  -tp 1 \
-  --trust-remote-code \
-  --attention-backend FLASH_ATTN_CUSTOM
-```
-### Qwen2-7B-Instruct IFB BW1000 1x vLLM 0.18
-```bash
-export VLLM_USE_MODELSCOPE=1
-export VLLM_HCU_USE_PD_SPLIT=1
-export VLLM_HCU_USE_CUSTOM_FLASH_ATTN=1
-
-vllm serve Qwen/Qwen2-7B-Instruct \
-  -tp 1 \
-  --trust-remote-code
-```
 
 ### Qwen2-7B-Instruct IFB BW1000 1x vLLM 0.18-hotfix
 
@@ -327,28 +366,6 @@ vllm serve Qwen/Qwen2-7B-Instruct \
   -tp 1 \
   --trust-remote-code \
   --attention-backend FLASH_ATTN_CUSTOM
-```
-### Qwen2-7B-Instruct IFB K100_AI 1x vLLM 0.21
-
-```bash
-export VLLM_HCU_USE_CUSTOM_QUANTIZATION_GEMM=0
-export VLLM_HCU_USE_CUSTOM_OPS=0
-export VLLM_USE_MODELSCOPE=1
-
-vllm serve Qwen/Qwen2-7B-Instruct \
-  -tp 1 \
-  --trust-remote-code
-```
-### Qwen2-7B-Instruct IFB K100_AI 1x vLLM 0.18
-```bash
-export VLLM_HCU_USE_CUSTOM_QUANTIZATION_GEMM=0
-export VLLM_HCU_USE_CUSTOM_OPS=0
-export VLLM_USE_MODELSCOPE=1
-export VLLM_HCU_USE_PD_SPLIT=1
-
-vllm serve Qwen/Qwen2-7B-Instruct \
-  -tp 1 \
-  --trust-remote-code
 ```
 
 ### Qwen2-7B-Instruct IFB K100_AI 1x vLLM 0.18-hotfix
@@ -362,6 +379,7 @@ vllm serve Qwen/Qwen2-7B-Instruct \
   -tp 1 \
   --trust-remote-code
 ```
+
 ### Qwen2-57B-A14B-Instruct IFB BW1100 2x vLLM 0.21
 
 ```bash
@@ -374,6 +392,31 @@ vllm serve Qwen/Qwen2-57B-A14B-Instruct \
   --kv-cache-dtype fp8_e4m3 \
   --attention-backend FLASH_ATTN_CUSTOM
 ```
+
+### Qwen2-57B-A14B-Instruct IFB BW1000 4x vLLM 0.21
+
+```bash
+export VLLM_HCU_USE_PD_SPLIT=1
+export VLLM_USE_MODELSCOPE=1
+
+vllm serve Qwen/Qwen2-57B-A14B-Instruct \
+  -tp 4 \
+  --trust-remote-code \
+  --attention-backend FLASH_ATTN_CUSTOM
+```
+
+### Qwen2-57B-A14B-Instruct IFB K100_AI 4x vLLM 0.21
+
+```bash
+export VLLM_HCU_USE_CUSTOM_QUANTIZATION_GEMM=0
+export VLLM_HCU_USE_CUSTOM_OPS=0
+export VLLM_USE_MODELSCOPE=1
+
+vllm serve Qwen/Qwen2-57B-A14B-Instruct \
+  -tp 4 \
+  --trust-remote-code
+```
+
 ### Qwen2-57B-A14B-Instruct IFB BW1100 2x vLLM 0.18
 ```bash
 export VLLM_USE_MODELSCOPE=1
@@ -382,6 +425,29 @@ export VLLM_HCU_USE_CUSTOM_FLASH_ATTN=1
 
 vllm serve Qwen/Qwen2-57B-A14B-Instruct \
   -tp 2 \
+  --trust-remote-code
+```
+
+### Qwen2-57B-A14B-Instruct IFB BW1000 4x vLLM 0.18
+```bash
+export VLLM_USE_MODELSCOPE=1
+export VLLM_HCU_USE_PD_SPLIT=1
+export VLLM_HCU_USE_CUSTOM_FLASH_ATTN=1
+
+vllm serve Qwen/Qwen2-57B-A14B-Instruct \
+  -tp 4 \
+  --trust-remote-code
+```
+
+### Qwen2-57B-A14B-Instruct IFB K100_AI 4x vLLM 0.18
+```bash
+export VLLM_HCU_USE_CUSTOM_QUANTIZATION_GEMM=0
+export VLLM_HCU_USE_CUSTOM_OPS=0
+export VLLM_USE_MODELSCOPE=1
+export VLLM_HCU_USE_PD_SPLIT=1
+
+vllm serve Qwen/Qwen2-57B-A14B-Instruct \
+  -tp 4 \
   --trust-remote-code
 ```
 
@@ -397,27 +463,6 @@ vllm serve Qwen/Qwen2-57B-A14B-Instruct \
   --kv-cache-dtype fp8_e4m3 \
   --attention-backend FLASH_ATTN_CUSTOM
 ```
-### Qwen2-57B-A14B-Instruct IFB BW1000 4x vLLM 0.21
-
-```bash
-export VLLM_HCU_USE_PD_SPLIT=1
-export VLLM_USE_MODELSCOPE=1
-
-vllm serve Qwen/Qwen2-57B-A14B-Instruct \
-  -tp 4 \
-  --trust-remote-code \
-  --attention-backend FLASH_ATTN_CUSTOM
-```
-### Qwen2-57B-A14B-Instruct IFB BW1000 4x vLLM 0.18
-```bash
-export VLLM_USE_MODELSCOPE=1
-export VLLM_HCU_USE_PD_SPLIT=1
-export VLLM_HCU_USE_CUSTOM_FLASH_ATTN=1
-
-vllm serve Qwen/Qwen2-57B-A14B-Instruct \
-  -tp 4 \
-  --trust-remote-code
-```
 
 ### Qwen2-57B-A14B-Instruct IFB BW1000 4x vLLM 0.18-hotfix
 
@@ -429,28 +474,6 @@ vllm serve Qwen/Qwen2-57B-A14B-Instruct \
   -tp 4 \
   --trust-remote-code \
   --attention-backend FLASH_ATTN_CUSTOM
-```
-### Qwen2-57B-A14B-Instruct IFB K100_AI 4x vLLM 0.21
-
-```bash
-export VLLM_HCU_USE_CUSTOM_QUANTIZATION_GEMM=0
-export VLLM_HCU_USE_CUSTOM_OPS=0
-export VLLM_USE_MODELSCOPE=1
-
-vllm serve Qwen/Qwen2-57B-A14B-Instruct \
-  -tp 4 \
-  --trust-remote-code
-```
-### Qwen2-57B-A14B-Instruct IFB K100_AI 4x vLLM 0.18
-```bash
-export VLLM_HCU_USE_CUSTOM_QUANTIZATION_GEMM=0
-export VLLM_HCU_USE_CUSTOM_OPS=0
-export VLLM_USE_MODELSCOPE=1
-export VLLM_HCU_USE_PD_SPLIT=1
-
-vllm serve Qwen/Qwen2-57B-A14B-Instruct \
-  -tp 4 \
-  --trust-remote-code
 ```
 
 ### Qwen2-57B-A14B-Instruct IFB K100_AI 4x vLLM 0.18-hotfix
@@ -464,6 +487,7 @@ vllm serve Qwen/Qwen2-57B-A14B-Instruct \
   -tp 4 \
   --trust-remote-code
 ```
+
 ### Qwen2-72B-Instruct IFB BW1100 2x vLLM 0.21
 
 ```bash
@@ -476,6 +500,31 @@ vllm serve Qwen/Qwen2-72B-Instruct \
   --kv-cache-dtype fp8_e4m3 \
   --attention-backend FLASH_ATTN_CUSTOM
 ```
+
+### Qwen2-72B-Instruct IFB BW1000 4x vLLM 0.21
+
+```bash
+export VLLM_HCU_USE_PD_SPLIT=1
+export VLLM_USE_MODELSCOPE=1
+
+vllm serve Qwen/Qwen2-72B-Instruct \
+  -tp 4 \
+  --trust-remote-code \
+  --attention-backend FLASH_ATTN_CUSTOM
+```
+
+### Qwen2-72B-Instruct IFB K100_AI 4x vLLM 0.21
+
+```bash
+export VLLM_HCU_USE_CUSTOM_QUANTIZATION_GEMM=0
+export VLLM_HCU_USE_CUSTOM_OPS=0
+export VLLM_USE_MODELSCOPE=1
+
+vllm serve Qwen/Qwen2-72B-Instruct \
+  -tp 4 \
+  --trust-remote-code
+```
+
 ### Qwen2-72B-Instruct IFB BW1100 2x vLLM 0.18
 ```bash
 export VLLM_USE_MODELSCOPE=1
@@ -484,6 +533,29 @@ export VLLM_HCU_USE_CUSTOM_FLASH_ATTN=1
 
 vllm serve Qwen/Qwen2-72B-Instruct \
   -tp 2 \
+  --trust-remote-code
+```
+
+### Qwen2-72B-Instruct IFB BW1000 4x vLLM 0.18
+```bash
+export VLLM_USE_MODELSCOPE=1
+export VLLM_HCU_USE_PD_SPLIT=1
+export VLLM_HCU_USE_CUSTOM_FLASH_ATTN=1
+
+vllm serve Qwen/Qwen2-72B-Instruct \
+  -tp 4 \
+  --trust-remote-code
+```
+
+### Qwen2-72B-Instruct IFB K100_AI 4x vLLM 0.18
+```bash
+export VLLM_HCU_USE_CUSTOM_QUANTIZATION_GEMM=0
+export VLLM_HCU_USE_CUSTOM_OPS=0
+export VLLM_USE_MODELSCOPE=1
+export VLLM_HCU_USE_PD_SPLIT=1
+
+vllm serve Qwen/Qwen2-72B-Instruct \
+  -tp 4 \
   --trust-remote-code
 ```
 
@@ -499,27 +571,6 @@ vllm serve Qwen/Qwen2-72B-Instruct \
   --kv-cache-dtype fp8_e4m3 \
   --attention-backend FLASH_ATTN_CUSTOM
 ```
-### Qwen2-72B-Instruct IFB BW1000 4x vLLM 0.21
-
-```bash
-export VLLM_HCU_USE_PD_SPLIT=1
-export VLLM_USE_MODELSCOPE=1
-
-vllm serve Qwen/Qwen2-72B-Instruct \
-  -tp 4 \
-  --trust-remote-code \
-  --attention-backend FLASH_ATTN_CUSTOM
-```
-### Qwen2-72B-Instruct IFB BW1000 4x vLLM 0.18
-```bash
-export VLLM_USE_MODELSCOPE=1
-export VLLM_HCU_USE_PD_SPLIT=1
-export VLLM_HCU_USE_CUSTOM_FLASH_ATTN=1
-
-vllm serve Qwen/Qwen2-72B-Instruct \
-  -tp 4 \
-  --trust-remote-code
-```
 
 ### Qwen2-72B-Instruct IFB BW1000 4x vLLM 0.18-hotfix
 
@@ -531,28 +582,6 @@ vllm serve Qwen/Qwen2-72B-Instruct \
   -tp 4 \
   --trust-remote-code \
   --attention-backend FLASH_ATTN_CUSTOM
-```
-### Qwen2-72B-Instruct IFB K100_AI 4x vLLM 0.21
-
-```bash
-export VLLM_HCU_USE_CUSTOM_QUANTIZATION_GEMM=0
-export VLLM_HCU_USE_CUSTOM_OPS=0
-export VLLM_USE_MODELSCOPE=1
-
-vllm serve Qwen/Qwen2-72B-Instruct \
-  -tp 4 \
-  --trust-remote-code
-```
-### Qwen2-72B-Instruct IFB K100_AI 4x vLLM 0.18
-```bash
-export VLLM_HCU_USE_CUSTOM_QUANTIZATION_GEMM=0
-export VLLM_HCU_USE_CUSTOM_OPS=0
-export VLLM_USE_MODELSCOPE=1
-export VLLM_HCU_USE_PD_SPLIT=1
-
-vllm serve Qwen/Qwen2-72B-Instruct \
-  -tp 4 \
-  --trust-remote-code
 ```
 
 ### Qwen2-72B-Instruct IFB K100_AI 4x vLLM 0.18-hotfix


### PR DESCRIPTION
## Summary
- Reorder Qwen2 vLLM table rows by version first, then hardware.
- Reorder the matching startup command sections in the same sequence.

## Notes
- qwen2.md currently has 0.21, 0.18, and 0.18-hotfix entries; no 0.15 entries are present in this file.