### PR TITLE
docs: remove Qwen2 v0.21 pd split env

### DIFF
--- a/docs/model-deployment/vllm/qwen2.md
+++ b/docs/model-deployment/vllm/qwen2.md
@@ -59,7 +59,6 @@ Qwen2 是阿里通义千问开源大语言模型系列，支持多种参数规�
 ### Qwen2-0.5B-Instruct IFB BW1100 1x vLLM 0.21
 
 ```bash
-export VLLM_HCU_USE_PD_SPLIT=1
 export VLLM_USE_MODELSCOPE=1
 
 vllm serve Qwen/Qwen2-0.5B-Instruct \
@@ -72,7 +71,6 @@ vllm serve Qwen/Qwen2-0.5B-Instruct \
 ### Qwen2-0.5B-Instruct IFB BW1000 1x vLLM 0.21
 
 ```bash
-export VLLM_HCU_USE_PD_SPLIT=1
 export VLLM_USE_MODELSCOPE=1
 
 vllm serve Qwen/Qwen2-0.5B-Instruct \
@@ -167,7 +165,6 @@ vllm serve Qwen/Qwen2-0.5B-Instruct \
 ### Qwen2-1.5B-Instruct IFB BW1100 1x vLLM 0.21
 
 ```bash
-export VLLM_HCU_USE_PD_SPLIT=1
 export VLLM_USE_MODELSCOPE=1
 
 vllm serve Qwen/Qwen2-1.5B-Instruct \
@@ -180,7 +177,6 @@ vllm serve Qwen/Qwen2-1.5B-Instruct \
 ### Qwen2-1.5B-Instruct IFB BW1000 1x vLLM 0.21
 
 ```bash
-export VLLM_HCU_USE_PD_SPLIT=1
 export VLLM_USE_MODELSCOPE=1
 
 vllm serve Qwen/Qwen2-1.5B-Instruct \
@@ -275,7 +271,6 @@ vllm serve Qwen/Qwen2-1.5B-Instruct \
 ### Qwen2-7B-Instruct IFB BW1100 1x vLLM 0.21
 
 ```bash
-export VLLM_HCU_USE_PD_SPLIT=1
 export VLLM_USE_MODELSCOPE=1
 
 vllm serve Qwen/Qwen2-7B-Instruct \
@@ -288,7 +283,6 @@ vllm serve Qwen/Qwen2-7B-Instruct \
 ### Qwen2-7B-Instruct IFB BW1000 1x vLLM 0.21
 
 ```bash
-export VLLM_HCU_USE_PD_SPLIT=1
 export VLLM_USE_MODELSCOPE=1
 
 vllm serve Qwen/Qwen2-7B-Instruct \
@@ -383,7 +377,6 @@ vllm serve Qwen/Qwen2-7B-Instruct \
 ### Qwen2-57B-A14B-Instruct IFB BW1100 2x vLLM 0.21
 
 ```bash
-export VLLM_HCU_USE_PD_SPLIT=1
 export VLLM_USE_MODELSCOPE=1
 
 vllm serve Qwen/Qwen2-57B-A14B-Instruct \
@@ -396,7 +389,6 @@ vllm serve Qwen/Qwen2-57B-A14B-Instruct \
 ### Qwen2-57B-A14B-Instruct IFB BW1000 4x vLLM 0.21
 
 ```bash
-export VLLM_HCU_USE_PD_SPLIT=1
 export VLLM_USE_MODELSCOPE=1
 
 vllm serve Qwen/Qwen2-57B-A14B-Instruct \
@@ -491,7 +483,6 @@ vllm serve Qwen/Qwen2-57B-A14B-Instruct \
 ### Qwen2-72B-Instruct IFB BW1100 2x vLLM 0.21
 
 ```bash
-export VLLM_HCU_USE_PD_SPLIT=1
 export VLLM_USE_MODELSCOPE=1
 
 vllm serve Qwen/Qwen2-72B-Instruct \
@@ -504,7 +495,6 @@ vllm serve Qwen/Qwen2-72B-Instruct \
 ### Qwen2-72B-Instruct IFB BW1000 4x vLLM 0.21
 
 ```bash
-export VLLM_HCU_USE_PD_SPLIT=1
 export VLLM_USE_MODELSCOPE=1
 
 vllm serve Qwen/Qwen2-72B-Instruct \


### PR DESCRIPTION
## Summary
- Remove export VLLM_HCU_USE_PD_SPLIT=1 from Qwen2 v0.21 command blocks.
- Keep non-v0.21 command blocks unchanged.

## Verification
- Checked v0.21 command blocks have zero export VLLM_HCU_USE_PD_SPLIT=1 entries.
- Checked non-v0.21 command blocks still retain their existing PD_SPLIT entries.