### PR TITLE
docs: reorder Qwen vLLM versions

### DIFF
--- a/docs/model-deployment/vllm/qwen3.5.md
+++ b/docs/model-deployment/vllm/qwen3.5.md
@@ -8,98 +8,98 @@ Qwen3.5 是 Qwen3 系列的增强版本，在推理能力、代码生成、多�
 
 | 模型权重 | 量化方式 | vLLM 版本 | 推荐硬件 | 卡数 | 部署方式 | 启动命令 |
 | -------- | -------- | --------- | -------- | ---- | -------- | -------- |
-| [Qwen/Qwen3.5-4B](https://www.modelscope.cn/models/Qwen/Qwen3.5-4B)           | BF16 | 0.21 | BW1100 | 1 | IFB | [**`>_`**](#qwen35-4b-ifb-bw1100-1x-vllm-021) |
-|  | BF16      | 0.18 | BW1100  | 1 | IFB | [**`>_`**](#qwen35-4b-ifb-bw1100-1x-vllm-018)          |
-|  | BF16 | 0.18-hotfix | BW1100 | 1 | IFB | [**`>_`**](#qwen35-4b-ifb-bw1100-1x-vllm-018-hotfix) |
-|                                                                               | BF16      | 0.21 | BW1000  | 1 | IFB | [**`>_`**](#qwen35-4b-ifb-bw1000-1x-vllm-021) |
-|                                                                               | BF16      | 0.18 | BW1000  | 1 | IFB | [**`>_`**](#qwen35-4b-ifb-bw1000-1x-vllm-018)           |
-|                                                                               | BF16      | 0.18-hotfix | BW1000  | 1 | IFB | [**`>_`**](#qwen35-4b-ifb-bw1000-1x-vllm-018-hotfix) |
+| [Qwen/Qwen3.5-4B](https://www.modelscope.cn/models/Qwen/Qwen3.5-4B) | BF16 | 0.21 | BW1100 | 1 | IFB | [**`>_`**](#qwen35-4b-ifb-bw1100-1x-vllm-021) |
+|  | BF16 | 0.21 | BW1000 | 1 | IFB | [**`>_`**](#qwen35-4b-ifb-bw1000-1x-vllm-021) |
 |  | BF16 | 0.21 | K100_AI | 1 | IFB | [**`>_`**](#qwen35-4b-ifb-k100_ai-1x-vllm-021) |
-|                                                                               | BF16      | 0.18 | K100_AI | 1 | IFB | [**`>_`**](#qwen35-4b-ifb-k100_ai-1x-vllm-018)           |
+|  | BF16 | 0.18 | BW1100 | 1 | IFB | [**`>_`**](#qwen35-4b-ifb-bw1100-1x-vllm-018) |
+|  | BF16 | 0.18 | BW1000 | 1 | IFB | [**`>_`**](#qwen35-4b-ifb-bw1000-1x-vllm-018) |
+|  | BF16 | 0.18 | K100_AI | 1 | IFB | [**`>_`**](#qwen35-4b-ifb-k100_ai-1x-vllm-018) |
+|  | BF16 | 0.18-hotfix | BW1100 | 1 | IFB | [**`>_`**](#qwen35-4b-ifb-bw1100-1x-vllm-018-hotfix) |
+|  | BF16 | 0.18-hotfix | BW1000 | 1 | IFB | [**`>_`**](#qwen35-4b-ifb-bw1000-1x-vllm-018-hotfix) |
 |  | BF16 | 0.18-hotfix | K100_AI | 1 | IFB | [**`>_`**](#qwen35-4b-ifb-k100_ai-1x-vllm-018-hotfix) |
-| [Qwen/Qwen3.5-9B](https://www.modelscope.cn/models/Qwen/Qwen3.5-9B)           | BF16 | 0.21 | BW1100 | 1 | IFB | [**`>_`**](#qwen35-9b-ifb-bw1100-1x-vllm-021) |
-|  | BF16      | 0.18 | BW1100  | 1 | IFB | [**`>_`**](#qwen35-9b-ifb-bw1100-1x-vllm-018)          |
-|  | BF16 | 0.18-hotfix | BW1100 | 1 | IFB | [**`>_`**](#qwen35-9b-ifb-bw1100-1x-vllm-018-hotfix) |
+| [Qwen/Qwen3.5-9B](https://www.modelscope.cn/models/Qwen/Qwen3.5-9B) | BF16 | 0.21 | BW1100 | 1 | IFB | [**`>_`**](#qwen35-9b-ifb-bw1100-1x-vllm-021) |
 |  | BF16 | 0.21 | BW1000 | 1 | IFB | [**`>_`**](#qwen35-9b-ifb-bw1000-1x-vllm-021) |
-|                                                                               | BF16      | 0.18 | BW1000  | 1 | IFB | [**`>_`**](#qwen35-9b-ifb-bw1000-1x-vllm-018)           |
-|  | BF16 | 0.18-hotfix | BW1000 | 1 | IFB | [**`>_`**](#qwen35-9b-ifb-bw1000-1x-vllm-018-hotfix) |
 |  | BF16 | 0.21 | K100_AI | 1 | IFB | [**`>_`**](#qwen35-9b-ifb-k100_ai-1x-vllm-021) |
-|                                                                               | BF16      | 0.18 | K100_AI | 1 | IFB | [**`>_`**](#qwen35-9b-ifb-k100_ai-1x-vllm-018)           |
+|  | BF16 | 0.18 | BW1100 | 1 | IFB | [**`>_`**](#qwen35-9b-ifb-bw1100-1x-vllm-018) |
+|  | BF16 | 0.18 | BW1000 | 1 | IFB | [**`>_`**](#qwen35-9b-ifb-bw1000-1x-vllm-018) |
+|  | BF16 | 0.18 | K100_AI | 1 | IFB | [**`>_`**](#qwen35-9b-ifb-k100_ai-1x-vllm-018) |
+|  | BF16 | 0.18-hotfix | BW1100 | 1 | IFB | [**`>_`**](#qwen35-9b-ifb-bw1100-1x-vllm-018-hotfix) |
+|  | BF16 | 0.18-hotfix | BW1000 | 1 | IFB | [**`>_`**](#qwen35-9b-ifb-bw1000-1x-vllm-018-hotfix) |
 |  | BF16 | 0.18-hotfix | K100_AI | 1 | IFB | [**`>_`**](#qwen35-9b-ifb-k100_ai-1x-vllm-018-hotfix) |
-| [Qwen/Qwen3.5-27B](https://www.modelscope.cn/models/Qwen/Qwen3.5-27B)         | BF16 | 0.21 | BW1100 | 1 | IFB | [**`>_`**](#qwen35-27b-ifb-bw1100-1x-vllm-021) |
-|  | BF16      | 0.18 | BW1100  | 1 | IFB | [**`>_`**](#qwen35-27b-ifb-bw1100-1x-vllm-018)          |
-|  | BF16 | 0.18-hotfix | BW1100 | 1 | IFB | [**`>_`**](#qwen35-27b-ifb-bw1100-1x-vllm-018-hotfix) |
+| [Qwen/Qwen3.5-27B](https://www.modelscope.cn/models/Qwen/Qwen3.5-27B) | BF16 | 0.21 | BW1100 | 1 | IFB | [**`>_`**](#qwen35-27b-ifb-bw1100-1x-vllm-021) |
 |  | BF16 | 0.21 | BW1000 | 2 | IFB | [**`>_`**](#qwen35-27b-ifb-bw1000-2x-vllm-021) |
-|                                                                               | BF16      | 0.18 | BW1000  | 2 | IFB | [**`>_`**](#qwen35-27b-ifb-bw1000-2x-vllm-018)          |
-|  | BF16 | 0.18-hotfix | BW1000 | 2 | IFB | [**`>_`**](#qwen35-27b-ifb-bw1000-2x-vllm-018-hotfix) |
 |  | BF16 | 0.21 | K100_AI | 2 | IFB | [**`>_`**](#qwen35-27b-ifb-k100_ai-2x-vllm-021) |
-|                                                                               | BF16      | 0.18 | K100_AI | 2 | IFB | [**`>_`**](#qwen35-27b-ifb-k100_ai-2x-vllm-018)          |
+|  | BF16 | 0.18 | BW1100 | 1 | IFB | [**`>_`**](#qwen35-27b-ifb-bw1100-1x-vllm-018) |
+|  | BF16 | 0.18 | BW1000 | 2 | IFB | [**`>_`**](#qwen35-27b-ifb-bw1000-2x-vllm-018) |
+|  | BF16 | 0.18 | K100_AI | 2 | IFB | [**`>_`**](#qwen35-27b-ifb-k100_ai-2x-vllm-018) |
+|  | BF16 | 0.18-hotfix | BW1100 | 1 | IFB | [**`>_`**](#qwen35-27b-ifb-bw1100-1x-vllm-018-hotfix) |
+|  | BF16 | 0.18-hotfix | BW1000 | 2 | IFB | [**`>_`**](#qwen35-27b-ifb-bw1000-2x-vllm-018-hotfix) |
 |  | BF16 | 0.18-hotfix | K100_AI | 2 | IFB | [**`>_`**](#qwen35-27b-ifb-k100_ai-2x-vllm-018-hotfix) |
-|  | INT8 W8A8 | 0.21 | BW1100 | 1 | IFB | [**`>_`**](#qwen35-27b-channel-int8-w8a8-ifb-bw1100-1x-vllm-021) |
-| [hygon/Qwen3.5-27B-Channel-INT8-w8a8]() | INT8 W8A8 | 0.18 | BW1100  | 1 | IFB | [**`>_`**](#qwen35-27b-channel-int8-w8a8-ifb-bw1100-1x-vllm-018) |
-|  | INT8 W8A8 | 0.18-hotfix | BW1100 | 1 | IFB | [**`>_`**](#qwen35-27b-channel-int8-w8a8-ifb-bw1100-1x-vllm-018-hotfix) |
+| [hygon/Qwen3.5-27B-Channel-INT8-w8a8]() | INT8 W8A8 | 0.21 | BW1100 | 1 | IFB | [**`>_`**](#qwen35-27b-channel-int8-w8a8-ifb-bw1100-1x-vllm-021) |
 |  | INT8 W8A8 | 0.21 | BW1000 | 1 | IFB | [**`>_`**](#qwen35-27b-channel-int8-w8a8-ifb-bw1000-1x-vllm-021) |
-|                                                                                              | INT8 W8A8 | 0.18 | BW1000  | 1 | IFB | [**`>_`**](#qwen35-27b-channel-int8-w8a8-ifb-bw1000-1x-vllm-018) |
-|  | INT8 W8A8 | 0.18-hotfix | BW1000 | 1 | IFB | [**`>_`**](#qwen35-27b-channel-int8-w8a8-ifb-bw1000-1x-vllm-018-hotfix) |
 |  | INT8 W8A8 | 0.21 | K100_AI | 1 | IFB | [**`>_`**](#qwen35-27b-channel-int8-w8a8-ifb-k100_ai-1x-vllm-021) |
-|                                                                                              | INT8 W8A8 | 0.18 | K100_AI | 1 | IFB | [**`>_`**](#qwen35-27b-channel-int8-w8a8-ifb-k100_ai-1x-vllm-018) |
+|  | INT8 W8A8 | 0.18 | BW1100 | 1 | IFB | [**`>_`**](#qwen35-27b-channel-int8-w8a8-ifb-bw1100-1x-vllm-018) |
+|  | INT8 W8A8 | 0.18 | BW1000 | 1 | IFB | [**`>_`**](#qwen35-27b-channel-int8-w8a8-ifb-bw1000-1x-vllm-018) |
+|  | INT8 W8A8 | 0.18 | K100_AI | 1 | IFB | [**`>_`**](#qwen35-27b-channel-int8-w8a8-ifb-k100_ai-1x-vllm-018) |
+|  | INT8 W8A8 | 0.18-hotfix | BW1100 | 1 | IFB | [**`>_`**](#qwen35-27b-channel-int8-w8a8-ifb-bw1100-1x-vllm-018-hotfix) |
+|  | INT8 W8A8 | 0.18-hotfix | BW1000 | 1 | IFB | [**`>_`**](#qwen35-27b-channel-int8-w8a8-ifb-bw1000-1x-vllm-018-hotfix) |
 |  | INT8 W8A8 | 0.18-hotfix | K100_AI | 1 | IFB | [**`>_`**](#qwen35-27b-channel-int8-w8a8-ifb-k100_ai-1x-vllm-018-hotfix) |
-| [Qwen/Qwen3.5-27B-W8A8-FP8](https://modelscope.cn/models/hygon/Qwen3.5-27B-Channel-FP8-w8a8) | FP8 W8A8  | 0.18 | BW1100  | 1 | IFB | [**`>_`**](#qwen35-27b-w8a8-fp8-ifb-bw1100-1x-vllm-018) |
+| [Qwen/Qwen3.5-27B-W8A8-FP8](https://modelscope.cn/models/hygon/Qwen3.5-27B-Channel-FP8-w8a8) | FP8 W8A8 | 0.18 | BW1100 | 1 | IFB | [**`>_`**](#qwen35-27b-w8a8-fp8-ifb-bw1100-1x-vllm-018) |
 | [Qwen/Qwen3.5-35B-A3B](https://www.modelscope.cn/models/Qwen/Qwen3.5-35B-A3B) | BF16 | 0.21 | BW1100 | 1 | IFB | [**`>_`**](#qwen35-35b-a3b-ifb-bw1100-1x-vllm-021) |
-|  | BF16      | 0.18 | BW1100  | 1 | IFB | [**`>_`**](#qwen35-35b-a3b-ifb-bw1100-1x-vllm-018)     |
-|  | BF16 | 0.18-hotfix | BW1100 | 1 | IFB | [**`>_`**](#qwen35-35b-a3b-ifb-bw1100-1x-vllm-018-hotfix) |
 |  | BF16 | 0.21 | BW1000 | 2 | IFB | [**`>_`**](#qwen35-35b-a3b-ifb-bw1000-2x-vllm-021) |
-|                                                                               | BF16      | 0.18 | BW1000  | 2 | IFB | [**`>_`**](#qwen35-35b-a3b-ifb-bw1000-2x-vllm-018)      |
-|  | BF16 | 0.18-hotfix | BW1000 | 2 | IFB | [**`>_`**](#qwen35-35b-a3b-ifb-bw1000-2x-vllm-018-hotfix) |
 |  | BF16 | 0.21 | K100_AI | 2 | IFB | [**`>_`**](#qwen35-35b-a3b-ifb-k100_ai-2x-vllm-021) |
-|                                                                               | BF16      | 0.18 | K100_AI | 2 | IFB | [**`>_`**](#qwen35-35b-a3b-ifb-k100_ai-2x-vllm-018)      |
+|  | BF16 | 0.18 | BW1100 | 1 | IFB | [**`>_`**](#qwen35-35b-a3b-ifb-bw1100-1x-vllm-018) |
+|  | BF16 | 0.18 | BW1000 | 2 | IFB | [**`>_`**](#qwen35-35b-a3b-ifb-bw1000-2x-vllm-018) |
+|  | BF16 | 0.18 | K100_AI | 2 | IFB | [**`>_`**](#qwen35-35b-a3b-ifb-k100_ai-2x-vllm-018) |
+|  | BF16 | 0.18-hotfix | BW1100 | 1 | IFB | [**`>_`**](#qwen35-35b-a3b-ifb-bw1100-1x-vllm-018-hotfix) |
+|  | BF16 | 0.18-hotfix | BW1000 | 2 | IFB | [**`>_`**](#qwen35-35b-a3b-ifb-bw1000-2x-vllm-018-hotfix) |
 |  | BF16 | 0.18-hotfix | K100_AI | 2 | IFB | [**`>_`**](#qwen35-35b-a3b-ifb-k100_ai-2x-vllm-018-hotfix) |
 | [hygon/Qwen3.5-35B-A3B-Channel-INT8-w8a8](https://www.modelscope.cn/models/hygon/Qwen3.5-35B-A3B-Channel-INT8-w8a8) | INT8 W8A8 | 0.21 | BW1100 | 1 | IFB | [**`>_`**](#qwen35-35b-a3b-channel-int8-w8a8-ifb-bw1100-1x-vllm-021) |
-|  | INT8 W8A8 | 0.18 | BW1100  | 1 | IFB | [**`>_`**](#qwen35-35b-a3b-channel-int8-w8a8-ifb-bw1100-1x-vllm-018) |
-|  | INT8 W8A8 | 0.18-hotfix | BW1100 | 1 | IFB | [**`>_`**](#qwen35-35b-a3b-channel-int8-w8a8-ifb-bw1100-1x-vllm-018-hotfix) |
 |  | INT8 W8A8 | 0.21 | BW1000 | 1 | IFB | [**`>_`**](#qwen35-35b-a3b-channel-int8-w8a8-ifb-bw1000-1x-vllm-021) |
-|                                                                                              | INT8 W8A8 | 0.18 | BW1000  | 1 | IFB | [**`>_`**](#qwen35-35b-a3b-channel-int8-w8a8-ifb-bw1000-1x-vllm-018) |
-|  | INT8 W8A8 | 0.18-hotfix | BW1000 | 1 | IFB | [**`>_`**](#qwen35-35b-a3b-channel-int8-w8a8-ifb-bw1000-1x-vllm-018-hotfix) |
 |  | INT8 W8A8 | 0.21 | K100_AI | 1 | IFB | [**`>_`**](#qwen35-35b-a3b-channel-int8-w8a8-ifb-k100_ai-1x-vllm-021) |
-|                                                                                              | INT8 W8A8 | 0.18 | K100_AI | 1 | IFB | [**`>_`**](#qwen35-35b-a3b-channel-int8-w8a8-ifb-k100_ai-1x-vllm-018) |
+|  | INT8 W8A8 | 0.18 | BW1100 | 1 | IFB | [**`>_`**](#qwen35-35b-a3b-channel-int8-w8a8-ifb-bw1100-1x-vllm-018) |
+|  | INT8 W8A8 | 0.18 | BW1000 | 1 | IFB | [**`>_`**](#qwen35-35b-a3b-channel-int8-w8a8-ifb-bw1000-1x-vllm-018) |
+|  | INT8 W8A8 | 0.18 | K100_AI | 1 | IFB | [**`>_`**](#qwen35-35b-a3b-channel-int8-w8a8-ifb-k100_ai-1x-vllm-018) |
+|  | INT8 W8A8 | 0.18-hotfix | BW1100 | 1 | IFB | [**`>_`**](#qwen35-35b-a3b-channel-int8-w8a8-ifb-bw1100-1x-vllm-018-hotfix) |
+|  | INT8 W8A8 | 0.18-hotfix | BW1000 | 1 | IFB | [**`>_`**](#qwen35-35b-a3b-channel-int8-w8a8-ifb-bw1000-1x-vllm-018-hotfix) |
 |  | INT8 W8A8 | 0.18-hotfix | K100_AI | 1 | IFB | [**`>_`**](#qwen35-35b-a3b-channel-int8-w8a8-ifb-k100_ai-1x-vllm-018-hotfix) |
-| [hygon/Qwen3.5-35B-A3B-Channel-FP8-w8a8](https://www.modelscope.cn/models/hygon/Qwen3.5-35B-A3B-Channel-FP8-w8a8)       | FP8 W8A8 | 0.21 | BW1100 | 1 | IFB | [**`>_`**](#qwen35-35b-a3b-channel-fp8-w8a8-ifb-bw1100-1x-vllm-021) |
-|  | FP8 W8A8  | 0.18 | BW1100  | 1 | IFB | [**`>_`**](#qwen35-35b-a3b-channel-fp8-w8a8-ifb-bw1100-1x-vllm-018) |
+| [hygon/Qwen3.5-35B-A3B-Channel-FP8-w8a8](https://www.modelscope.cn/models/hygon/Qwen3.5-35B-A3B-Channel-FP8-w8a8) | FP8 W8A8 | 0.21 | BW1100 | 1 | IFB | [**`>_`**](#qwen35-35b-a3b-channel-fp8-w8a8-ifb-bw1100-1x-vllm-021) |
+|  | FP8 W8A8 | 0.18 | BW1100 | 1 | IFB | [**`>_`**](#qwen35-35b-a3b-channel-fp8-w8a8-ifb-bw1100-1x-vllm-018) |
 |  | FP8 W8A8 | 0.18-hotfix | BW1100 | 1 | IFB | [**`>_`**](#qwen35-35b-a3b-channel-fp8-w8a8-ifb-bw1100-1x-vllm-018-hotfix) |
 | [Qwen/Qwen3.5-122B-A10B](https://www.modelscope.cn/models/Qwen/Qwen3.5-122B-A10B) | BF16 | 0.21 | BW1100 | 4 | IFB | [**`>_`**](#qwen35-122b-a10b-ifb-bw1100-4x-vllm-021) |
-|  | BF16   | [0.18](../docker_images.md) | BW1100  | 4 | IFB | [**`>_`**](#qwen35-122b-a10b-ifb-bw1100-4x-vllm-018)  |
-|  | BF16 | 0.18-hotfix | BW1100 | 4 | IFB | [**`>_`**](#qwen35-122b-a10b-ifb-bw1100-4x-vllm-018-hotfix) |
 |  | BF16 | 0.21 | BW1000 | 8 | IFB | [**`>_`**](#qwen35-122b-a10b-ifb-bw1000-8x-vllm-021) |
-|                                                                                  | BF16   | [0.18](../docker_images.md) | BW1000  | 8 | IFB | [**`>_`**](#qwen35-122b-a10b-ifb-bw1000-8x-vllm-018)   |
-|  | BF16 | 0.18-hotfix | BW1000 | 8 | IFB | [**`>_`**](#qwen35-122b-a10b-ifb-bw1000-8x-vllm-018-hotfix) |
 |  | BF16 | 0.21 | K100_AI | 8 | IFB | [**`>_`**](#qwen35-122b-a10b-ifb-k100_ai-8x-vllm-021) |
-|                                                                                  | BF16   | [0.18](../docker_images.md) | K100_AI | 8 | IFB | [**`>_`**](#qwen35-122b-a10b-ifb-k100_ai-8x-vllm-018)   |
+|  | BF16 | 0.18-hotfix | BW1100 | 4 | IFB | [**`>_`**](#qwen35-122b-a10b-ifb-bw1100-4x-vllm-018-hotfix) |
+|  | BF16 | 0.18-hotfix | BW1000 | 8 | IFB | [**`>_`**](#qwen35-122b-a10b-ifb-bw1000-8x-vllm-018-hotfix) |
 |  | BF16 | 0.18-hotfix | K100_AI | 8 | IFB | [**`>_`**](#qwen35-122b-a10b-ifb-k100_ai-8x-vllm-018-hotfix) |
+|  | BF16 | [0.18](../docker_images.md) | BW1100 | 4 | IFB | [**`>_`**](#qwen35-122b-a10b-ifb-bw1100-4x-vllm-018) |
+|  | BF16 | [0.18](../docker_images.md) | BW1000 | 8 | IFB | [**`>_`**](#qwen35-122b-a10b-ifb-bw1000-8x-vllm-018) |
+|  | BF16 | [0.18](../docker_images.md) | K100_AI | 8 | IFB | [**`>_`**](#qwen35-122b-a10b-ifb-k100_ai-8x-vllm-018) |
 | [Qwen/Qwen3.5-122B-A10B-AWQ](https://www.modelscope.cn/models/tclf90/Qwen3.5-122B-A10B-AWQ) | AWQ | 0.18 | K100_AI | 4 | IFB | [**`>_`**](#qwen35-122b-a10b-awq-ifb-k100_ai-4x-vllm-018) |
 | [Qwen/Qwen3.5-122B-A10B-W8A8-INT8](https://www.modelscope.cn/models/Qwen/Qwen3.5-122B-A10B-W8A8-INT8) | INT8 W8A8 | 0.21 | BW1100 | 2 | IFB | [**`>_`**](#qwen35-122b-a10b-w8a8-int8-ifb-bw1100-2x-vllm-021) |
-|  | INT8 W8A8 | 0.18 | BW1100  | 2 | IFB | [**`>_`**](#qwen35-122b-a10b-w8a8-int8-ifb-bw1100-2x-vllm-018) |
-|  | INT8 W8A8 | 0.18-hotfix | BW1100 | 2 | IFB | [**`>_`**](#qwen35-122b-a10b-w8a8-int8-ifb-bw1100-2x-vllm-018-hotfix) |
 |  | INT8 W8A8 | 0.21 | BW1000 | 4 | IFB | [**`>_`**](#qwen35-122b-a10b-w8a8-int8-ifb-bw1000-4x-vllm-021) |
-|                                                                                               | INT8 W8A8 | 0.18 | BW1000  | 4 | IFB | [**`>_`**](#qwen35-122b-a10b-w8a8-int8-ifb-bw1000-4x-vllm-018) |
-|  | INT8 W8A8 | 0.18-hotfix | BW1000 | 4 | IFB | [**`>_`**](#qwen35-122b-a10b-w8a8-int8-ifb-bw1000-4x-vllm-018-hotfix) |
 |  | INT8 W8A8 | 0.21 | K100_AI | 4 | IFB | [**`>_`**](#qwen35-122b-a10b-w8a8-int8-ifb-k100_ai-4x-vllm-021) |
-|                                                                                               | INT8 W8A8 | [0.18](../docker_images.md) | K100_AI | 4 | IFB | [**`>_`**](#qwen35-122b-a10b-w8a8-int8-ifb-k100_ai-4x-vllm-018) |
+|  | INT8 W8A8 | 0.18 | BW1100 | 2 | IFB | [**`>_`**](#qwen35-122b-a10b-w8a8-int8-ifb-bw1100-2x-vllm-018) |
+|  | INT8 W8A8 | 0.18 | BW1000 | 4 | IFB | [**`>_`**](#qwen35-122b-a10b-w8a8-int8-ifb-bw1000-4x-vllm-018) |
+|  | INT8 W8A8 | 0.18-hotfix | BW1100 | 2 | IFB | [**`>_`**](#qwen35-122b-a10b-w8a8-int8-ifb-bw1100-2x-vllm-018-hotfix) |
+|  | INT8 W8A8 | 0.18-hotfix | BW1000 | 4 | IFB | [**`>_`**](#qwen35-122b-a10b-w8a8-int8-ifb-bw1000-4x-vllm-018-hotfix) |
 |  | INT8 W8A8 | 0.18-hotfix | K100_AI | 4 | IFB | [**`>_`**](#qwen35-122b-a10b-w8a8-int8-ifb-k100_ai-4x-vllm-018-hotfix) |
-| [hygon/Qwen3.5-122B-A10B-Channel-FP8-w8a8](https://www.modelscope.cn/models/hygon/Qwen3.5-122B-A10B-Channel-FP8-w8a8)    | FP8 W8A8 | 0.21 | BW1100 | 2 | IFB | [**`>_`**](#qwen35-122b-a10b-channel-fp8-w8a8-ifb-bw1100-2x-vllm-021) |
-|  | FP8 W8A8  | 0.18 | BW1100  | 2 | IFB | [**`>_`**](#qwen35-122b-a10b-channel-fp8-w8a8-ifb-bw1100-2x-vllm-018) |
+|  | INT8 W8A8 | [0.18](../docker_images.md) | K100_AI | 4 | IFB | [**`>_`**](#qwen35-122b-a10b-w8a8-int8-ifb-k100_ai-4x-vllm-018) |
+| [hygon/Qwen3.5-122B-A10B-Channel-FP8-w8a8](https://www.modelscope.cn/models/hygon/Qwen3.5-122B-A10B-Channel-FP8-w8a8) | FP8 W8A8 | 0.21 | BW1100 | 2 | IFB | [**`>_`**](#qwen35-122b-a10b-channel-fp8-w8a8-ifb-bw1100-2x-vllm-021) |
+|  | FP8 W8A8 | 0.18 | BW1100 | 2 | IFB | [**`>_`**](#qwen35-122b-a10b-channel-fp8-w8a8-ifb-bw1100-2x-vllm-018) |
 |  | FP8 W8A8 | 0.18-hotfix | BW1100 | 2 | IFB | [**`>_`**](#qwen35-122b-a10b-channel-fp8-w8a8-ifb-bw1100-2x-vllm-018-hotfix) |
 | [Qwen/Qwen3.5-397B-A17B-W8A8-INT8](https://modelscope.cn/models/hygon/Qwen3.5-397B-A17B-Channel-INT8-w8a8) | INT8 W8A8 | 0.21 | BW1100 | 8 | IFB | [**`>_`**](#qwen35-397b-a17b-w8a8-int8-ifb-bw1100-8x-vllm-021) |
-|  | INT8 W8A8 | [0.18](../docker_images.md) | BW1100  | 8 | IFB | [**`>_`**](#qwen35-397b-a17b-w8a8-int8-ifb-bw1100-8x-vllm-018) |
-|  | INT8 W8A8 | 0.18-hotfix | BW1100 | 8 | IFB | [**`>_`**](#qwen35-397b-a17b-w8a8-int8-ifb-bw1100-8x-vllm-018-hotfix) |
 |  | INT8 W8A8 | 0.21 | BW1000 | 8 | IFB | [**`>_`**](#qwen35-397b-a17b-w8a8-int8-ifb-bw1000-8x-vllm-021) |
-|                                                                                                | INT8 W8A8 | 0.18 | BW1000  | 8 | IFB | [**`>_`**](#qwen35-397b-a17b-w8a8-int8-ifb-bw1000-8x-vllm-018) |
-|  | INT8 W8A8 | 0.18-hotfix | BW1000 | 8 | IFB | [**`>_`**](#qwen35-397b-a17b-w8a8-int8-ifb-bw1000-8x-vllm-018-hotfix) |
 |  | INT8 W8A8 | 0.21 | K100_AI | 8 | IFB | [**`>_`**](#qwen35-397b-a17b-w8a8-int8-ifb-k100_ai-8x-vllm-021) |
-|                                                                                                | INT8 W8A8 | 0.18 | K100_AI | 8 | IFB | [**`>_`**](#qwen35-397b-a17b-w8a8-int8-ifb-k100_ai-8x-vllm-018) |
+|  | INT8 W8A8 | 0.18 | BW1000 | 8 | IFB | [**`>_`**](#qwen35-397b-a17b-w8a8-int8-ifb-bw1000-8x-vllm-018) |
+|  | INT8 W8A8 | 0.18 | K100_AI | 8 | IFB | [**`>_`**](#qwen35-397b-a17b-w8a8-int8-ifb-k100_ai-8x-vllm-018) |
+|  | INT8 W8A8 | 0.18-hotfix | BW1100 | 8 | IFB | [**`>_`**](#qwen35-397b-a17b-w8a8-int8-ifb-bw1100-8x-vllm-018-hotfix) |
+|  | INT8 W8A8 | 0.18-hotfix | BW1000 | 8 | IFB | [**`>_`**](#qwen35-397b-a17b-w8a8-int8-ifb-bw1000-8x-vllm-018-hotfix) |
 |  | INT8 W8A8 | 0.18-hotfix | K100_AI | 8 | IFB | [**`>_`**](#qwen35-397b-a17b-w8a8-int8-ifb-k100_ai-8x-vllm-018-hotfix) |
+|  | INT8 W8A8 | [0.18](../docker_images.md) | BW1100 | 8 | IFB | [**`>_`**](#qwen35-397b-a17b-w8a8-int8-ifb-bw1100-8x-vllm-018) |
 | [hygon/Qwen3.5-397B-A17B-Channel-FP8](https://www.modelscope.cn/models/hygon/Qwen3.5-397B-A17B-Channel-FP8) | FP8 W8A8 | 0.21 | BW1100 | 4 | IFB | [**`>_`**](#qwen35-397b-a17b-channel-fp8-ifb-bw1100-4x-vllm-021) |
-|  | FP8 W8A8 | [0.18](../docker_images.md) | BW1100  | 4 | IFB | [**`>_`**](#qwen35-397b-a17b-channel-fp8-ifb-bw1100-4x-vllm-018) |
 |  | FP8 W8A8 | 0.18-hotfix | BW1100 | 4 | IFB | [**`>_`**](#qwen35-397b-a17b-channel-fp8-ifb-bw1100-4x-vllm-018-hotfix) |
+|  | FP8 W8A8 | [0.18](../docker_images.md) | BW1100 | 4 | IFB | [**`>_`**](#qwen35-397b-a17b-channel-fp8-ifb-bw1100-4x-vllm-018) |
 
 ## 启动命令
 
@@ -116,11 +116,68 @@ vllm serve Qwen/Qwen3.5-4B \
   --attention-backend FLASH_ATTN_CUSTOM \
   --max-num-seqs 128
 ```
+
+### Qwen3.5-4B IFB BW1000 1x vLLM 0.21
+
+```bash
+vllm serve Qwen/Qwen3.5-4B \
+  -tp 1 \
+  --trust-remote-code \
+  --max-num-batched-tokens 16384 \
+  --speculative-config.method mtp \
+  --speculative-config.num_speculative_tokens 3 \
+  --attention-backend FLASH_ATTN_CUSTOM \
+  --max-num-seqs 128
+```
+
+### Qwen3.5-4B IFB K100_AI 1x vLLM 0.21
+
+```bash
+export VLLM_HCU_USE_CUSTOM_QUANTIZATION_GEMM=0
+export VLLM_HCU_USE_CUSTOM_OPS=0
+
+vllm serve Qwen/Qwen3.5-4B \
+  -tp 1 \
+  --trust-remote-code \
+  --max-num-batched-tokens 16384 \
+  --speculative-config.method mtp \
+  --speculative-config.num_speculative_tokens 3 \
+  --max-num-seqs 128
+```
+
 ### Qwen3.5-4B IFB BW1100 1x vLLM 0.18
 
 ```bash
 export VLLM_HCU_USE_FLASH_ATTN=1
 export VLLM_HCU_USE_CUSTOM_TOPK_TOPP_SAMPLER=1
+
+vllm serve Qwen/Qwen3.5-4B \
+  -tp 1 \
+  --trust-remote-code \
+  --max-num-batched-tokens 10240 \
+  --speculative-config.method mtp \
+  --speculative-config.num_speculative_tokens 3
+```
+
+### Qwen3.5-4B IFB BW1000 1x vLLM 0.18
+
+```bash
+export VLLM_HCU_USE_FLASH_ATTN=1
+export VLLM_HCU_USE_CUSTOM_TOPK_TOPP_SAMPLER=1
+
+vllm serve Qwen/Qwen3.5-4B \
+  -tp 1 \
+  --trust-remote-code \
+  --max-num-batched-tokens 10240 \
+  --speculative-config.method mtp \
+  --speculative-config.num_speculative_tokens 3
+```
+
+### Qwen3.5-4B IFB K100_AI 1x vLLM 0.18
+
+```bash
+export VLLM_HCU_USE_CUSTOM_QUANTIZATION_GEMM=0
+export VLLM_HCU_USE_CUSTOM_OPS=0
 
 vllm serve Qwen/Qwen3.5-4B \
   -tp 1 \
@@ -142,32 +199,6 @@ vllm serve Qwen/Qwen3.5-4B \
   --kv-cache-dtype fp8_e4m3 \
   --attention-backend FLASH_ATTN_CUSTOM
 ```
-### Qwen3.5-4B IFB BW1000 1x vLLM 0.21
-
-```bash
-vllm serve Qwen/Qwen3.5-4B \
-  -tp 1 \
-  --trust-remote-code \
-  --max-num-batched-tokens 16384 \
-  --speculative-config.method mtp \
-  --speculative-config.num_speculative_tokens 3 \
-  --attention-backend FLASH_ATTN_CUSTOM \
-  --max-num-seqs 128
-```
-
-### Qwen3.5-4B IFB BW1000 1x vLLM 0.18
-
-```bash
-export VLLM_HCU_USE_FLASH_ATTN=1
-export VLLM_HCU_USE_CUSTOM_TOPK_TOPP_SAMPLER=1
-
-vllm serve Qwen/Qwen3.5-4B \
-  -tp 1 \
-  --trust-remote-code \
-  --max-num-batched-tokens 10240 \
-  --speculative-config.method mtp \
-  --speculative-config.num_speculative_tokens 3
-```
 
 ### Qwen3.5-4B IFB BW1000 1x vLLM 0.18-hotfix
 
@@ -179,34 +210,6 @@ vllm serve Qwen/Qwen3.5-4B \
   --speculative-config.method mtp \
   --speculative-config.num_speculative_tokens 3 \
   --attention-backend FLASH_ATTN_CUSTOM
-```
-
-### Qwen3.5-4B IFB K100_AI 1x vLLM 0.21
-
-```bash
-export VLLM_HCU_USE_CUSTOM_QUANTIZATION_GEMM=0
-export VLLM_HCU_USE_CUSTOM_OPS=0
-
-vllm serve Qwen/Qwen3.5-4B \
-  -tp 1 \
-  --trust-remote-code \
-  --max-num-batched-tokens 16384 \
-  --speculative-config.method mtp \
-  --speculative-config.num_speculative_tokens 3 \
-  --max-num-seqs 128
-```
-### Qwen3.5-4B IFB K100_AI 1x vLLM 0.18
-
-```bash
-export VLLM_HCU_USE_CUSTOM_QUANTIZATION_GEMM=0
-export VLLM_HCU_USE_CUSTOM_OPS=0
-
-vllm serve Qwen/Qwen3.5-4B \
-  -tp 1 \
-  --trust-remote-code \
-  --max-num-batched-tokens 10240 \
-  --speculative-config.method mtp \
-  --speculative-config.num_speculative_tokens 3
 ```
 
 ### Qwen3.5-4B IFB K100_AI 1x vLLM 0.18-hotfix
@@ -222,6 +225,7 @@ vllm serve Qwen/Qwen3.5-4B \
   --speculative-config.method mtp \
   --speculative-config.num_speculative_tokens 3
 ```
+
 ### Qwen3.5-9B IFB BW1100 1x vLLM 0.21
 
 ```bash
@@ -235,11 +239,68 @@ vllm serve Qwen/Qwen3.5-9B \
   --attention-backend FLASH_ATTN_CUSTOM \
   --max-num-seqs 128
 ```
+
+### Qwen3.5-9B IFB BW1000 1x vLLM 0.21
+
+```bash
+vllm serve Qwen/Qwen3.5-9B \
+  -tp 1 \
+  --trust-remote-code \
+  --max-num-batched-tokens 16384 \
+  --speculative-config.method mtp \
+  --speculative-config.num_speculative_tokens 3 \
+  --attention-backend FLASH_ATTN_CUSTOM \
+  --max-num-seqs 128
+```
+
+### Qwen3.5-9B IFB K100_AI 1x vLLM 0.21
+
+```bash
+export VLLM_HCU_USE_CUSTOM_QUANTIZATION_GEMM=0
+export VLLM_HCU_USE_CUSTOM_OPS=0
+
+vllm serve Qwen/Qwen3.5-9B \
+  -tp 1 \
+  --trust-remote-code \
+  --max-num-batched-tokens 16384 \
+  --speculative-config.method mtp \
+  --speculative-config.num_speculative_tokens 3 \
+  --max-num-seqs 128
+```
+
 ### Qwen3.5-9B IFB BW1100 1x vLLM 0.18
 
 ```bash
 export VLLM_HCU_USE_FLASH_ATTN=1
 export VLLM_HCU_USE_CUSTOM_TOPK_TOPP_SAMPLER=1
+
+vllm serve Qwen/Qwen3.5-9B \
+  -tp 1 \
+  --trust-remote-code \
+  --max-num-batched-tokens 10240 \
+  --speculative-config.method mtp \
+  --speculative-config.num_speculative_tokens 3
+```
+
+### Qwen3.5-9B IFB BW1000 1x vLLM 0.18
+
+```bash
+export VLLM_HCU_USE_FLASH_ATTN=1
+export VLLM_HCU_USE_CUSTOM_TOPK_TOPP_SAMPLER=1
+
+vllm serve Qwen/Qwen3.5-9B \
+  -tp 1 \
+  --trust-remote-code \
+  --max-num-batched-tokens 10240 \
+  --speculative-config.method mtp \
+  --speculative-config.num_speculative_tokens 3
+```
+
+### Qwen3.5-9B IFB K100_AI 1x vLLM 0.18
+
+```bash
+export VLLM_HCU_USE_CUSTOM_QUANTIZATION_GEMM=0
+export VLLM_HCU_USE_CUSTOM_OPS=0
 
 vllm serve Qwen/Qwen3.5-9B \
   -tp 1 \
@@ -261,31 +322,6 @@ vllm serve Qwen/Qwen3.5-9B \
   --kv-cache-dtype fp8_e4m3 \
   --attention-backend FLASH_ATTN_CUSTOM
 ```
-### Qwen3.5-9B IFB BW1000 1x vLLM 0.21
-
-```bash
-vllm serve Qwen/Qwen3.5-9B \
-  -tp 1 \
-  --trust-remote-code \
-  --max-num-batched-tokens 16384 \
-  --speculative-config.method mtp \
-  --speculative-config.num_speculative_tokens 3 \
-  --attention-backend FLASH_ATTN_CUSTOM \
-  --max-num-seqs 128
-```
-### Qwen3.5-9B IFB BW1000 1x vLLM 0.18
-
-```bash
-export VLLM_HCU_USE_FLASH_ATTN=1
-export VLLM_HCU_USE_CUSTOM_TOPK_TOPP_SAMPLER=1
-
-vllm serve Qwen/Qwen3.5-9B \
-  -tp 1 \
-  --trust-remote-code \
-  --max-num-batched-tokens 10240 \
-  --speculative-config.method mtp \
-  --speculative-config.num_speculative_tokens 3
-```
 
 ### Qwen3.5-9B IFB BW1000 1x vLLM 0.18-hotfix
 
@@ -297,33 +333,6 @@ vllm serve Qwen/Qwen3.5-9B \
   --speculative-config.method mtp \
   --speculative-config.num_speculative_tokens 3 \
   --attention-backend FLASH_ATTN_CUSTOM
-```
-### Qwen3.5-9B IFB K100_AI 1x vLLM 0.21
-
-```bash
-export VLLM_HCU_USE_CUSTOM_QUANTIZATION_GEMM=0
-export VLLM_HCU_USE_CUSTOM_OPS=0
-
-vllm serve Qwen/Qwen3.5-9B \
-  -tp 1 \
-  --trust-remote-code \
-  --max-num-batched-tokens 16384 \
-  --speculative-config.method mtp \
-  --speculative-config.num_speculative_tokens 3 \
-  --max-num-seqs 128
-```
-### Qwen3.5-9B IFB K100_AI 1x vLLM 0.18
-
-```bash
-export VLLM_HCU_USE_CUSTOM_QUANTIZATION_GEMM=0
-export VLLM_HCU_USE_CUSTOM_OPS=0
-
-vllm serve Qwen/Qwen3.5-9B \
-  -tp 1 \
-  --trust-remote-code \
-  --max-num-batched-tokens 10240 \
-  --speculative-config.method mtp \
-  --speculative-config.num_speculative_tokens 3
 ```
 
 ### Qwen3.5-9B IFB K100_AI 1x vLLM 0.18-hotfix
@@ -339,6 +348,7 @@ vllm serve Qwen/Qwen3.5-9B \
   --speculative-config.method mtp \
   --speculative-config.num_speculative_tokens 3
 ```
+
 ### Qwen3.5-27B IFB BW1100 1x vLLM 0.21
 
 ```bash
@@ -352,6 +362,35 @@ vllm serve Qwen/Qwen3.5-27B \
   --attention-backend FLASH_ATTN_CUSTOM \
   --max-num-seqs 128
 ```
+
+### Qwen3.5-27B IFB BW1000 2x vLLM 0.21
+
+```bash
+vllm serve Qwen/Qwen3.5-27B \
+  -tp 2 \
+  --trust-remote-code \
+  --max-num-batched-tokens 16384 \
+  --speculative-config.method mtp \
+  --speculative-config.num_speculative_tokens 3 \
+  --attention-backend FLASH_ATTN_CUSTOM \
+  --max-num-seqs 128
+```
+
+### Qwen3.5-27B IFB K100_AI 2x vLLM 0.21
+
+```bash
+export VLLM_HCU_USE_CUSTOM_QUANTIZATION_GEMM=0
+export VLLM_HCU_USE_CUSTOM_OPS=0
+
+vllm serve Qwen/Qwen3.5-27B \
+  -tp 2 \
+  --trust-remote-code \
+  --max-num-batched-tokens 16384 \
+  --speculative-config.method mtp \
+  --speculative-config.num_speculative_tokens 3 \
+  --max-num-seqs 128
+```
+
 ### Qwen3.5-27B IFB BW1100 1x vLLM 0.18
 
 ```bash
@@ -360,6 +399,34 @@ export VLLM_HCU_USE_CUSTOM_TOPK_TOPP_SAMPLER=1
 
 vllm serve Qwen/Qwen3.5-27B \
   -tp 1 \
+  --trust-remote-code \
+  --max-num-batched-tokens 10240 \
+  --speculative-config.method mtp \
+  --speculative-config.num_speculative_tokens 3
+```
+
+### Qwen3.5-27B IFB BW1000 2x vLLM 0.18
+
+```bash
+export VLLM_HCU_USE_FLASH_ATTN=1
+export VLLM_HCU_USE_CUSTOM_TOPK_TOPP_SAMPLER=1
+
+vllm serve Qwen/Qwen3.5-27B \
+  -tp 2 \
+  --trust-remote-code \
+  --max-num-batched-tokens 10240 \
+  --speculative-config.method mtp \
+  --speculative-config.num_speculative_tokens 3
+```
+
+### Qwen3.5-27B IFB K100_AI 2x vLLM 0.18
+
+```bash
+export VLLM_HCU_USE_CUSTOM_QUANTIZATION_GEMM=0
+export VLLM_HCU_USE_CUSTOM_OPS=0
+
+vllm serve Qwen/Qwen3.5-27B \
+  -tp 2 \
   --trust-remote-code \
   --max-num-batched-tokens 10240 \
   --speculative-config.method mtp \
@@ -378,31 +445,6 @@ vllm serve Qwen/Qwen3.5-27B \
   --kv-cache-dtype fp8_e4m3 \
   --attention-backend FLASH_ATTN_CUSTOM
 ```
-### Qwen3.5-27B IFB BW1000 2x vLLM 0.21
-
-```bash
-vllm serve Qwen/Qwen3.5-27B \
-  -tp 2 \
-  --trust-remote-code \
-  --max-num-batched-tokens 16384 \
-  --speculative-config.method mtp \
-  --speculative-config.num_speculative_tokens 3 \
-  --attention-backend FLASH_ATTN_CUSTOM \
-  --max-num-seqs 128
-```
-### Qwen3.5-27B IFB BW1000 2x vLLM 0.18
-
-```bash
-export VLLM_HCU_USE_FLASH_ATTN=1
-export VLLM_HCU_USE_CUSTOM_TOPK_TOPP_SAMPLER=1
-
-vllm serve Qwen/Qwen3.5-27B \
-  -tp 2 \
-  --trust-remote-code \
-  --max-num-batched-tokens 10240 \
-  --speculative-config.method mtp \
-  --speculative-config.num_speculative_tokens 3
-```
 
 ### Qwen3.5-27B IFB BW1000 2x vLLM 0.18-hotfix
 
@@ -414,33 +456,6 @@ vllm serve Qwen/Qwen3.5-27B \
   --speculative-config.method mtp \
   --speculative-config.num_speculative_tokens 3 \
   --attention-backend FLASH_ATTN_CUSTOM
-```
-### Qwen3.5-27B IFB K100_AI 2x vLLM 0.21
-
-```bash
-export VLLM_HCU_USE_CUSTOM_QUANTIZATION_GEMM=0
-export VLLM_HCU_USE_CUSTOM_OPS=0
-
-vllm serve Qwen/Qwen3.5-27B \
-  -tp 2 \
-  --trust-remote-code \
-  --max-num-batched-tokens 16384 \
-  --speculative-config.method mtp \
-  --speculative-config.num_speculative_tokens 3 \
-  --max-num-seqs 128
-```
-### Qwen3.5-27B IFB K100_AI 2x vLLM 0.18
-
-```bash
-export VLLM_HCU_USE_CUSTOM_QUANTIZATION_GEMM=0
-export VLLM_HCU_USE_CUSTOM_OPS=0
-
-vllm serve Qwen/Qwen3.5-27B \
-  -tp 2 \
-  --trust-remote-code \
-  --max-num-batched-tokens 10240 \
-  --speculative-config.method mtp \
-  --speculative-config.num_speculative_tokens 3
 ```
 
 ### Qwen3.5-27B IFB K100_AI 2x vLLM 0.18-hotfix
@@ -456,6 +471,7 @@ vllm serve Qwen/Qwen3.5-27B \
   --speculative-config.method mtp \
   --speculative-config.num_speculative_tokens 3
 ```
+
 ### Qwen3.5-27B-Channel-INT8-w8a8 IFB BW1100 1x vLLM 0.21
 
 ```bash
@@ -471,6 +487,37 @@ vllm serve hygon/Qwen3.5-27B-Channel-INT8-w8a8 \
   --attention-backend FLASH_ATTN_CUSTOM \
   --max-num-seqs 128
 ```
+
+### Qwen3.5-27B-Channel-INT8-w8a8 IFB BW1000 1x vLLM 0.21
+
+```bash
+vllm serve hygon/Qwen3.5-27B-Channel-INT8-w8a8 \
+  -tp 1 \
+  --trust-remote-code \
+  --max-num-batched-tokens 16384 \
+  -q slimquant_marlin \
+  --speculative-config.method mtp \
+  --speculative-config.num_speculative_tokens 3 \
+  --speculative-config.quantization "slimquant_marlin" \
+  --attention-backend FLASH_ATTN_CUSTOM \
+  --max-num-seqs 128
+```
+
+### Qwen3.5-27B-Channel-INT8-w8a8 IFB K100_AI 1x vLLM 0.21
+
+```bash
+export VLLM_HCU_USE_CUSTOM_QUANTIZATION_GEMM=0
+export VLLM_HCU_USE_CUSTOM_OPS=0
+
+vllm serve hygon/Qwen3.5-27B-Channel-INT8-w8a8 \
+  -tp 1 \
+  --trust-remote-code \
+  --max-num-batched-tokens 16384 \
+  --speculative-config.method mtp \
+  --speculative-config.num_speculative_tokens 3 \
+  --max-num-seqs 128
+```
+
 ### Qwen3.5-27B-Channel-INT8-w8a8 IFB BW1100 1x vLLM 0.18
 
 ```bash
@@ -487,34 +534,6 @@ vllm serve hygon/Qwen3.5-27B-Channel-INT8-w8a8 \
   --speculative-config.quantization "slimquant_marlin"
 ```
 
-### Qwen3.5-27B-Channel-INT8-w8a8 IFB BW1100 1x vLLM 0.18-hotfix
-
-```bash
-vllm serve hygon/Qwen3.5-27B-Channel-INT8-w8a8 \
-  -tp 1 \
-  --trust-remote-code \
-  --max-num-batched-tokens 10240 \
-  -q slimquant_marlin \
-  --speculative-config.method mtp \
-  --speculative-config.num_speculative_tokens 3 \
-  --speculative-config.quantization "slimquant_marlin" \
-  --kv-cache-dtype fp8_e4m3 \
-  --attention-backend FLASH_ATTN_CUSTOM
-```
-### Qwen3.5-27B-Channel-INT8-w8a8 IFB BW1000 1x vLLM 0.21
-
-```bash
-vllm serve hygon/Qwen3.5-27B-Channel-INT8-w8a8 \
-  -tp 1 \
-  --trust-remote-code \
-  --max-num-batched-tokens 16384 \
-  -q slimquant_marlin \
-  --speculative-config.method mtp \
-  --speculative-config.num_speculative_tokens 3 \
-  --speculative-config.quantization "slimquant_marlin" \
-  --attention-backend FLASH_ATTN_CUSTOM \
-  --max-num-seqs 128
-```
 ### Qwen3.5-27B-Channel-INT8-w8a8 IFB BW1000 1x vLLM 0.18
 
 ```bash
@@ -531,33 +550,6 @@ vllm serve hygon/Qwen3.5-27B-Channel-INT8-w8a8 \
   --speculative-config.quantization "slimquant_marlin"
 ```
 
-### Qwen3.5-27B-Channel-INT8-w8a8 IFB BW1000 1x vLLM 0.18-hotfix
-
-```bash
-vllm serve hygon/Qwen3.5-27B-Channel-INT8-w8a8 \
-  -tp 1 \
-  --trust-remote-code \
-  --max-num-batched-tokens 10240 \
-  -q slimquant_marlin \
-  --speculative-config.method mtp \
-  --speculative-config.num_speculative_tokens 3 \
-  --speculative-config.quantization "slimquant_marlin" \
-  --attention-backend FLASH_ATTN_CUSTOM
-```
-### Qwen3.5-27B-Channel-INT8-w8a8 IFB K100_AI 1x vLLM 0.21
-
-```bash
-export VLLM_HCU_USE_CUSTOM_QUANTIZATION_GEMM=0
-export VLLM_HCU_USE_CUSTOM_OPS=0
-
-vllm serve hygon/Qwen3.5-27B-Channel-INT8-w8a8 \
-  -tp 1 \
-  --trust-remote-code \
-  --max-num-batched-tokens 16384 \
-  --speculative-config.method mtp \
-  --speculative-config.num_speculative_tokens 3 \
-  --max-num-seqs 128
-```
 ### Qwen3.5-27B-Channel-INT8-w8a8 IFB K100_AI 1x vLLM 0.18
 
 ```bash
@@ -570,6 +562,35 @@ vllm serve hygon/Qwen3.5-27B-Channel-INT8-w8a8 \
   --max-num-batched-tokens 10240 \
   --speculative-config.method mtp \
   --speculative-config.num_speculative_tokens 3 
+```
+
+### Qwen3.5-27B-Channel-INT8-w8a8 IFB BW1100 1x vLLM 0.18-hotfix
+
+```bash
+vllm serve hygon/Qwen3.5-27B-Channel-INT8-w8a8 \
+  -tp 1 \
+  --trust-remote-code \
+  --max-num-batched-tokens 10240 \
+  -q slimquant_marlin \
+  --speculative-config.method mtp \
+  --speculative-config.num_speculative_tokens 3 \
+  --speculative-config.quantization "slimquant_marlin" \
+  --kv-cache-dtype fp8_e4m3 \
+  --attention-backend FLASH_ATTN_CUSTOM
+```
+
+### Qwen3.5-27B-Channel-INT8-w8a8 IFB BW1000 1x vLLM 0.18-hotfix
+
+```bash
+vllm serve hygon/Qwen3.5-27B-Channel-INT8-w8a8 \
+  -tp 1 \
+  --trust-remote-code \
+  --max-num-batched-tokens 10240 \
+  -q slimquant_marlin \
+  --speculative-config.method mtp \
+  --speculative-config.num_speculative_tokens 3 \
+  --speculative-config.quantization "slimquant_marlin" \
+  --attention-backend FLASH_ATTN_CUSTOM
 ```
 
 ### Qwen3.5-27B-Channel-INT8-w8a8 IFB K100_AI 1x vLLM 0.18-hotfix
@@ -585,6 +606,7 @@ vllm serve hygon/Qwen3.5-27B-Channel-INT8-w8a8 \
   --speculative-config.method mtp \
   --speculative-config.num_speculative_tokens 3 
 ```
+
 ### Qwen3.5-35B-A3B IFB BW1100 1x vLLM 0.21
 
 ```bash
@@ -599,6 +621,36 @@ vllm serve Qwen/Qwen3.5-35B-A3B \
   --moe-backend aiter \
   --max-num-seqs 128
 ```
+
+### Qwen3.5-35B-A3B IFB BW1000 2x vLLM 0.21
+
+```bash
+vllm serve Qwen/Qwen3.5-35B-A3B \
+  -tp 2 \
+  --trust-remote-code \
+  --max-num-batched-tokens 16384 \
+  --speculative-config.method mtp \
+  --speculative-config.num_speculative_tokens 3 \
+  --attention-backend FLASH_ATTN_CUSTOM \
+  --moe-backend aiter \
+  --max-num-seqs 128
+```
+
+### Qwen3.5-35B-A3B IFB K100_AI 2x vLLM 0.21
+
+```bash
+export VLLM_HCU_USE_CUSTOM_QUANTIZATION_GEMM=0
+export VLLM_HCU_USE_CUSTOM_OPS=0
+
+vllm serve Qwen/Qwen3.5-35B-A3B \
+  -tp 2 \
+  --trust-remote-code \
+  --max-num-batched-tokens 16384 \
+  --speculative-config.method mtp \
+  --speculative-config.num_speculative_tokens 3 \
+  --max-num-seqs 128
+```
+
 ### Qwen3.5-35B-A3B IFB BW1100 1x vLLM 0.18
 
 ```bash
@@ -610,6 +662,37 @@ export VLLM_HCU_USE_PD_SPLIT=1
 
 vllm serve Qwen/Qwen3.5-35B-A3B \
   -tp 1 \
+  --trust-remote-code \
+  --max-num-batched-tokens 10240 \
+  --speculative-config.method mtp \
+  --speculative-config.num_speculative_tokens 3
+```
+
+### Qwen3.5-35B-A3B IFB BW1000 2x vLLM 0.18
+
+```bash
+export VLLM_HCU_USE_FLASH_ATTN=1
+export VLLM_HCU_USE_CUSTOM_TOPK_TOPP_SAMPLER=1
+export VLLM_ROCM_USE_AITER=1
+export VLLM_ROCM_USE_AITER_MOE=1
+export VLLM_HCU_USE_PD_SPLIT=1
+
+vllm serve Qwen/Qwen3.5-35B-A3B \
+  -tp 2 \
+  --trust-remote-code \
+  --max-num-batched-tokens 10240 \
+  --speculative-config.method mtp \
+  --speculative-config.num_speculative_tokens 3
+```
+
+### Qwen3.5-35B-A3B IFB K100_AI 2x vLLM 0.18
+
+```bash
+export VLLM_HCU_USE_CUSTOM_QUANTIZATION_GEMM=0
+export VLLM_HCU_USE_CUSTOM_OPS=0
+
+vllm serve Qwen/Qwen3.5-35B-A3B \
+  -tp 2 \
   --trust-remote-code \
   --max-num-batched-tokens 10240 \
   --speculative-config.method mtp \
@@ -629,35 +712,6 @@ vllm serve Qwen/Qwen3.5-35B-A3B \
   --attention-backend FLASH_ATTN_CUSTOM \
   --moe-backend aiter
 ```
-### Qwen3.5-35B-A3B IFB BW1000 2x vLLM 0.21
-
-```bash
-vllm serve Qwen/Qwen3.5-35B-A3B \
-  -tp 2 \
-  --trust-remote-code \
-  --max-num-batched-tokens 16384 \
-  --speculative-config.method mtp \
-  --speculative-config.num_speculative_tokens 3 \
-  --attention-backend FLASH_ATTN_CUSTOM \
-  --moe-backend aiter \
-  --max-num-seqs 128
-```
-### Qwen3.5-35B-A3B IFB BW1000 2x vLLM 0.18
-
-```bash
-export VLLM_HCU_USE_FLASH_ATTN=1
-export VLLM_HCU_USE_CUSTOM_TOPK_TOPP_SAMPLER=1
-export VLLM_ROCM_USE_AITER=1
-export VLLM_ROCM_USE_AITER_MOE=1
-export VLLM_HCU_USE_PD_SPLIT=1
-
-vllm serve Qwen/Qwen3.5-35B-A3B \
-  -tp 2 \
-  --trust-remote-code \
-  --max-num-batched-tokens 10240 \
-  --speculative-config.method mtp \
-  --speculative-config.num_speculative_tokens 3
-```
 
 ### Qwen3.5-35B-A3B IFB BW1000 2x vLLM 0.18-hotfix
 
@@ -670,33 +724,6 @@ vllm serve Qwen/Qwen3.5-35B-A3B \
   --speculative-config.num_speculative_tokens 3 \
   --attention-backend FLASH_ATTN_CUSTOM \
   --moe-backend aiter
-```
-### Qwen3.5-35B-A3B IFB K100_AI 2x vLLM 0.21
-
-```bash
-export VLLM_HCU_USE_CUSTOM_QUANTIZATION_GEMM=0
-export VLLM_HCU_USE_CUSTOM_OPS=0
-
-vllm serve Qwen/Qwen3.5-35B-A3B \
-  -tp 2 \
-  --trust-remote-code \
-  --max-num-batched-tokens 16384 \
-  --speculative-config.method mtp \
-  --speculative-config.num_speculative_tokens 3 \
-  --max-num-seqs 128
-```
-### Qwen3.5-35B-A3B IFB K100_AI 2x vLLM 0.18
-
-```bash
-export VLLM_HCU_USE_CUSTOM_QUANTIZATION_GEMM=0
-export VLLM_HCU_USE_CUSTOM_OPS=0
-
-vllm serve Qwen/Qwen3.5-35B-A3B \
-  -tp 2 \
-  --trust-remote-code \
-  --max-num-batched-tokens 10240 \
-  --speculative-config.method mtp \
-  --speculative-config.num_speculative_tokens 3
 ```
 
 ### Qwen3.5-35B-A3B IFB K100_AI 2x vLLM 0.18-hotfix
@@ -712,6 +739,7 @@ vllm serve Qwen/Qwen3.5-35B-A3B \
   --speculative-config.method mtp \
   --speculative-config.num_speculative_tokens 3
 ```
+
 ### Qwen3.5-35B-A3B-Channel-INT8-w8a8 IFB BW1100 1x vLLM 0.21
 
 ```bash
@@ -727,6 +755,37 @@ vllm serve hygon/Qwen3.5-35B-A3B-Channel-INT8-w8a8 \
   --attention-backend FLASH_ATTN_CUSTOM \
   --max-num-seqs 128
 ```
+
+### Qwen3.5-35B-A3B-Channel-INT8-w8a8 IFB BW1000 1x vLLM 0.21
+
+```bash
+vllm serve hygon/Qwen3.5-35B-A3B-Channel-INT8-w8a8 \
+  -tp 1 \
+  --trust-remote-code \
+  --max-num-batched-tokens 16384 \
+  -q slimquant_marlin \
+  --speculative-config.method mtp \
+  --speculative-config.num_speculative_tokens 3 \
+  --speculative-config.quantization "slimquant_marlin" \
+  --attention-backend FLASH_ATTN_CUSTOM \
+  --max-num-seqs 128
+```
+
+### Qwen3.5-35B-A3B-Channel-INT8-w8a8 IFB K100_AI 1x vLLM 0.21
+
+```bash
+export VLLM_HCU_USE_CUSTOM_QUANTIZATION_GEMM=0
+export VLLM_HCU_USE_CUSTOM_OPS=0
+
+vllm serve hygon/Qwen3.5-35B-A3B-Channel-INT8-w8a8 \
+  -tp 1 \
+  --trust-remote-code \
+  --max-num-batched-tokens 16384 \
+  --speculative-config.method mtp \
+  --speculative-config.num_speculative_tokens 3 \
+  --max-num-seqs 128
+```
+
 ### Qwen3.5-35B-A3B-Channel-INT8-w8a8 IFB BW1100 1x vLLM 0.18
 
 ```bash
@@ -743,34 +802,6 @@ vllm serve hygon/Qwen3.5-35B-A3B-Channel-INT8-w8a8 \
   --speculative-config.quantization "slimquant_marlin"
 ```
 
-### Qwen3.5-35B-A3B-Channel-INT8-w8a8 IFB BW1100 1x vLLM 0.18-hotfix
-
-```bash
-vllm serve hygon/Qwen3.5-35B-A3B-Channel-INT8-w8a8 \
-  -tp 1 \
-  --trust-remote-code \
-  --max-num-batched-tokens 10240 \
-  -q slimquant_marlin \
-  --speculative-config.method mtp \
-  --speculative-config.num_speculative_tokens 3 \
-  --speculative-config.quantization "slimquant_marlin" \
-  --kv-cache-dtype fp8_e4m3 \
-  --attention-backend FLASH_ATTN_CUSTOM
-```
-### Qwen3.5-35B-A3B-Channel-INT8-w8a8 IFB BW1000 1x vLLM 0.21
-
-```bash
-vllm serve hygon/Qwen3.5-35B-A3B-Channel-INT8-w8a8 \
-  -tp 1 \
-  --trust-remote-code \
-  --max-num-batched-tokens 16384 \
-  -q slimquant_marlin \
-  --speculative-config.method mtp \
-  --speculative-config.num_speculative_tokens 3 \
-  --speculative-config.quantization "slimquant_marlin" \
-  --attention-backend FLASH_ATTN_CUSTOM \
-  --max-num-seqs 128
-```
 ### Qwen3.5-35B-A3B-Channel-INT8-w8a8 IFB BW1000 1x vLLM 0.18
 
 ```bash
@@ -787,33 +818,6 @@ vllm serve hygon/Qwen3.5-35B-A3B-Channel-INT8-w8a8 \
   --speculative-config.quantization "slimquant_marlin"
 ```
 
-### Qwen3.5-35B-A3B-Channel-INT8-w8a8 IFB BW1000 1x vLLM 0.18-hotfix
-
-```bash
-vllm serve hygon/Qwen3.5-35B-A3B-Channel-INT8-w8a8 \
-  -tp 1 \
-  --trust-remote-code \
-  --max-num-batched-tokens 10240 \
-  -q slimquant_marlin \
-  --speculative-config.method mtp \
-  --speculative-config.num_speculative_tokens 3 \
-  --speculative-config.quantization "slimquant_marlin" \
-  --attention-backend FLASH_ATTN_CUSTOM
-```
-### Qwen3.5-35B-A3B-Channel-INT8-w8a8 IFB K100_AI 1x vLLM 0.21
-
-```bash
-export VLLM_HCU_USE_CUSTOM_QUANTIZATION_GEMM=0
-export VLLM_HCU_USE_CUSTOM_OPS=0
-
-vllm serve hygon/Qwen3.5-35B-A3B-Channel-INT8-w8a8 \
-  -tp 1 \
-  --trust-remote-code \
-  --max-num-batched-tokens 16384 \
-  --speculative-config.method mtp \
-  --speculative-config.num_speculative_tokens 3 \
-  --max-num-seqs 128
-```
 ### Qwen3.5-35B-A3B-Channel-INT8-w8a8 IFB K100_AI 1x vLLM 0.18
 
 ```bash
@@ -826,6 +830,35 @@ vllm serve hygon/Qwen3.5-35B-A3B-Channel-INT8-w8a8 \
   --max-num-batched-tokens 10240 \
   --speculative-config.method mtp \
   --speculative-config.num_speculative_tokens 3
+```
+
+### Qwen3.5-35B-A3B-Channel-INT8-w8a8 IFB BW1100 1x vLLM 0.18-hotfix
+
+```bash
+vllm serve hygon/Qwen3.5-35B-A3B-Channel-INT8-w8a8 \
+  -tp 1 \
+  --trust-remote-code \
+  --max-num-batched-tokens 10240 \
+  -q slimquant_marlin \
+  --speculative-config.method mtp \
+  --speculative-config.num_speculative_tokens 3 \
+  --speculative-config.quantization "slimquant_marlin" \
+  --kv-cache-dtype fp8_e4m3 \
+  --attention-backend FLASH_ATTN_CUSTOM
+```
+
+### Qwen3.5-35B-A3B-Channel-INT8-w8a8 IFB BW1000 1x vLLM 0.18-hotfix
+
+```bash
+vllm serve hygon/Qwen3.5-35B-A3B-Channel-INT8-w8a8 \
+  -tp 1 \
+  --trust-remote-code \
+  --max-num-batched-tokens 10240 \
+  -q slimquant_marlin \
+  --speculative-config.method mtp \
+  --speculative-config.num_speculative_tokens 3 \
+  --speculative-config.quantization "slimquant_marlin" \
+  --attention-backend FLASH_ATTN_CUSTOM
 ```
 
 ### Qwen3.5-35B-A3B-Channel-INT8-w8a8 IFB K100_AI 1x vLLM 0.18-hotfix
@@ -841,6 +874,7 @@ vllm serve hygon/Qwen3.5-35B-A3B-Channel-INT8-w8a8 \
   --speculative-config.method mtp \
   --speculative-config.num_speculative_tokens 3
 ```
+
 ### Qwen3.5-35B-A3B-Channel-FP8-w8a8 IFB BW1100 1x vLLM 0.21
 
 ```bash
@@ -856,6 +890,7 @@ vllm serve hygon/Qwen3.5-35B-A3B-Channel-FP8-w8a8 \
   --attention-backend FLASH_ATTN_CUSTOM \
   --max-num-seqs 128
 ```
+
 ### Qwen3.5-35B-A3B-Channel-FP8-w8a8 IFB BW1100 1x vLLM 0.18
 
 ```bash
@@ -886,6 +921,7 @@ vllm serve hygon/Qwen3.5-35B-A3B-Channel-FP8-w8a8 \
   --kv-cache-dtype fp8_e4m3 \
   --attention-backend FLASH_ATTN_CUSTOM
 ```
+
 ### Qwen3.5-122B-A10B IFB BW1100 4x vLLM 0.21
 
 ```bash
@@ -900,6 +936,36 @@ vllm serve Qwen/Qwen3.5-122B-A10B \
   --moe-backend aiter \
   --max-num-seqs 128
 ```
+
+### Qwen3.5-122B-A10B IFB BW1000 8x vLLM 0.21
+
+```bash
+vllm serve Qwen/Qwen3.5-122B-A10B \
+  -tp 8 \
+  --trust-remote-code \
+  --max-num-batched-tokens 16384 \
+  --speculative-config.method mtp \
+  --speculative-config.num_speculative_tokens 3 \
+  --attention-backend FLASH_ATTN_CUSTOM \
+  --moe-backend aiter \
+  --max-num-seqs 128
+```
+
+### Qwen3.5-122B-A10B IFB K100_AI 8x vLLM 0.21
+
+```bash
+export VLLM_HCU_USE_CUSTOM_QUANTIZATION_GEMM=0
+export VLLM_HCU_USE_CUSTOM_OPS=0
+
+vllm serve Qwen/Qwen3.5-122B-A10B \
+  -tp 8 \
+  --trust-remote-code \
+  --max-num-batched-tokens 16384 \
+  --speculative-config.method mtp \
+  --speculative-config.num_speculative_tokens 3 \
+  --max-num-seqs 128
+```
+
 ### Qwen3.5-122B-A10B IFB BW1100 4x vLLM 0.18
 
 ```bash
@@ -911,6 +977,37 @@ export VLLM_HCU_USE_PD_SPLIT=1
 
 vllm serve Qwen/Qwen3.5-122B-A10B \
   -tp 4 \
+  --trust-remote-code \
+  --max-num-batched-tokens 10240 \
+  --speculative-config.method mtp \
+  --speculative-config.num_speculative_tokens 3
+```
+
+### Qwen3.5-122B-A10B IFB BW1000 8x vLLM 0.18
+
+```bash
+export VLLM_HCU_USE_FLASH_ATTN=1
+export VLLM_HCU_USE_CUSTOM_TOPK_TOPP_SAMPLER=1
+export VLLM_ROCM_USE_AITER=1
+export VLLM_ROCM_USE_AITER_MOE=1
+export VLLM_HCU_USE_PD_SPLIT=1
+
+vllm serve Qwen/Qwen3.5-122B-A10B \
+  -tp 8 \
+  --trust-remote-code \
+  --max-num-batched-tokens 10240 \
+  --speculative-config.method mtp \
+  --speculative-config.num_speculative_tokens 3
+```
+
+### Qwen3.5-122B-A10B IFB K100_AI 8x vLLM 0.18
+
+```bash
+export VLLM_HCU_USE_CUSTOM_QUANTIZATION_GEMM=0
+export VLLM_HCU_USE_CUSTOM_OPS=0
+
+vllm serve Qwen/Qwen3.5-122B-A10B \
+  -tp 8 \
   --trust-remote-code \
   --max-num-batched-tokens 10240 \
   --speculative-config.method mtp \
@@ -930,35 +1027,6 @@ vllm serve Qwen/Qwen3.5-122B-A10B \
   --attention-backend FLASH_ATTN_CUSTOM \
   --moe-backend aiter
 ```
-### Qwen3.5-122B-A10B IFB BW1000 8x vLLM 0.21
-
-```bash
-vllm serve Qwen/Qwen3.5-122B-A10B \
-  -tp 8 \
-  --trust-remote-code \
-  --max-num-batched-tokens 16384 \
-  --speculative-config.method mtp \
-  --speculative-config.num_speculative_tokens 3 \
-  --attention-backend FLASH_ATTN_CUSTOM \
-  --moe-backend aiter \
-  --max-num-seqs 128
-```
-### Qwen3.5-122B-A10B IFB BW1000 8x vLLM 0.18
-
-```bash
-export VLLM_HCU_USE_FLASH_ATTN=1
-export VLLM_HCU_USE_CUSTOM_TOPK_TOPP_SAMPLER=1
-export VLLM_ROCM_USE_AITER=1
-export VLLM_ROCM_USE_AITER_MOE=1
-export VLLM_HCU_USE_PD_SPLIT=1
-
-vllm serve Qwen/Qwen3.5-122B-A10B \
-  -tp 8 \
-  --trust-remote-code \
-  --max-num-batched-tokens 10240 \
-  --speculative-config.method mtp \
-  --speculative-config.num_speculative_tokens 3
-```
 
 ### Qwen3.5-122B-A10B IFB BW1000 8x vLLM 0.18-hotfix
 
@@ -971,33 +1039,6 @@ vllm serve Qwen/Qwen3.5-122B-A10B \
   --speculative-config.num_speculative_tokens 3 \
   --attention-backend FLASH_ATTN_CUSTOM \
   --moe-backend aiter
-```
-### Qwen3.5-122B-A10B IFB K100_AI 8x vLLM 0.21
-
-```bash
-export VLLM_HCU_USE_CUSTOM_QUANTIZATION_GEMM=0
-export VLLM_HCU_USE_CUSTOM_OPS=0
-
-vllm serve Qwen/Qwen3.5-122B-A10B \
-  -tp 8 \
-  --trust-remote-code \
-  --max-num-batched-tokens 16384 \
-  --speculative-config.method mtp \
-  --speculative-config.num_speculative_tokens 3 \
-  --max-num-seqs 128
-```
-### Qwen3.5-122B-A10B IFB K100_AI 8x vLLM 0.18
-
-```bash
-export VLLM_HCU_USE_CUSTOM_QUANTIZATION_GEMM=0
-export VLLM_HCU_USE_CUSTOM_OPS=0
-
-vllm serve Qwen/Qwen3.5-122B-A10B \
-  -tp 8 \
-  --trust-remote-code \
-  --max-num-batched-tokens 10240 \
-  --speculative-config.method mtp \
-  --speculative-config.num_speculative_tokens 3
 ```
 
 ### Qwen3.5-122B-A10B IFB K100_AI 8x vLLM 0.18-hotfix
@@ -1013,6 +1054,7 @@ vllm serve Qwen/Qwen3.5-122B-A10B \
   --speculative-config.method mtp \
   --speculative-config.num_speculative_tokens 3
 ```
+
 ### Qwen3.5-122B-A10B-W8A8-INT8 IFB BW1100 2x vLLM 0.21
 
 ```bash
@@ -1028,6 +1070,37 @@ vllm serve Qwen/Qwen3.5-122B-A10B-W8A8-INT8 \
   --attention-backend FLASH_ATTN_CUSTOM \
   --max-num-seqs 128
 ```
+
+### Qwen3.5-122B-A10B-W8A8-INT8 IFB BW1000 4x vLLM 0.21
+
+```bash
+vllm serve Qwen/Qwen3.5-122B-A10B-W8A8-INT8 \
+  -tp 4 \
+  --trust-remote-code \
+  --max-num-batched-tokens 16384 \
+  -q slimquant_marlin \
+  --speculative-config.method mtp \
+  --speculative-config.num_speculative_tokens 3 \
+  --speculative-config.quantization "slimquant_marlin" \
+  --attention-backend FLASH_ATTN_CUSTOM \
+  --max-num-seqs 128
+```
+
+### Qwen3.5-122B-A10B-W8A8-INT8 IFB K100_AI 4x vLLM 0.21
+
+```bash
+export VLLM_HCU_USE_CUSTOM_QUANTIZATION_GEMM=0
+export VLLM_HCU_USE_CUSTOM_OPS=0
+
+vllm serve Qwen/Qwen3.5-122B-A10B-W8A8-INT8 \
+  -tp 4 \
+  --trust-remote-code \
+  --max-num-batched-tokens 16384 \
+  --speculative-config.method mtp \
+  --speculative-config.num_speculative_tokens 3 \
+  --max-num-seqs 128
+```
+
 ### Qwen3.5-122B-A10B-W8A8-INT8 IFB BW1100 2x vLLM 0.18
 
 ```bash
@@ -1044,34 +1117,6 @@ vllm serve Qwen/Qwen3.5-122B-A10B-W8A8-INT8 \
   --speculative-config.quantization "slimquant_marlin"
 ```
 
-### Qwen3.5-122B-A10B-W8A8-INT8 IFB BW1100 2x vLLM 0.18-hotfix
-
-```bash
-vllm serve Qwen/Qwen3.5-122B-A10B-W8A8-INT8 \
-  -tp 2 \
-  --trust-remote-code \
-  --max-num-batched-tokens 10240 \
-  -q slimquant_marlin \
-  --speculative-config.method mtp \
-  --speculative-config.num_speculative_tokens 3 \
-  --speculative-config.quantization "slimquant_marlin" \
-  --kv-cache-dtype fp8_e4m3 \
-  --attention-backend FLASH_ATTN_CUSTOM
-```
-### Qwen3.5-122B-A10B-W8A8-INT8 IFB BW1000 4x vLLM 0.21
-
-```bash
-vllm serve Qwen/Qwen3.5-122B-A10B-W8A8-INT8 \
-  -tp 4 \
-  --trust-remote-code \
-  --max-num-batched-tokens 16384 \
-  -q slimquant_marlin \
-  --speculative-config.method mtp \
-  --speculative-config.num_speculative_tokens 3 \
-  --speculative-config.quantization "slimquant_marlin" \
-  --attention-backend FLASH_ATTN_CUSTOM \
-  --max-num-seqs 128
-```
 ### Qwen3.5-122B-A10B-W8A8-INT8 IFB BW1000 4x vLLM 0.18
 
 ```bash
@@ -1088,33 +1133,6 @@ vllm serve Qwen/Qwen3.5-122B-A10B-W8A8-INT8 \
   --speculative-config.quantization "slimquant_marlin"
 ```
 
-### Qwen3.5-122B-A10B-W8A8-INT8 IFB BW1000 4x vLLM 0.18-hotfix
-
-```bash
-vllm serve Qwen/Qwen3.5-122B-A10B-W8A8-INT8 \
-  -tp 4 \
-  --trust-remote-code \
-  --max-num-batched-tokens 10240 \
-  -q slimquant_marlin \
-  --speculative-config.method mtp \
-  --speculative-config.num_speculative_tokens 3 \
-  --speculative-config.quantization "slimquant_marlin" \
-  --attention-backend FLASH_ATTN_CUSTOM
-```
-### Qwen3.5-122B-A10B-W8A8-INT8 IFB K100_AI 4x vLLM 0.21
-
-```bash
-export VLLM_HCU_USE_CUSTOM_QUANTIZATION_GEMM=0
-export VLLM_HCU_USE_CUSTOM_OPS=0
-
-vllm serve Qwen/Qwen3.5-122B-A10B-W8A8-INT8 \
-  -tp 4 \
-  --trust-remote-code \
-  --max-num-batched-tokens 16384 \
-  --speculative-config.method mtp \
-  --speculative-config.num_speculative_tokens 3 \
-  --max-num-seqs 128
-```
 ### Qwen3.5-122B-A10B-W8A8-INT8 IFB K100_AI 4x vLLM 0.18
 
 ```bash
@@ -1127,6 +1145,35 @@ vllm serve Qwen/Qwen3.5-122B-A10B-W8A8-INT8 \
   --max-num-batched-tokens 10240 \
   --speculative-config.method mtp \
   --speculative-config.num_speculative_tokens 3 
+```
+
+### Qwen3.5-122B-A10B-W8A8-INT8 IFB BW1100 2x vLLM 0.18-hotfix
+
+```bash
+vllm serve Qwen/Qwen3.5-122B-A10B-W8A8-INT8 \
+  -tp 2 \
+  --trust-remote-code \
+  --max-num-batched-tokens 10240 \
+  -q slimquant_marlin \
+  --speculative-config.method mtp \
+  --speculative-config.num_speculative_tokens 3 \
+  --speculative-config.quantization "slimquant_marlin" \
+  --kv-cache-dtype fp8_e4m3 \
+  --attention-backend FLASH_ATTN_CUSTOM
+```
+
+### Qwen3.5-122B-A10B-W8A8-INT8 IFB BW1000 4x vLLM 0.18-hotfix
+
+```bash
+vllm serve Qwen/Qwen3.5-122B-A10B-W8A8-INT8 \
+  -tp 4 \
+  --trust-remote-code \
+  --max-num-batched-tokens 10240 \
+  -q slimquant_marlin \
+  --speculative-config.method mtp \
+  --speculative-config.num_speculative_tokens 3 \
+  --speculative-config.quantization "slimquant_marlin" \
+  --attention-backend FLASH_ATTN_CUSTOM
 ```
 
 ### Qwen3.5-122B-A10B-W8A8-INT8 IFB K100_AI 4x vLLM 0.18-hotfix
@@ -1142,6 +1189,7 @@ vllm serve Qwen/Qwen3.5-122B-A10B-W8A8-INT8 \
   --speculative-config.method mtp \
   --speculative-config.num_speculative_tokens 3 
 ```
+
 ### Qwen3.5-122B-A10B-Channel-FP8-w8a8 IFB BW1100 2x vLLM 0.21
 
 ```bash
@@ -1157,6 +1205,7 @@ vllm serve hygon/Qwen3.5-122B-A10B-Channel-FP8-w8a8 \
   --attention-backend FLASH_ATTN_CUSTOM \
   --max-num-seqs 128
 ```
+
 ### Qwen3.5-122B-A10B-Channel-FP8-w8a8 IFB BW1100 2x vLLM 0.18
 
 ```bash
@@ -1187,6 +1236,7 @@ vllm serve hygon/Qwen3.5-122B-A10B-Channel-FP8-w8a8 \
   --kv-cache-dtype fp8_e4m3 \
   --attention-backend FLASH_ATTN_CUSTOM
 ```
+
 ### Qwen3.5-397B-A17B-W8A8-INT8 IFB BW1100 8x vLLM 0.21
 
 ```bash
@@ -1202,6 +1252,37 @@ vllm serve Qwen/Qwen3.5-397B-A17B-W8A8-INT8 \
   --attention-backend FLASH_ATTN_CUSTOM \
   --max-num-seqs 128
 ```
+
+### Qwen3.5-397B-A17B-W8A8-INT8 IFB BW1000 8x vLLM 0.21
+
+```bash
+vllm serve Qwen/Qwen3.5-397B-A17B-W8A8-INT8 \
+  -tp 8 \
+  --trust-remote-code \
+  --max-num-batched-tokens 16384 \
+  -q slimquant_marlin \
+  --speculative-config.method mtp \
+  --speculative-config.num_speculative_tokens 3 \
+  --speculative-config.quantization "slimquant_marlin" \
+  --attention-backend FLASH_ATTN_CUSTOM \
+  --max-num-seqs 128
+```
+
+### Qwen3.5-397B-A17B-W8A8-INT8 IFB K100_AI 8x vLLM 0.21
+
+```bash
+export VLLM_HCU_USE_CUSTOM_QUANTIZATION_GEMM=0
+export VLLM_HCU_USE_CUSTOM_OPS=0
+
+vllm serve Qwen/Qwen3.5-397B-A17B-W8A8-INT8 \
+  -tp 8 \
+  --trust-remote-code \
+  --max-num-batched-tokens 16384 \
+  --speculative-config.method mtp \
+  --speculative-config.num_speculative_tokens 3 \
+  --max-num-seqs 128
+```
+
 ### Qwen3.5-397B-A17B-W8A8-INT8 IFB BW1100 8x vLLM 0.18
 
 ```bash
@@ -1218,34 +1299,6 @@ vllm serve Qwen/Qwen3.5-397B-A17B-W8A8-INT8 \
   --speculative-config.quantization "slimquant_marlin"
 ```
 
-### Qwen3.5-397B-A17B-W8A8-INT8 IFB BW1100 8x vLLM 0.18-hotfix
-
-```bash
-vllm serve Qwen/Qwen3.5-397B-A17B-W8A8-INT8 \
-  -tp 8 \
-  --trust-remote-code \
-  --max-num-batched-tokens 10240 \
-  -q slimquant_marlin \
-  --speculative-config.method mtp \
-  --speculative-config.num_speculative_tokens 3 \
-  --speculative-config.quantization "slimquant_marlin" \
-  --kv-cache-dtype fp8_e4m3 \
-  --attention-backend FLASH_ATTN_CUSTOM
-```
-### Qwen3.5-397B-A17B-W8A8-INT8 IFB BW1000 8x vLLM 0.21
-
-```bash
-vllm serve Qwen/Qwen3.5-397B-A17B-W8A8-INT8 \
-  -tp 8 \
-  --trust-remote-code \
-  --max-num-batched-tokens 16384 \
-  -q slimquant_marlin \
-  --speculative-config.method mtp \
-  --speculative-config.num_speculative_tokens 3 \
-  --speculative-config.quantization "slimquant_marlin" \
-  --attention-backend FLASH_ATTN_CUSTOM \
-  --max-num-seqs 128
-```
 ### Qwen3.5-397B-A17B-W8A8-INT8 IFB BW1000 8x vLLM 0.18
 
 ```bash
@@ -1262,33 +1315,6 @@ vllm serve Qwen/Qwen3.5-397B-A17B-W8A8-INT8 \
   --speculative-config.quantization "slimquant_marlin"
 ```
 
-### Qwen3.5-397B-A17B-W8A8-INT8 IFB BW1000 8x vLLM 0.18-hotfix
-
-```bash
-vllm serve Qwen/Qwen3.5-397B-A17B-W8A8-INT8 \
-  -tp 8 \
-  --trust-remote-code \
-  --max-num-batched-tokens 10240 \
-  -q slimquant_marlin \
-  --speculative-config.method mtp \
-  --speculative-config.num_speculative_tokens 3 \
-  --speculative-config.quantization "slimquant_marlin" \
-  --attention-backend FLASH_ATTN_CUSTOM
-```
-### Qwen3.5-397B-A17B-W8A8-INT8 IFB K100_AI 8x vLLM 0.21
-
-```bash
-export VLLM_HCU_USE_CUSTOM_QUANTIZATION_GEMM=0
-export VLLM_HCU_USE_CUSTOM_OPS=0
-
-vllm serve Qwen/Qwen3.5-397B-A17B-W8A8-INT8 \
-  -tp 8 \
-  --trust-remote-code \
-  --max-num-batched-tokens 16384 \
-  --speculative-config.method mtp \
-  --speculative-config.num_speculative_tokens 3 \
-  --max-num-seqs 128
-```
 ### Qwen3.5-397B-A17B-W8A8-INT8 IFB K100_AI 8x vLLM 0.18
 
 ```bash
@@ -1301,6 +1327,35 @@ vllm serve Qwen/Qwen3.5-397B-A17B-W8A8-INT8 \
   --max-num-batched-tokens 10240 \
   --speculative-config.method mtp \
   --speculative-config.num_speculative_tokens 3 
+```
+
+### Qwen3.5-397B-A17B-W8A8-INT8 IFB BW1100 8x vLLM 0.18-hotfix
+
+```bash
+vllm serve Qwen/Qwen3.5-397B-A17B-W8A8-INT8 \
+  -tp 8 \
+  --trust-remote-code \
+  --max-num-batched-tokens 10240 \
+  -q slimquant_marlin \
+  --speculative-config.method mtp \
+  --speculative-config.num_speculative_tokens 3 \
+  --speculative-config.quantization "slimquant_marlin" \
+  --kv-cache-dtype fp8_e4m3 \
+  --attention-backend FLASH_ATTN_CUSTOM
+```
+
+### Qwen3.5-397B-A17B-W8A8-INT8 IFB BW1000 8x vLLM 0.18-hotfix
+
+```bash
+vllm serve Qwen/Qwen3.5-397B-A17B-W8A8-INT8 \
+  -tp 8 \
+  --trust-remote-code \
+  --max-num-batched-tokens 10240 \
+  -q slimquant_marlin \
+  --speculative-config.method mtp \
+  --speculative-config.num_speculative_tokens 3 \
+  --speculative-config.quantization "slimquant_marlin" \
+  --attention-backend FLASH_ATTN_CUSTOM
 ```
 
 ### Qwen3.5-397B-A17B-W8A8-INT8 IFB K100_AI 8x vLLM 0.18-hotfix
@@ -1316,6 +1371,7 @@ vllm serve Qwen/Qwen3.5-397B-A17B-W8A8-INT8 \
   --speculative-config.method mtp \
   --speculative-config.num_speculative_tokens 3 
 ```
+
 ### Qwen3.5-397B-A17B-Channel-FP8 IFB BW1100 4x vLLM 0.21
 
 ```bash
@@ -1331,6 +1387,7 @@ vllm serve hygon/Qwen3.5-397B-A17B-Channel-FP8 \
   --attention-backend FLASH_ATTN_CUSTOM \
   --max-num-seqs 128
 ```
+
 ### Qwen3.5-397B-A17B-Channel-FP8 IFB BW1100 4x vLLM 0.18
 
 ```bash

--- a/docs/model-deployment/vllm/qwen3.5.md
+++ b/docs/model-deployment/vllm/qwen3.5.md
@@ -69,22 +69,22 @@ Qwen3.5 是 Qwen3 系列的增强版本，在推理能力、代码生成、多�
 | [Qwen/Qwen3.5-122B-A10B](https://www.modelscope.cn/models/Qwen/Qwen3.5-122B-A10B) | BF16 | 0.21 | BW1100 | 4 | IFB | [**`>_`**](#qwen35-122b-a10b-ifb-bw1100-4x-vllm-021) |
 |  | BF16 | 0.21 | BW1000 | 8 | IFB | [**`>_`**](#qwen35-122b-a10b-ifb-bw1000-8x-vllm-021) |
 |  | BF16 | 0.21 | K100_AI | 8 | IFB | [**`>_`**](#qwen35-122b-a10b-ifb-k100_ai-8x-vllm-021) |
-|  | BF16 | 0.18-hotfix | BW1100 | 4 | IFB | [**`>_`**](#qwen35-122b-a10b-ifb-bw1100-4x-vllm-018-hotfix) |
-|  | BF16 | 0.18-hotfix | BW1000 | 8 | IFB | [**`>_`**](#qwen35-122b-a10b-ifb-bw1000-8x-vllm-018-hotfix) |
-|  | BF16 | 0.18-hotfix | K100_AI | 8 | IFB | [**`>_`**](#qwen35-122b-a10b-ifb-k100_ai-8x-vllm-018-hotfix) |
 |  | BF16 | [0.18](../docker_images.md) | BW1100 | 4 | IFB | [**`>_`**](#qwen35-122b-a10b-ifb-bw1100-4x-vllm-018) |
 |  | BF16 | [0.18](../docker_images.md) | BW1000 | 8 | IFB | [**`>_`**](#qwen35-122b-a10b-ifb-bw1000-8x-vllm-018) |
 |  | BF16 | [0.18](../docker_images.md) | K100_AI | 8 | IFB | [**`>_`**](#qwen35-122b-a10b-ifb-k100_ai-8x-vllm-018) |
+|  | BF16 | 0.18-hotfix | BW1100 | 4 | IFB | [**`>_`**](#qwen35-122b-a10b-ifb-bw1100-4x-vllm-018-hotfix) |
+|  | BF16 | 0.18-hotfix | BW1000 | 8 | IFB | [**`>_`**](#qwen35-122b-a10b-ifb-bw1000-8x-vllm-018-hotfix) |
+|  | BF16 | 0.18-hotfix | K100_AI | 8 | IFB | [**`>_`**](#qwen35-122b-a10b-ifb-k100_ai-8x-vllm-018-hotfix) |
 | [Qwen/Qwen3.5-122B-A10B-AWQ](https://www.modelscope.cn/models/tclf90/Qwen3.5-122B-A10B-AWQ) | AWQ | 0.18 | K100_AI | 4 | IFB | [**`>_`**](#qwen35-122b-a10b-awq-ifb-k100_ai-4x-vllm-018) |
 | [Qwen/Qwen3.5-122B-A10B-W8A8-INT8](https://www.modelscope.cn/models/Qwen/Qwen3.5-122B-A10B-W8A8-INT8) | INT8 W8A8 | 0.21 | BW1100 | 2 | IFB | [**`>_`**](#qwen35-122b-a10b-w8a8-int8-ifb-bw1100-2x-vllm-021) |
 |  | INT8 W8A8 | 0.21 | BW1000 | 4 | IFB | [**`>_`**](#qwen35-122b-a10b-w8a8-int8-ifb-bw1000-4x-vllm-021) |
 |  | INT8 W8A8 | 0.21 | K100_AI | 4 | IFB | [**`>_`**](#qwen35-122b-a10b-w8a8-int8-ifb-k100_ai-4x-vllm-021) |
 |  | INT8 W8A8 | 0.18 | BW1100 | 2 | IFB | [**`>_`**](#qwen35-122b-a10b-w8a8-int8-ifb-bw1100-2x-vllm-018) |
 |  | INT8 W8A8 | 0.18 | BW1000 | 4 | IFB | [**`>_`**](#qwen35-122b-a10b-w8a8-int8-ifb-bw1000-4x-vllm-018) |
+|  | INT8 W8A8 | [0.18](../docker_images.md) | K100_AI | 4 | IFB | [**`>_`**](#qwen35-122b-a10b-w8a8-int8-ifb-k100_ai-4x-vllm-018) |
 |  | INT8 W8A8 | 0.18-hotfix | BW1100 | 2 | IFB | [**`>_`**](#qwen35-122b-a10b-w8a8-int8-ifb-bw1100-2x-vllm-018-hotfix) |
 |  | INT8 W8A8 | 0.18-hotfix | BW1000 | 4 | IFB | [**`>_`**](#qwen35-122b-a10b-w8a8-int8-ifb-bw1000-4x-vllm-018-hotfix) |
 |  | INT8 W8A8 | 0.18-hotfix | K100_AI | 4 | IFB | [**`>_`**](#qwen35-122b-a10b-w8a8-int8-ifb-k100_ai-4x-vllm-018-hotfix) |
-|  | INT8 W8A8 | [0.18](../docker_images.md) | K100_AI | 4 | IFB | [**`>_`**](#qwen35-122b-a10b-w8a8-int8-ifb-k100_ai-4x-vllm-018) |
 | [hygon/Qwen3.5-122B-A10B-Channel-FP8-w8a8](https://www.modelscope.cn/models/hygon/Qwen3.5-122B-A10B-Channel-FP8-w8a8) | FP8 W8A8 | 0.21 | BW1100 | 2 | IFB | [**`>_`**](#qwen35-122b-a10b-channel-fp8-w8a8-ifb-bw1100-2x-vllm-021) |
 |  | FP8 W8A8 | 0.18 | BW1100 | 2 | IFB | [**`>_`**](#qwen35-122b-a10b-channel-fp8-w8a8-ifb-bw1100-2x-vllm-018) |
 |  | FP8 W8A8 | 0.18-hotfix | BW1100 | 2 | IFB | [**`>_`**](#qwen35-122b-a10b-channel-fp8-w8a8-ifb-bw1100-2x-vllm-018-hotfix) |
@@ -98,9 +98,8 @@ Qwen3.5 是 Qwen3 系列的增强版本，在推理能力、代码生成、多�
 |  | INT8 W8A8 | 0.18-hotfix | K100_AI | 8 | IFB | [**`>_`**](#qwen35-397b-a17b-w8a8-int8-ifb-k100_ai-8x-vllm-018-hotfix) |
 |  | INT8 W8A8 | [0.18](../docker_images.md) | BW1100 | 8 | IFB | [**`>_`**](#qwen35-397b-a17b-w8a8-int8-ifb-bw1100-8x-vllm-018) |
 | [hygon/Qwen3.5-397B-A17B-Channel-FP8](https://www.modelscope.cn/models/hygon/Qwen3.5-397B-A17B-Channel-FP8) | FP8 W8A8 | 0.21 | BW1100 | 4 | IFB | [**`>_`**](#qwen35-397b-a17b-channel-fp8-ifb-bw1100-4x-vllm-021) |
-|  | FP8 W8A8 | 0.18-hotfix | BW1100 | 4 | IFB | [**`>_`**](#qwen35-397b-a17b-channel-fp8-ifb-bw1100-4x-vllm-018-hotfix) |
 |  | FP8 W8A8 | [0.18](../docker_images.md) | BW1100 | 4 | IFB | [**`>_`**](#qwen35-397b-a17b-channel-fp8-ifb-bw1100-4x-vllm-018) |
-
+|  | FP8 W8A8 | 0.18-hotfix | BW1100 | 4 | IFB | [**`>_`**](#qwen35-397b-a17b-channel-fp8-ifb-bw1100-4x-vllm-018-hotfix) |
 ## 启动命令
 
 ### Qwen3.5-4B IFB BW1100 1x vLLM 0.21

--- a/docs/model-deployment/vllm/qwen3.6.md
+++ b/docs/model-deployment/vllm/qwen3.6.md
@@ -9,22 +9,22 @@ Qwen3.6 模型相较于 Qwen3.5 模型，**在智能体编程能力、推理速�
 | 模型权重 | 量化方式 | vLLM 版本 | 推荐硬件 | 卡数 | 部署方式 | 启动命令 |
 | -------- | -------- | --------- | -------- | ---- | -------- | -------- |
 | [Qwen/Qwen3.6-27B](https://www.modelscope.cn/models/Qwen/Qwen3.6-27B) | BF16 | 0.21 | BW1100 | 1 | IFB | [**`>_`**](#qwen36-27b-ifb-bw1100-1x-vllm-021) |
-|  | BF16 | 0.18 | BW1100  | 1 | IFB | [**`>_`**](#qwen36-27b-ifb-bw1100-1x-vllm-018) |
-|  | BF16 | 0.18-hotfix | BW1100 | 1 | IFB | [**`>_`**](#qwen36-27b-ifb-bw1100-1x-vllm-018-hotfix) |
 |  | BF16 | 0.21 | BW1000 | 2 | IFB | [**`>_`**](#qwen36-27b-ifb-bw1000-2x-vllm-021) |
-|                                                                  | BF16 | 0.18 | BW1000  | 2 | IFB | [**`>_`**](#qwen36-27b-ifb-bw1000-2x-vllm-018) |
-|  | BF16 | 0.18-hotfix | BW1000 | 2 | IFB | [**`>_`**](#qwen36-27b-ifb-bw1000-2x-vllm-018-hotfix) |
 |  | BF16 | 0.21 | K100_AI | 2 | IFB | [**`>_`**](#qwen36-27b-ifb-k100_ai-2x-vllm-021) |
-|                                                                  | BF16 | 0.18 | K100_AI | 2 | IFB | [**`>_`**](#qwen36-27b-ifb-k100_ai-2x-vllm-018) |
+|  | BF16 | 0.18 | BW1100 | 1 | IFB | [**`>_`**](#qwen36-27b-ifb-bw1100-1x-vllm-018) |
+|  | BF16 | 0.18 | BW1000 | 2 | IFB | [**`>_`**](#qwen36-27b-ifb-bw1000-2x-vllm-018) |
+|  | BF16 | 0.18 | K100_AI | 2 | IFB | [**`>_`**](#qwen36-27b-ifb-k100_ai-2x-vllm-018) |
+|  | BF16 | 0.18-hotfix | BW1100 | 1 | IFB | [**`>_`**](#qwen36-27b-ifb-bw1100-1x-vllm-018-hotfix) |
+|  | BF16 | 0.18-hotfix | BW1000 | 2 | IFB | [**`>_`**](#qwen36-27b-ifb-bw1000-2x-vllm-018-hotfix) |
 |  | BF16 | 0.18-hotfix | K100_AI | 2 | IFB | [**`>_`**](#qwen36-27b-ifb-k100_ai-2x-vllm-018-hotfix) |
 | [Qwen/Qwen3.6-35B-A3B](https://www.modelscope.cn/models/Qwen/Qwen3.6-35B-A3B) | BF16 | 0.21 | BW1100 | 1 | IFB | [**`>_`**](#qwen36-35b-a3b-ifb-bw1100-1x-vllm-021) |
-|  | BF16 | 0.18 | BW1100  | 1 | IFB | [**`>_`**](#qwen36-35b-a3b-ifb-bw1100-1x-vllm-018) |
-|  | BF16 | 0.18-hotfix | BW1100 | 1 | IFB | [**`>_`**](#qwen36-35b-a3b-ifb-bw1100-1x-vllm-018-hotfix) |
 |  | BF16 | 0.21 | BW1000 | 2 | IFB | [**`>_`**](#qwen36-35b-a3b-ifb-bw1000-2x-vllm-021) |
-|                                                                         | BF16 | 0.18 | BW1000  | 2 | IFB | [**`>_`**](#qwen36-35b-a3b-ifb-bw1000-2x-vllm-018) |
-|  | BF16 | 0.18-hotfix | BW1000 | 2 | IFB | [**`>_`**](#qwen36-35b-a3b-ifb-bw1000-2x-vllm-018-hotfix) |
 |  | BF16 | 0.21 | K100_AI | 2 | IFB | [**`>_`**](#qwen36-35b-a3b-ifb-k100_ai-2x-vllm-021) |
-|                                                                         | BF16 | 0.18 | K100_AI | 2 | IFB | [**`>_`**](#qwen36-35b-a3b-ifb-k100_ai-2x-vllm-018) |
+|  | BF16 | 0.18 | BW1100 | 1 | IFB | [**`>_`**](#qwen36-35b-a3b-ifb-bw1100-1x-vllm-018) |
+|  | BF16 | 0.18 | BW1000 | 2 | IFB | [**`>_`**](#qwen36-35b-a3b-ifb-bw1000-2x-vllm-018) |
+|  | BF16 | 0.18 | K100_AI | 2 | IFB | [**`>_`**](#qwen36-35b-a3b-ifb-k100_ai-2x-vllm-018) |
+|  | BF16 | 0.18-hotfix | BW1100 | 1 | IFB | [**`>_`**](#qwen36-35b-a3b-ifb-bw1100-1x-vllm-018-hotfix) |
+|  | BF16 | 0.18-hotfix | BW1000 | 2 | IFB | [**`>_`**](#qwen36-35b-a3b-ifb-bw1000-2x-vllm-018-hotfix) |
 |  | BF16 | 0.18-hotfix | K100_AI | 2 | IFB | [**`>_`**](#qwen36-35b-a3b-ifb-k100_ai-2x-vllm-018-hotfix) |
 
 ## 启动命令
@@ -43,6 +43,35 @@ vllm serve Qwen/Qwen3.6-27B \
   --kv-cache-dtype fp8_e4m3 \
   --attention-backend FLASH_ATTN_CUSTOM
 ```
+
+### Qwen3.6-27B IFB BW1000 2x vLLM 0.21
+
+```bash
+export VLLM_HCU_USE_PD_SPLIT=1
+
+vllm serve Qwen/Qwen3.6-27B \
+  -tp 2 \
+  --trust-remote-code \
+  --max-num-batched-tokens 10240 \
+  --speculative-config.method mtp \
+  --speculative-config.num_speculative_tokens 3 \
+  --attention-backend FLASH_ATTN_CUSTOM
+```
+
+### Qwen3.6-27B IFB K100_AI 2x vLLM 0.21
+
+```bash
+export VLLM_HCU_USE_CUSTOM_QUANTIZATION_GEMM=0
+export VLLM_HCU_USE_CUSTOM_OPS=0
+
+vllm serve Qwen/Qwen3.6-27B \
+  -tp 2 \
+  --trust-remote-code \
+  --max-num-batched-tokens 10240 \
+  --speculative-config.method mtp \
+  --speculative-config.num_speculative_tokens 3
+```
+
 ### Qwen3.6-27B IFB BW1100 1x vLLM 0.18
 
 ```bash
@@ -51,6 +80,34 @@ export VLLM_HCU_USE_CUSTOM_TOPK_TOPP_SAMPLER=1
 
 vllm serve Qwen/Qwen3.6-27B \
   -tp 1 \
+  --trust-remote-code \
+  --max-num-batched-tokens 10240 \
+  --speculative-config.method mtp \
+  --speculative-config.num_speculative_tokens 3
+```
+
+### Qwen3.6-27B IFB BW1000 2x vLLM 0.18
+
+```bash
+export VLLM_HCU_USE_FLASH_ATTN=1
+export VLLM_HCU_USE_CUSTOM_TOPK_TOPP_SAMPLER=1
+
+vllm serve Qwen/Qwen3.6-27B \
+  -tp 2 \
+  --trust-remote-code \
+  --max-num-batched-tokens 10240 \
+  --speculative-config.method mtp \
+  --speculative-config.num_speculative_tokens 3
+```
+
+### Qwen3.6-27B IFB K100_AI 2x vLLM 0.18
+
+```bash
+export VLLM_HCU_USE_CUSTOM_QUANTIZATION_GEMM=0
+export VLLM_HCU_USE_CUSTOM_OPS=0
+
+vllm serve Qwen/Qwen3.6-27B \
+  -tp 2 \
   --trust-remote-code \
   --max-num-batched-tokens 10240 \
   --speculative-config.method mtp \
@@ -71,32 +128,6 @@ vllm serve Qwen/Qwen3.6-27B \
   --kv-cache-dtype fp8_e4m3 \
   --attention-backend FLASH_ATTN_CUSTOM
 ```
-### Qwen3.6-27B IFB BW1000 2x vLLM 0.21
-
-```bash
-export VLLM_HCU_USE_PD_SPLIT=1
-
-vllm serve Qwen/Qwen3.6-27B \
-  -tp 2 \
-  --trust-remote-code \
-  --max-num-batched-tokens 10240 \
-  --speculative-config.method mtp \
-  --speculative-config.num_speculative_tokens 3 \
-  --attention-backend FLASH_ATTN_CUSTOM
-```
-### Qwen3.6-27B IFB BW1000 2x vLLM 0.18
-
-```bash
-export VLLM_HCU_USE_FLASH_ATTN=1
-export VLLM_HCU_USE_CUSTOM_TOPK_TOPP_SAMPLER=1
-
-vllm serve Qwen/Qwen3.6-27B \
-  -tp 2 \
-  --trust-remote-code \
-  --max-num-batched-tokens 10240 \
-  --speculative-config.method mtp \
-  --speculative-config.num_speculative_tokens 3
-```
 
 ### Qwen3.6-27B IFB BW1000 2x vLLM 0.18-hotfix
 
@@ -110,32 +141,6 @@ vllm serve Qwen/Qwen3.6-27B \
   --speculative-config.method mtp \
   --speculative-config.num_speculative_tokens 3 \
   --attention-backend FLASH_ATTN_CUSTOM
-```
-### Qwen3.6-27B IFB K100_AI 2x vLLM 0.21
-
-```bash
-export VLLM_HCU_USE_CUSTOM_QUANTIZATION_GEMM=0
-export VLLM_HCU_USE_CUSTOM_OPS=0
-
-vllm serve Qwen/Qwen3.6-27B \
-  -tp 2 \
-  --trust-remote-code \
-  --max-num-batched-tokens 10240 \
-  --speculative-config.method mtp \
-  --speculative-config.num_speculative_tokens 3
-```
-### Qwen3.6-27B IFB K100_AI 2x vLLM 0.18
-
-```bash
-export VLLM_HCU_USE_CUSTOM_QUANTIZATION_GEMM=0
-export VLLM_HCU_USE_CUSTOM_OPS=0
-
-vllm serve Qwen/Qwen3.6-27B \
-  -tp 2 \
-  --trust-remote-code \
-  --max-num-batched-tokens 10240 \
-  --speculative-config.method mtp \
-  --speculative-config.num_speculative_tokens 3
 ```
 
 ### Qwen3.6-27B IFB K100_AI 2x vLLM 0.18-hotfix
@@ -151,6 +156,7 @@ vllm serve Qwen/Qwen3.6-27B \
   --speculative-config.method mtp \
   --speculative-config.num_speculative_tokens 3
 ```
+
 ### Qwen3.6-35B-A3B IFB BW1100 1x vLLM 0.21
 
 ```bash
@@ -165,6 +171,35 @@ vllm serve Qwen/Qwen3.6-35B-A3B \
   --attention-backend FLASH_ATTN_CUSTOM \
   --moe-backend aiter
 ```
+
+### Qwen3.6-35B-A3B IFB BW1000 2x vLLM 0.21
+
+```bash
+export VLLM_HCU_USE_PD_SPLIT=1
+vllm serve Qwen/Qwen3.6-35B-A3B \
+  -tp 2 \
+  --trust-remote-code \
+  --max-num-batched-tokens 10240 \
+  --speculative-config.method mtp \
+  --speculative-config.num_speculative_tokens 3 \
+  --attention-backend FLASH_ATTN_CUSTOM \
+  --moe-backend aiter
+```
+
+### Qwen3.6-35B-A3B IFB K100_AI 2x vLLM 0.21
+
+```bash
+export VLLM_HCU_USE_CUSTOM_QUANTIZATION_GEMM=0
+export VLLM_HCU_USE_CUSTOM_OPS=0
+
+vllm serve Qwen/Qwen3.6-35B-A3B \
+  -tp 2 \
+  --trust-remote-code \
+  --max-num-batched-tokens 10240 \
+  --speculative-config.method mtp \
+  --speculative-config.num_speculative_tokens 3
+```
+
 ### Qwen3.6-35B-A3B IFB BW1100 1x vLLM 0.18
 
 ```bash
@@ -176,6 +211,37 @@ export VLLM_HCU_USE_PD_SPLIT=1
 
 vllm serve Qwen/Qwen3.6-35B-A3B \
   -tp 1 \
+  --trust-remote-code \
+  --max-num-batched-tokens 10240 \
+  --speculative-config.method mtp \
+  --speculative-config.num_speculative_tokens 3
+```
+
+### Qwen3.6-35B-A3B IFB BW1000 2x vLLM 0.18
+
+```bash
+export VLLM_HCU_USE_FLASH_ATTN=1
+export VLLM_HCU_USE_CUSTOM_TOPK_TOPP_SAMPLER=1
+export VLLM_ROCM_USE_AITER=1
+export VLLM_ROCM_USE_AITER_MOE=1
+export VLLM_HCU_USE_PD_SPLIT=1
+
+vllm serve Qwen/Qwen3.6-35B-A3B \
+  -tp 2 \
+  --trust-remote-code \
+  --max-num-batched-tokens 10240 \
+  --speculative-config.method mtp \
+  --speculative-config.num_speculative_tokens 3
+```
+
+### Qwen3.6-35B-A3B IFB K100_AI 2x vLLM 0.18
+
+```bash
+export VLLM_HCU_USE_CUSTOM_QUANTIZATION_GEMM=0
+export VLLM_HCU_USE_CUSTOM_OPS=0
+
+vllm serve Qwen/Qwen3.6-35B-A3B \
+  -tp 2 \
   --trust-remote-code \
   --max-num-batched-tokens 10240 \
   --speculative-config.method mtp \
@@ -196,35 +262,6 @@ vllm serve Qwen/Qwen3.6-35B-A3B \
   --attention-backend FLASH_ATTN_CUSTOM \
   --moe-backend aiter
 ```
-### Qwen3.6-35B-A3B IFB BW1000 2x vLLM 0.21
-
-```bash
-export VLLM_HCU_USE_PD_SPLIT=1
-vllm serve Qwen/Qwen3.6-35B-A3B \
-  -tp 2 \
-  --trust-remote-code \
-  --max-num-batched-tokens 10240 \
-  --speculative-config.method mtp \
-  --speculative-config.num_speculative_tokens 3 \
-  --attention-backend FLASH_ATTN_CUSTOM \
-  --moe-backend aiter
-```
-### Qwen3.6-35B-A3B IFB BW1000 2x vLLM 0.18
-
-```bash
-export VLLM_HCU_USE_FLASH_ATTN=1
-export VLLM_HCU_USE_CUSTOM_TOPK_TOPP_SAMPLER=1
-export VLLM_ROCM_USE_AITER=1
-export VLLM_ROCM_USE_AITER_MOE=1
-export VLLM_HCU_USE_PD_SPLIT=1
-
-vllm serve Qwen/Qwen3.6-35B-A3B \
-  -tp 2 \
-  --trust-remote-code \
-  --max-num-batched-tokens 10240 \
-  --speculative-config.method mtp \
-  --speculative-config.num_speculative_tokens 3
-```
 
 ### Qwen3.6-35B-A3B IFB BW1000 2x vLLM 0.18-hotfix
 
@@ -238,32 +275,6 @@ vllm serve Qwen/Qwen3.6-35B-A3B \
   --speculative-config.num_speculative_tokens 3 \
   --attention-backend FLASH_ATTN_CUSTOM \
   --moe-backend aiter
-```
-### Qwen3.6-35B-A3B IFB K100_AI 2x vLLM 0.21
-
-```bash
-export VLLM_HCU_USE_CUSTOM_QUANTIZATION_GEMM=0
-export VLLM_HCU_USE_CUSTOM_OPS=0
-
-vllm serve Qwen/Qwen3.6-35B-A3B \
-  -tp 2 \
-  --trust-remote-code \
-  --max-num-batched-tokens 10240 \
-  --speculative-config.method mtp \
-  --speculative-config.num_speculative_tokens 3
-```
-### Qwen3.6-35B-A3B IFB K100_AI 2x vLLM 0.18
-
-```bash
-export VLLM_HCU_USE_CUSTOM_QUANTIZATION_GEMM=0
-export VLLM_HCU_USE_CUSTOM_OPS=0
-
-vllm serve Qwen/Qwen3.6-35B-A3B \
-  -tp 2 \
-  --trust-remote-code \
-  --max-num-batched-tokens 10240 \
-  --speculative-config.method mtp \
-  --speculative-config.num_speculative_tokens 3
 ```
 
 ### Qwen3.6-35B-A3B IFB K100_AI 2x vLLM 0.18-hotfix

--- a/docs/model-deployment/vllm/qwen3.6.md
+++ b/docs/model-deployment/vllm/qwen3.6.md
@@ -32,7 +32,6 @@ Qwen3.6 模型相较于 Qwen3.5 模型，**在智能体编程能力、推理速�
 ### Qwen3.6-27B IFB BW1100 1x vLLM 0.21
 
 ```bash
-export VLLM_HCU_USE_PD_SPLIT=1
 
 vllm serve Qwen/Qwen3.6-27B \
   -tp 1 \
@@ -47,7 +46,6 @@ vllm serve Qwen/Qwen3.6-27B \
 ### Qwen3.6-27B IFB BW1000 2x vLLM 0.21
 
 ```bash
-export VLLM_HCU_USE_PD_SPLIT=1
 
 vllm serve Qwen/Qwen3.6-27B \
   -tp 2 \
@@ -160,7 +158,6 @@ vllm serve Qwen/Qwen3.6-27B \
 ### Qwen3.6-35B-A3B IFB BW1100 1x vLLM 0.21
 
 ```bash
-export VLLM_HCU_USE_PD_SPLIT=1
 vllm serve Qwen/Qwen3.6-35B-A3B \
   -tp 1 \
   --trust-remote-code \
@@ -175,7 +172,6 @@ vllm serve Qwen/Qwen3.6-35B-A3B \
 ### Qwen3.6-35B-A3B IFB BW1000 2x vLLM 0.21
 
 ```bash
-export VLLM_HCU_USE_PD_SPLIT=1
 vllm serve Qwen/Qwen3.6-35B-A3B \
   -tp 2 \
   --trust-remote-code \

--- a/docs/model-deployment/vllm/qwen3.md
+++ b/docs/model-deployment/vllm/qwen3.md
@@ -13,13 +13,13 @@ Qwen3 是阿里通义千问第三代大语言模型，支持 0.6B ~ 235B 多种�
 |  | BF16 | 0.21 | K100_AI | 1 | IFB | [**`>_`**](#qwen3-06b-ifb-k100_ai-1x-vllm-021) |
 |  | BF16 | 0.18 | BW1100 | 1 | IFB | [**`>_`**](#qwen3-06b-ifb-bw1100-1x-vllm-018) |
 |  | BF16 | 0.18 | BW1000 | 1 | IFB | [**`>_`**](#qwen3-06b-ifb-bw1000-1x-vllm-018) |
+|  | BF16 | [0.18](../docker_images.md) | K100_AI | 1 | IFB | [**`>_`**](#qwen3-06b-ifb-k100_ai-1x-vllm-018) |
 |  | BF16 | 0.18-hotfix | BW1100 | 1 | IFB | [**`>_`**](#qwen3-06b-ifb-bw1100-1x-vllm-018-hotfix) |
 |  | BF16 | 0.18-hotfix | BW1000 | 1 | IFB | [**`>_`**](#qwen3-06b-ifb-bw1000-1x-vllm-018-hotfix) |
 |  | BF16 | 0.18-hotfix | K100_AI | 1 | IFB | [**`>_`**](#qwen3-06b-ifb-k100_ai-1x-vllm-018-hotfix) |
 |  | BF16 | 0.15 | BW1100 | 1 | IFB | [**`>_`**](#qwen3-06b-ifb-bw1100-1x-vllm-015) |
 |  | BF16 | 0.15 | BW1000 | 1 | IFB | [**`>_`**](#qwen3-06b-ifb-bw1000-1x-vllm-015) |
 |  | BF16 | 0.15 | K100_AI | 1 | IFB | [**`>_`**](#qwen3-06b-ifb-k100_ai-1x-vllm-015) |
-|  | BF16 | [0.18](../docker_images.md) | K100_AI | 1 | IFB | [**`>_`**](#qwen3-06b-ifb-k100_ai-1x-vllm-018) |
 | [Qwen/Qwen3-1.7B](https://www.modelscope.cn/models/Qwen/Qwen3-1.7B) | BF16 | 0.21 | BW1100 | 1 | IFB | [**`>_`**](#qwen3-17b-ifb-bw1100-1x-vllm-021) |
 |  | BF16 | 0.21 | BW1000 | 1 | IFB | [**`>_`**](#qwen3-17b-ifb-bw1000-1x-vllm-021) |
 |  | BF16 | 0.21 | K100_AI | 1 | IFB | [**`>_`**](#qwen3-17b-ifb-k100_ai-1x-vllm-021) |
@@ -37,13 +37,13 @@ Qwen3 是阿里通义千问第三代大语言模型，支持 0.6B ~ 235B 多种�
 |  | BF16 | 0.21 | K100_AI | 1 | IFB | [**`>_`**](#qwen3-4b-ifb-k100_ai-1x-vllm-021) |
 |  | BF16 | 0.18 | BW1100 | 1 | IFB | [**`>_`**](#qwen3-4b-ifb-bw1100-1x-vllm-018) |
 |  | BF16 | 0.18 | BW1000 | 1 | IFB | [**`>_`**](#qwen3-4b-ifb-bw1000-1x-vllm-018) |
+|  | BF16 | [0.18](../docker_images.md) | K100_AI | 1 | IFB | [**`>_`**](#qwen3-4b-ifb-k100_ai-1x-vllm-018) |
 |  | BF16 | 0.18-hotfix | BW1100 | 1 | IFB | [**`>_`**](#qwen3-4b-ifb-bw1100-1x-vllm-018-hotfix) |
 |  | BF16 | 0.18-hotfix | BW1000 | 1 | IFB | [**`>_`**](#qwen3-4b-ifb-bw1000-1x-vllm-018-hotfix) |
 |  | BF16 | 0.18-hotfix | K100_AI | 1 | IFB | [**`>_`**](#qwen3-4b-ifb-k100_ai-1x-vllm-018-hotfix) |
 |  | BF16 | 0.15 | BW1100 | 1 | IFB | [**`>_`**](#qwen3-4b-ifb-bw1100-1x-vllm-015) |
 |  | BF16 | 0.15 | BW1000 | 1 | IFB | [**`>_`**](#qwen3-4b-ifb-bw1000-1x-vllm-015) |
 |  | BF16 | 0.15 | K100_AI | 1 | IFB | [**`>_`**](#qwen3-4b-ifb-k100_ai-1x-vllm-015) |
-|  | BF16 | [0.18](../docker_images.md) | K100_AI | 1 | IFB | [**`>_`**](#qwen3-4b-ifb-k100_ai-1x-vllm-018) |
 | [Qwen/Qwen3-4B-Channel-INT8-w8a8](https://www.modelscope.cn/models/hygon/Qwen3-4B-Channel-INT8-w8a8) | INT8 W8A8 | 0.21 | BW1100 | 1 | IFB | [**`>_`**](#qwen3-4b-channel-int8-w8a8-ifb-bw1100-1x-vllm-021) |
 |  | INT8 W8A8 | 0.21 | BW1000 | 1 | IFB | [**`>_`**](#qwen3-4b-channel-int8-w8a8-ifb-bw1000-1x-vllm-021) |
 |  | INT8 W8A8 | 0.18 | BW1100 | 1 | IFB | [**`>_`**](#qwen3-4b-channel-int8-w8a8-ifb-bw1100-1x-vllm-018) |
@@ -60,15 +60,15 @@ Qwen3 是阿里通义千问第三代大语言模型，支持 0.6B ~ 235B 多种�
 | [Qwen/Qwen3-8B](https://www.modelscope.cn/models/Qwen/Qwen3-8B) | BF16 | 0.21 | BW1100 | 1 | IFB | [**`>_`**](#qwen3-8b-ifb-bw1100-1x-vllm-021) |
 |  | BF16 | 0.21 | BW1000 | 1 | IFB | [**`>_`**](#qwen3-8b-ifb-bw1000-1x-vllm-021) |
 |  | BF16 | 0.21 | K100_AI | 1 | IFB | [**`>_`**](#qwen3-8b-ifb-k100_ai-1x-vllm-021) |
+|  | BF16 | [0.18](../docker_images.md) | BW1100 | 1 | IFB | [**`>_`**](#qwen3-8b-ifb-bw1100-1x-vllm-018) |
+|  | BF16 | [0.18](../docker_images.md) | BW1000 | 1 | IFB | [**`>_`**](#qwen3-8b-ifb-bw1000-1x-vllm-018) |
+|  | BF16 | [0.18](../docker_images.md) | K100_AI | 1 | IFB | [**`>_`**](#qwen3-8b-ifb-k100_ai-1x-vllm-018) |
 |  | BF16 | 0.18-hotfix | BW1100 | 1 | IFB | [**`>_`**](#qwen3-8b-ifb-bw1100-1x-vllm-018-hotfix) |
 |  | BF16 | 0.18-hotfix | BW1000 | 1 | IFB | [**`>_`**](#qwen3-8b-ifb-bw1000-1x-vllm-018-hotfix) |
 |  | BF16 | 0.18-hotfix | K100_AI | 1 | IFB | [**`>_`**](#qwen3-8b-ifb-k100_ai-1x-vllm-018-hotfix) |
 |  | BF16 | 0.15 | BW1100 | 1 | IFB | [**`>_`**](#qwen3-8b-ifb-bw1100-1x-vllm-015) |
 |  | BF16 | 0.15 | BW1000 | 1 | IFB | [**`>_`**](#qwen3-8b-ifb-bw1000-1x-vllm-015) |
 |  | BF16 | 0.15 | K100_AI | 1 | IFB | [**`>_`**](#qwen3-8b-ifb-k100_ai-1x-vllm-015) |
-|  | BF16 | [0.18](../docker_images.md) | BW1100 | 1 | IFB | [**`>_`**](#qwen3-8b-ifb-bw1100-1x-vllm-018) |
-|  | BF16 | [0.18](../docker_images.md) | BW1000 | 1 | IFB | [**`>_`**](#qwen3-8b-ifb-bw1000-1x-vllm-018) |
-|  | BF16 | [0.18](../docker_images.md) | K100_AI | 1 | IFB | [**`>_`**](#qwen3-8b-ifb-k100_ai-1x-vllm-018) |
 | [Qwen/Qwen3-8B-Channel-INT8-w8a8](https://www.modelscope.cn/models/hygon/Qwen3-8B-Channel-INT8-w8a8) | INT8 W8A8 | 0.21 | BW1100 | 1 | IFB | [**`>_`**](#qwen3-8b-channel-int8-w8a8-ifb-bw1100-1x-vllm-021) |
 |  | INT8 W8A8 | 0.21 | BW1000 | 1 | IFB | [**`>_`**](#qwen3-8b-channel-int8-w8a8-ifb-bw1000-1x-vllm-021) |
 |  | INT8 W8A8 | 0.18 | BW1100 | 1 | IFB | [**`>_`**](#qwen3-8b-channel-int8-w8a8-ifb-bw1100-1x-vllm-018) |
@@ -165,7 +165,6 @@ Qwen3 是阿里通义千问第三代大语言模型，支持 0.6B ~ 235B 多种�
 |  | FP8 | 0.18 | BW1100 | 4 | IFB | [**`>_`**](#qwen3-235b-a22b-fp8-channelwise-ifb-bw1100-4x-vllm-018) |
 |  | FP8 | 0.18-hotfix | BW1100 | 4 | IFB | [**`>_`**](#qwen3-235b-a22b-fp8-channelwise-ifb-bw1100-4x-vllm-018-hotfix) |
 |  | FP8 | 0.15 | BW1100 | 4 | IFB | [**`>_`**](#qwen3-235b-a22b-fp8-channelwise-ifb-bw1100-4x-vllm-015) |
-
 ## 启动命令
 
 ### Qwen3-0.6B IFB BW1100 1x vLLM 0.21

--- a/docs/model-deployment/vllm/qwen3.md
+++ b/docs/model-deployment/vllm/qwen3.md
@@ -8,139 +8,138 @@ Qwen3 是阿里通义千问第三代大语言模型，支持 0.6B ~ 235B 多种�
 
 | 模型权重 | 量化方式 | vLLM 版本 | 推荐硬件 | 卡数 | 部署方式 | 启动命令 |
 | -------- | -------- | --------- | -------- | ---- | -------- | -------- |
-| [Qwen/Qwen3-0.6B](https://www.modelscope.cn/models/Qwen/Qwen3-0.6B)           | BF16 | 0.21 | BW1100 | 1 | IFB | [**`>_`**](#qwen3-06b-ifb-bw1100-1x-vllm-021) |
-|  | BF16 | 0.18 | BW1100  | 1 | IFB | [**`>_`**](#qwen3-06b-ifb-bw1100-1x-vllm-018)           |
-|  | BF16 | 0.18-hotfix | BW1100 | 1 | IFB | [**`>_`**](#qwen3-06b-ifb-bw1100-1x-vllm-018-hotfix) |
+| [Qwen/Qwen3-0.6B](https://www.modelscope.cn/models/Qwen/Qwen3-0.6B) | BF16 | 0.21 | BW1100 | 1 | IFB | [**`>_`**](#qwen3-06b-ifb-bw1100-1x-vllm-021) |
 |  | BF16 | 0.21 | BW1000 | 1 | IFB | [**`>_`**](#qwen3-06b-ifb-bw1000-1x-vllm-021) |
-|                                                                               | BF16 | 0.18 | BW1000  | 1 | IFB | [**`>_`**](#qwen3-06b-ifb-bw1000-1x-vllm-018)           |
-|  | BF16 | 0.18-hotfix | BW1000 | 1 | IFB | [**`>_`**](#qwen3-06b-ifb-bw1000-1x-vllm-018-hotfix) |
 |  | BF16 | 0.21 | K100_AI | 1 | IFB | [**`>_`**](#qwen3-06b-ifb-k100_ai-1x-vllm-021) |
-|                                                                               | BF16 | [0.18](../docker_images.md) | K100_AI | 1 | IFB | [**`>_`**](#qwen3-06b-ifb-k100_ai-1x-vllm-018)          |
+|  | BF16 | 0.18 | BW1100 | 1 | IFB | [**`>_`**](#qwen3-06b-ifb-bw1100-1x-vllm-018) |
+|  | BF16 | 0.18 | BW1000 | 1 | IFB | [**`>_`**](#qwen3-06b-ifb-bw1000-1x-vllm-018) |
+|  | BF16 | 0.18-hotfix | BW1100 | 1 | IFB | [**`>_`**](#qwen3-06b-ifb-bw1100-1x-vllm-018-hotfix) |
+|  | BF16 | 0.18-hotfix | BW1000 | 1 | IFB | [**`>_`**](#qwen3-06b-ifb-bw1000-1x-vllm-018-hotfix) |
 |  | BF16 | 0.18-hotfix | K100_AI | 1 | IFB | [**`>_`**](#qwen3-06b-ifb-k100_ai-1x-vllm-018-hotfix) |
-|                                                                               | BF16 | 0.15 | BW1100  | 1   | IFB | [**`>_`**](#qwen3-06b-ifb-bw1100-1x-vllm-015) |
-|                                                                               | BF16 | 0.15 | BW1000  | 1 | IFB | [**`>_`**](#qwen3-06b-ifb-bw1000-1x-vllm-015)           |
-|                                                                               | BF16 | 0.15 | K100_AI | 1   | IFB | [**`>_`**](#qwen3-06b-ifb-k100_ai-1x-vllm-015) |
-| [Qwen/Qwen3-1.7B](https://www.modelscope.cn/models/Qwen/Qwen3-1.7B)           | BF16 | 0.21 | BW1100 | 1 | IFB | [**`>_`**](#qwen3-17b-ifb-bw1100-1x-vllm-021) |
-|  | BF16 | 0.18 | BW1100  | 1 | IFB | [**`>_`**](#qwen3-17b-ifb-bw1100-1x-vllm-018)           |
-|  | BF16 | 0.18-hotfix | BW1100 | 1 | IFB | [**`>_`**](#qwen3-17b-ifb-bw1100-1x-vllm-018-hotfix) |
+|  | BF16 | 0.15 | BW1100 | 1 | IFB | [**`>_`**](#qwen3-06b-ifb-bw1100-1x-vllm-015) |
+|  | BF16 | 0.15 | BW1000 | 1 | IFB | [**`>_`**](#qwen3-06b-ifb-bw1000-1x-vllm-015) |
+|  | BF16 | 0.15 | K100_AI | 1 | IFB | [**`>_`**](#qwen3-06b-ifb-k100_ai-1x-vllm-015) |
+|  | BF16 | [0.18](../docker_images.md) | K100_AI | 1 | IFB | [**`>_`**](#qwen3-06b-ifb-k100_ai-1x-vllm-018) |
+| [Qwen/Qwen3-1.7B](https://www.modelscope.cn/models/Qwen/Qwen3-1.7B) | BF16 | 0.21 | BW1100 | 1 | IFB | [**`>_`**](#qwen3-17b-ifb-bw1100-1x-vllm-021) |
 |  | BF16 | 0.21 | BW1000 | 1 | IFB | [**`>_`**](#qwen3-17b-ifb-bw1000-1x-vllm-021) |
-|                                                                               | BF16 | 0.18 | BW1000  | 1 | IFB | [**`>_`**](#qwen3-17b-ifb-bw1000-1x-vllm-018)           |
-|  | BF16 | 0.18-hotfix | BW1000 | 1 | IFB | [**`>_`**](#qwen3-17b-ifb-bw1000-1x-vllm-018-hotfix) |
 |  | BF16 | 0.21 | K100_AI | 1 | IFB | [**`>_`**](#qwen3-17b-ifb-k100_ai-1x-vllm-021) |
-|                                                                               | BF16 | 0.18 | K100_AI | 1 | IFB | [**`>_`**](#qwen3-17b-ifb-k100_ai-1x-vllm-018)          |
+|  | BF16 | 0.18 | BW1100 | 1 | IFB | [**`>_`**](#qwen3-17b-ifb-bw1100-1x-vllm-018) |
+|  | BF16 | 0.18 | BW1000 | 1 | IFB | [**`>_`**](#qwen3-17b-ifb-bw1000-1x-vllm-018) |
+|  | BF16 | 0.18 | K100_AI | 1 | IFB | [**`>_`**](#qwen3-17b-ifb-k100_ai-1x-vllm-018) |
+|  | BF16 | 0.18-hotfix | BW1100 | 1 | IFB | [**`>_`**](#qwen3-17b-ifb-bw1100-1x-vllm-018-hotfix) |
+|  | BF16 | 0.18-hotfix | BW1000 | 1 | IFB | [**`>_`**](#qwen3-17b-ifb-bw1000-1x-vllm-018-hotfix) |
 |  | BF16 | 0.18-hotfix | K100_AI | 1 | IFB | [**`>_`**](#qwen3-17b-ifb-k100_ai-1x-vllm-018-hotfix) |
-|                                                                               | BF16 | 0.15 | BW1100  | 1   | IFB | [**`>_`**](#qwen3-17b-ifb-bw1100-1x-vllm-015) |
-|                                                                               | BF16 | 0.15 | BW1000  | 1 | IFB | [**`>_`**](#qwen3-17b-ifb-bw1000-1x-vllm-015)           |
-|                                                                               | BF16 | 0.15 | K100_AI | 1   | IFB | [**`>_`**](#qwen3-17b-ifb-k100_ai-1x-vllm-015) |
-| [Qwen/Qwen3-4B](https://www.modelscope.cn/models/Qwen/Qwen3-4B)               | BF16 | 0.21 | BW1100 | 1 | IFB | [**`>_`**](#qwen3-4b-ifb-bw1100-1x-vllm-021) |
-|  | BF16 | 0.18 | BW1100  | 1 | IFB | [**`>_`**](#qwen3-4b-ifb-bw1100-1x-vllm-018)            |
-|  | BF16 | 0.18-hotfix | BW1100 | 1 | IFB | [**`>_`**](#qwen3-4b-ifb-bw1100-1x-vllm-018-hotfix) |
+|  | BF16 | 0.15 | BW1100 | 1 | IFB | [**`>_`**](#qwen3-17b-ifb-bw1100-1x-vllm-015) |
+|  | BF16 | 0.15 | BW1000 | 1 | IFB | [**`>_`**](#qwen3-17b-ifb-bw1000-1x-vllm-015) |
+|  | BF16 | 0.15 | K100_AI | 1 | IFB | [**`>_`**](#qwen3-17b-ifb-k100_ai-1x-vllm-015) |
+| [Qwen/Qwen3-4B](https://www.modelscope.cn/models/Qwen/Qwen3-4B) | BF16 | 0.21 | BW1100 | 1 | IFB | [**`>_`**](#qwen3-4b-ifb-bw1100-1x-vllm-021) |
 |  | BF16 | 0.21 | BW1000 | 1 | IFB | [**`>_`**](#qwen3-4b-ifb-bw1000-1x-vllm-021) |
-|                                                                               | BF16 | 0.18 | BW1000  | 1 | IFB | [**`>_`**](#qwen3-4b-ifb-bw1000-1x-vllm-018)            |
-|  | BF16 | 0.18-hotfix | BW1000 | 1 | IFB | [**`>_`**](#qwen3-4b-ifb-bw1000-1x-vllm-018-hotfix) |
 |  | BF16 | 0.21 | K100_AI | 1 | IFB | [**`>_`**](#qwen3-4b-ifb-k100_ai-1x-vllm-021) |
-|                                                                               | BF16 | [0.18](../docker_images.md) | K100_AI | 1 | IFB | [**`>_`**](#qwen3-4b-ifb-k100_ai-1x-vllm-018)           |
+|  | BF16 | 0.18 | BW1100 | 1 | IFB | [**`>_`**](#qwen3-4b-ifb-bw1100-1x-vllm-018) |
+|  | BF16 | 0.18 | BW1000 | 1 | IFB | [**`>_`**](#qwen3-4b-ifb-bw1000-1x-vllm-018) |
+|  | BF16 | 0.18-hotfix | BW1100 | 1 | IFB | [**`>_`**](#qwen3-4b-ifb-bw1100-1x-vllm-018-hotfix) |
+|  | BF16 | 0.18-hotfix | BW1000 | 1 | IFB | [**`>_`**](#qwen3-4b-ifb-bw1000-1x-vllm-018-hotfix) |
 |  | BF16 | 0.18-hotfix | K100_AI | 1 | IFB | [**`>_`**](#qwen3-4b-ifb-k100_ai-1x-vllm-018-hotfix) |
-|                                                                               | BF16 | 0.15 | BW1100  | 1   | IFB | [**`>_`**](#qwen3-4b-ifb-bw1100-1x-vllm-015) |
-|                                                                               | BF16 | 0.15 | BW1000  | 1 | IFB | [**`>_`**](#qwen3-4b-ifb-bw1000-1x-vllm-015)            |
-|                                                                               | BF16 | 0.15 | K100_AI | 1   | IFB | [**`>_`**](#qwen3-4b-ifb-k100_ai-1x-vllm-015) |
+|  | BF16 | 0.15 | BW1100 | 1 | IFB | [**`>_`**](#qwen3-4b-ifb-bw1100-1x-vllm-015) |
+|  | BF16 | 0.15 | BW1000 | 1 | IFB | [**`>_`**](#qwen3-4b-ifb-bw1000-1x-vllm-015) |
+|  | BF16 | 0.15 | K100_AI | 1 | IFB | [**`>_`**](#qwen3-4b-ifb-k100_ai-1x-vllm-015) |
+|  | BF16 | [0.18](../docker_images.md) | K100_AI | 1 | IFB | [**`>_`**](#qwen3-4b-ifb-k100_ai-1x-vllm-018) |
 | [Qwen/Qwen3-4B-Channel-INT8-w8a8](https://www.modelscope.cn/models/hygon/Qwen3-4B-Channel-INT8-w8a8) | INT8 W8A8 | 0.21 | BW1100 | 1 | IFB | [**`>_`**](#qwen3-4b-channel-int8-w8a8-ifb-bw1100-1x-vllm-021) |
-|  | INT8 W8A8 | 0.18 | BW1100 | 1 | IFB | [**`>_`**](#qwen3-4b-channel-int8-w8a8-ifb-bw1100-1x-vllm-018) |
-|  | INT8 W8A8 | 0.18-hotfix | BW1100 | 1 | IFB | [**`>_`**](#qwen3-4b-channel-int8-w8a8-ifb-bw1100-1x-vllm-018-hotfix) |
 |  | INT8 W8A8 | 0.21 | BW1000 | 1 | IFB | [**`>_`**](#qwen3-4b-channel-int8-w8a8-ifb-bw1000-1x-vllm-021) |
-|                                                                               | INT8 W8A8 | 0.18 | BW1000 | 1 | IFB | [**`>_`**](#qwen3-4b-channel-int8-w8a8-ifb-bw1000-1x-vllm-018) |
+|  | INT8 W8A8 | 0.18 | BW1100 | 1 | IFB | [**`>_`**](#qwen3-4b-channel-int8-w8a8-ifb-bw1100-1x-vllm-018) |
+|  | INT8 W8A8 | 0.18 | BW1000 | 1 | IFB | [**`>_`**](#qwen3-4b-channel-int8-w8a8-ifb-bw1000-1x-vllm-018) |
+|  | INT8 W8A8 | 0.18 | K100_AI | 1 | IFB | [**`>_`**](#qwen3-4b-channel-int8-w8a8-ifb-k100_ai-1x-vllm-018) |
+|  | INT8 W8A8 | 0.18-hotfix | BW1100 | 1 | IFB | [**`>_`**](#qwen3-4b-channel-int8-w8a8-ifb-bw1100-1x-vllm-018-hotfix) |
 |  | INT8 W8A8 | 0.18-hotfix | BW1000 | 1 | IFB | [**`>_`**](#qwen3-4b-channel-int8-w8a8-ifb-bw1000-1x-vllm-018-hotfix) |
-|                                                                               | INT8 W8A8 | 0.18 | K100_AI | 1 | IFB | [**`>_`**](#qwen3-4b-channel-int8-w8a8-ifb-k100_ai-1x-vllm-018) |
-|                                                                               | INT8 W8A8 | 0.15 | BW1100 | 1 | IFB | [**`>_`**](#qwen3-4b-channel-int8-w8a8-ifb-bw1100-1x-vllm-015) |
-|                                                                               | INT8 W8A8 | 0.15 | BW1000 | 1 | IFB | [**`>_`**](#qwen3-4b-channel-int8-w8a8-ifb-bw1000-1x-vllm-015) |
-|                                                                               | INT8 W8A8 | 0.15 | K100_AI | 1 | IFB | [**`>_`**](#qwen3-4b-channel-int8-w8a8-ifb-k100_ai-1x-vllm-015) |
+|  | INT8 W8A8 | 0.15 | BW1100 | 1 | IFB | [**`>_`**](#qwen3-4b-channel-int8-w8a8-ifb-bw1100-1x-vllm-015) |
+|  | INT8 W8A8 | 0.15 | BW1000 | 1 | IFB | [**`>_`**](#qwen3-4b-channel-int8-w8a8-ifb-bw1000-1x-vllm-015) |
+|  | INT8 W8A8 | 0.15 | K100_AI | 1 | IFB | [**`>_`**](#qwen3-4b-channel-int8-w8a8-ifb-k100_ai-1x-vllm-015) |
 | [Qwen/Qwen3-4B-Thinking-2507](https://www.modelscope.cn/models/Qwen/Qwen3-4B-Thinking-2507) | BF16 | [0.18](../docker_images.md) | BW1100 | 1 | IFB | [**`>_`**](#qwen3-4b-thinking-2507-ifb-bw1100-1x-vllm-018) |
-|                                                                                              | BF16 | [0.18](../docker_images.md) | BW1000 | 1 | IFB | [**`>_`**](#qwen3-4b-thinking-2507-ifb-bw1000-1x-vllm-018) |
-|                                                                                              | BF16 | [0.18](../docker_images.md) | K100_AI | 1 | IFB | [**`>_`**](#qwen3-4b-thinking-2507-ifb-k100ai-1x-vllm-018) |
-| [Qwen/Qwen3-8B](https://www.modelscope.cn/models/Qwen/Qwen3-8B)               | BF16 | 0.21 | BW1100 | 1 | IFB | [**`>_`**](#qwen3-8b-ifb-bw1100-1x-vllm-021) |
-|  | BF16 | [0.18](../docker_images.md) | BW1100  | 1 | IFB | [**`>_`**](#qwen3-8b-ifb-bw1100-1x-vllm-018)            |
-|  | BF16 | 0.18-hotfix | BW1100 | 1 | IFB | [**`>_`**](#qwen3-8b-ifb-bw1100-1x-vllm-018-hotfix) |
+|  | BF16 | [0.18](../docker_images.md) | BW1000 | 1 | IFB | [**`>_`**](#qwen3-4b-thinking-2507-ifb-bw1000-1x-vllm-018) |
+|  | BF16 | [0.18](../docker_images.md) | K100_AI | 1 | IFB | [**`>_`**](#qwen3-4b-thinking-2507-ifb-k100ai-1x-vllm-018) |
+| [Qwen/Qwen3-8B](https://www.modelscope.cn/models/Qwen/Qwen3-8B) | BF16 | 0.21 | BW1100 | 1 | IFB | [**`>_`**](#qwen3-8b-ifb-bw1100-1x-vllm-021) |
 |  | BF16 | 0.21 | BW1000 | 1 | IFB | [**`>_`**](#qwen3-8b-ifb-bw1000-1x-vllm-021) |
-|                                                                               | BF16 | [0.18](../docker_images.md) | BW1000  | 1 | IFB | [**`>_`**](#qwen3-8b-ifb-bw1000-1x-vllm-018)            |
-|  | BF16 | 0.18-hotfix | BW1000 | 1 | IFB | [**`>_`**](#qwen3-8b-ifb-bw1000-1x-vllm-018-hotfix) |
 |  | BF16 | 0.21 | K100_AI | 1 | IFB | [**`>_`**](#qwen3-8b-ifb-k100_ai-1x-vllm-021) |
-|                                                                               | BF16 | [0.18](../docker_images.md) | K100_AI | 1 | IFB | [**`>_`**](#qwen3-8b-ifb-k100_ai-1x-vllm-018)           |
+|  | BF16 | 0.18-hotfix | BW1100 | 1 | IFB | [**`>_`**](#qwen3-8b-ifb-bw1100-1x-vllm-018-hotfix) |
+|  | BF16 | 0.18-hotfix | BW1000 | 1 | IFB | [**`>_`**](#qwen3-8b-ifb-bw1000-1x-vllm-018-hotfix) |
 |  | BF16 | 0.18-hotfix | K100_AI | 1 | IFB | [**`>_`**](#qwen3-8b-ifb-k100_ai-1x-vllm-018-hotfix) |
-|                                                                               | BF16 | 0.15 | BW1100  | 1   | IFB | [**`>_`**](#qwen3-8b-ifb-bw1100-1x-vllm-015) |
-|                                                                               | BF16 | 0.15 | BW1000  | 1 | IFB | [**`>_`**](#qwen3-8b-ifb-bw1000-1x-vllm-015)            |
-|                                                                               | BF16 | 0.15 | K100_AI | 1   | IFB | [**`>_`**](#qwen3-8b-ifb-k100_ai-1x-vllm-015) |
+|  | BF16 | 0.15 | BW1100 | 1 | IFB | [**`>_`**](#qwen3-8b-ifb-bw1100-1x-vllm-015) |
+|  | BF16 | 0.15 | BW1000 | 1 | IFB | [**`>_`**](#qwen3-8b-ifb-bw1000-1x-vllm-015) |
+|  | BF16 | 0.15 | K100_AI | 1 | IFB | [**`>_`**](#qwen3-8b-ifb-k100_ai-1x-vllm-015) |
+|  | BF16 | [0.18](../docker_images.md) | BW1100 | 1 | IFB | [**`>_`**](#qwen3-8b-ifb-bw1100-1x-vllm-018) |
+|  | BF16 | [0.18](../docker_images.md) | BW1000 | 1 | IFB | [**`>_`**](#qwen3-8b-ifb-bw1000-1x-vllm-018) |
+|  | BF16 | [0.18](../docker_images.md) | K100_AI | 1 | IFB | [**`>_`**](#qwen3-8b-ifb-k100_ai-1x-vllm-018) |
 | [Qwen/Qwen3-8B-Channel-INT8-w8a8](https://www.modelscope.cn/models/hygon/Qwen3-8B-Channel-INT8-w8a8) | INT8 W8A8 | 0.21 | BW1100 | 1 | IFB | [**`>_`**](#qwen3-8b-channel-int8-w8a8-ifb-bw1100-1x-vllm-021) |
-|  | INT8 W8A8 | 0.18 | BW1100 | 1 | IFB | [**`>_`**](#qwen3-8b-channel-int8-w8a8-ifb-bw1100-1x-vllm-018) |
-|  | INT8 W8A8 | 0.18-hotfix | BW1100 | 1 | IFB | [**`>_`**](#qwen3-8b-channel-int8-w8a8-ifb-bw1100-1x-vllm-018-hotfix) |
 |  | INT8 W8A8 | 0.21 | BW1000 | 1 | IFB | [**`>_`**](#qwen3-8b-channel-int8-w8a8-ifb-bw1000-1x-vllm-021) |
-|                                                                               | INT8 W8A8 | 0.18 | BW1000 | 1 | IFB | [**`>_`**](#qwen3-8b-channel-int8-w8a8-ifb-bw1000-1x-vllm-018) |
+|  | INT8 W8A8 | 0.18 | BW1100 | 1 | IFB | [**`>_`**](#qwen3-8b-channel-int8-w8a8-ifb-bw1100-1x-vllm-018) |
+|  | INT8 W8A8 | 0.18 | BW1000 | 1 | IFB | [**`>_`**](#qwen3-8b-channel-int8-w8a8-ifb-bw1000-1x-vllm-018) |
+|  | INT8 W8A8 | 0.18 | K100_AI | 1 | IFB | [**`>_`**](#qwen3-8b-channel-int8-w8a8-ifb-k100_ai-1x-vllm-018) |
+|  | INT8 W8A8 | 0.18-hotfix | BW1100 | 1 | IFB | [**`>_`**](#qwen3-8b-channel-int8-w8a8-ifb-bw1100-1x-vllm-018-hotfix) |
 |  | INT8 W8A8 | 0.18-hotfix | BW1000 | 1 | IFB | [**`>_`**](#qwen3-8b-channel-int8-w8a8-ifb-bw1000-1x-vllm-018-hotfix) |
-|                                                                               | INT8 W8A8 | 0.18 | K100_AI | 1 | IFB | [**`>_`**](#qwen3-8b-channel-int8-w8a8-ifb-k100_ai-1x-vllm-018) |
-|                                                                               | INT8 W8A8 | 0.15 | BW1100 | 1 | IFB | [**`>_`**](#qwen3-8b-channel-int8-w8a8-ifb-bw1100-1x-vllm-015) |
-|                                                                               | INT8 W8A8 | 0.15 | BW1000 | 1 | IFB | [**`>_`**](#qwen3-8b-channel-int8-w8a8-ifb-bw1000-1x-vllm-015) |
-|                                                                               | INT8 W8A8 | 0.15 | K100_AI | 1 | IFB | [**`>_`**](#qwen3-8b-channel-int8-w8a8-ifb-k100_ai-1x-vllm-015) |
-| [Qwen/Qwen3-14B](https://www.modelscope.cn/models/Qwen/Qwen3-14B)             | BF16 | 0.21 | BW1100 | 1 | IFB | [**`>_`**](#qwen3-14b-ifb-bw1100-1x-vllm-021) |
-|  | BF16 | 0.18 | BW1100  | 1 | IFB | [**`>_`**](#qwen3-14b-ifb-bw1100-1x-vllm-018)           |
-|  | BF16 | 0.18-hotfix | BW1100 | 1 | IFB | [**`>_`**](#qwen3-14b-ifb-bw1100-1x-vllm-018-hotfix) |
+|  | INT8 W8A8 | 0.15 | BW1100 | 1 | IFB | [**`>_`**](#qwen3-8b-channel-int8-w8a8-ifb-bw1100-1x-vllm-015) |
+|  | INT8 W8A8 | 0.15 | BW1000 | 1 | IFB | [**`>_`**](#qwen3-8b-channel-int8-w8a8-ifb-bw1000-1x-vllm-015) |
+|  | INT8 W8A8 | 0.15 | K100_AI | 1 | IFB | [**`>_`**](#qwen3-8b-channel-int8-w8a8-ifb-k100_ai-1x-vllm-015) |
+| [Qwen/Qwen3-14B](https://www.modelscope.cn/models/Qwen/Qwen3-14B) | BF16 | 0.21 | BW1100 | 1 | IFB | [**`>_`**](#qwen3-14b-ifb-bw1100-1x-vllm-021) |
 |  | BF16 | 0.21 | BW1000 | 1 | IFB | [**`>_`**](#qwen3-14b-ifb-bw1000-1x-vllm-021) |
-|                                                                               | BF16 | 0.18 | BW1000  | 1 | IFB | [**`>_`**](#qwen3-14b-ifb-bw1000-1x-vllm-018)           |
-|  | BF16 | 0.18-hotfix | BW1000 | 1 | IFB | [**`>_`**](#qwen3-14b-ifb-bw1000-1x-vllm-018-hotfix) |
 |  | BF16 | 0.21 | K100_AI | 1 | IFB | [**`>_`**](#qwen3-14b-ifb-k100_ai-1x-vllm-021) |
-|                                                                               | BF16 | 0.18 | K100_AI | 1 | IFB | [**`>_`**](#qwen3-14b-ifb-k100_ai-1x-vllm-018)          |
+|  | BF16 | 0.18 | BW1100 | 1 | IFB | [**`>_`**](#qwen3-14b-ifb-bw1100-1x-vllm-018) |
+|  | BF16 | 0.18 | BW1000 | 1 | IFB | [**`>_`**](#qwen3-14b-ifb-bw1000-1x-vllm-018) |
+|  | BF16 | 0.18 | K100_AI | 1 | IFB | [**`>_`**](#qwen3-14b-ifb-k100_ai-1x-vllm-018) |
+|  | BF16 | 0.18-hotfix | BW1100 | 1 | IFB | [**`>_`**](#qwen3-14b-ifb-bw1100-1x-vllm-018-hotfix) |
+|  | BF16 | 0.18-hotfix | BW1000 | 1 | IFB | [**`>_`**](#qwen3-14b-ifb-bw1000-1x-vllm-018-hotfix) |
 |  | BF16 | 0.18-hotfix | K100_AI | 1 | IFB | [**`>_`**](#qwen3-14b-ifb-k100_ai-1x-vllm-018-hotfix) |
-|                                                                               | BF16 | 0.15 | BW1100  | 1   | IFB | [**`>_`**](#qwen3-14b-ifb-bw1100-1x-vllm-015) |
-|                                                                               | BF16 | 0.15 | BW1000  | 1 | IFB | [**`>_`**](#qwen3-14b-ifb-bw1000-1x-vllm-015)           |
-|                                                                               | BF16 | 0.15 | K100_AI | 1   | IFB | [**`>_`**](#qwen3-14b-ifb-k100_ai-1x-vllm-015) |
+|  | BF16 | 0.15 | BW1100 | 1 | IFB | [**`>_`**](#qwen3-14b-ifb-bw1100-1x-vllm-015) |
+|  | BF16 | 0.15 | BW1000 | 1 | IFB | [**`>_`**](#qwen3-14b-ifb-bw1000-1x-vllm-015) |
+|  | BF16 | 0.15 | K100_AI | 1 | IFB | [**`>_`**](#qwen3-14b-ifb-k100_ai-1x-vllm-015) |
 | [Qwen/Qwen3-14B-Channel-INT8-w8a8](https://www.modelscope.cn/models/hygon/Qwen3-14B-Channel-INT8-w8a8) | INT8 W8A8 | 0.21 | BW1100 | 1 | IFB | [**`>_`**](#qwen3-14b-channel-int8-w8a8-ifb-bw1100-1x-vllm-021) |
-|  | INT8 W8A8 | 0.18 | BW1100 | 1 | IFB | [**`>_`**](#qwen3-14b-channel-int8-w8a8-ifb-bw1100-1x-vllm-018) |
-|  | INT8 W8A8 | 0.18-hotfix | BW1100 | 1 | IFB | [**`>_`**](#qwen3-14b-channel-int8-w8a8-ifb-bw1100-1x-vllm-018-hotfix) |
 |  | INT8 W8A8 | 0.21 | BW1000 | 1 | IFB | [**`>_`**](#qwen3-14b-channel-int8-w8a8-ifb-bw1000-1x-vllm-021) |
-|                                                                               | INT8 W8A8 | 0.18 | BW1000 | 1 | IFB | [**`>_`**](#qwen3-14b-channel-int8-w8a8-ifb-bw1000-1x-vllm-018) |
+|  | INT8 W8A8 | 0.18 | BW1100 | 1 | IFB | [**`>_`**](#qwen3-14b-channel-int8-w8a8-ifb-bw1100-1x-vllm-018) |
+|  | INT8 W8A8 | 0.18 | BW1000 | 1 | IFB | [**`>_`**](#qwen3-14b-channel-int8-w8a8-ifb-bw1000-1x-vllm-018) |
+|  | INT8 W8A8 | 0.18 | K100_AI | 1 | IFB | [**`>_`**](#qwen3-14b-channel-int8-w8a8-ifb-k100_ai-1x-vllm-018) |
+|  | INT8 W8A8 | 0.18-hotfix | BW1100 | 1 | IFB | [**`>_`**](#qwen3-14b-channel-int8-w8a8-ifb-bw1100-1x-vllm-018-hotfix) |
 |  | INT8 W8A8 | 0.18-hotfix | BW1000 | 1 | IFB | [**`>_`**](#qwen3-14b-channel-int8-w8a8-ifb-bw1000-1x-vllm-018-hotfix) |
-|                                                                               | INT8 W8A8 | 0.18 | K100_AI | 1 | IFB | [**`>_`**](#qwen3-14b-channel-int8-w8a8-ifb-k100_ai-1x-vllm-018) |
-|                                                                               | INT8 W8A8 | 0.15 | BW1100 | 1 | IFB | [**`>_`**](#qwen3-14b-channel-int8-w8a8-ifb-bw1100-1x-vllm-015) |
-|                                                                               | INT8 W8A8 | 0.15 | BW1000 | 1 | IFB | [**`>_`**](#qwen3-14b-channel-int8-w8a8-ifb-bw1000-1x-vllm-015) |
-|                                                                               | INT8 W8A8 | 0.15 | K100_AI | 1 | IFB | [**`>_`**](#qwen3-14b-channel-int8-w8a8-ifb-k100_ai-1x-vllm-015) |
-| [Qwen/Qwen3-32B](https://www.modelscope.cn/models/Qwen/Qwen3-32B)             | BF16 | 0.21 | BW1100 | 1 | IFB | [**`>_`**](#qwen3-32b-ifb-bw1100-1x-vllm-021) |
-|  | BF16 | 0.18 | BW1100  | 1 | IFB | [**`>_`**](#qwen3-32b-ifb-bw1100-1x-vllm-018)           |
-|  | BF16 | 0.18-hotfix | BW1100 | 1 | IFB | [**`>_`**](#qwen3-32b-ifb-bw1100-1x-vllm-018-hotfix) |
+|  | INT8 W8A8 | 0.15 | BW1100 | 1 | IFB | [**`>_`**](#qwen3-14b-channel-int8-w8a8-ifb-bw1100-1x-vllm-015) |
+|  | INT8 W8A8 | 0.15 | BW1000 | 1 | IFB | [**`>_`**](#qwen3-14b-channel-int8-w8a8-ifb-bw1000-1x-vllm-015) |
+|  | INT8 W8A8 | 0.15 | K100_AI | 1 | IFB | [**`>_`**](#qwen3-14b-channel-int8-w8a8-ifb-k100_ai-1x-vllm-015) |
+| [Qwen/Qwen3-32B](https://www.modelscope.cn/models/Qwen/Qwen3-32B) | BF16 | 0.21 | BW1100 | 1 | IFB | [**`>_`**](#qwen3-32b-ifb-bw1100-1x-vllm-021) |
 |  | BF16 | 0.21 | BW1000 | 2 | IFB | [**`>_`**](#qwen3-32b-ifb-bw1000-2x-vllm-021) |
-|                                                                               | BF16 | 0.18 | BW1000  | 2 | IFB | [**`>_`**](#qwen3-32b-ifb-bw1000-2x-vllm-018)           |
-|  | BF16 | 0.18-hotfix | BW1000 | 2 | IFB | [**`>_`**](#qwen3-32b-ifb-bw1000-2x-vllm-018-hotfix) |
 |  | BF16 | 0.21 | K100_AI | 2 | IFB | [**`>_`**](#qwen3-32b-ifb-k100_ai-2x-vllm-021) |
-|                                                                               | BF16 | 0.18 | K100_AI | 2 | IFB | [**`>_`**](#qwen3-32b-ifb-k100_ai-2x-vllm-018)          |
+|  | BF16 | 0.18 | BW1100 | 1 | IFB | [**`>_`**](#qwen3-32b-ifb-bw1100-1x-vllm-018) |
+|  | BF16 | 0.18 | BW1000 | 2 | IFB | [**`>_`**](#qwen3-32b-ifb-bw1000-2x-vllm-018) |
+|  | BF16 | 0.18 | K100_AI | 2 | IFB | [**`>_`**](#qwen3-32b-ifb-k100_ai-2x-vllm-018) |
+|  | BF16 | 0.18-hotfix | BW1100 | 1 | IFB | [**`>_`**](#qwen3-32b-ifb-bw1100-1x-vllm-018-hotfix) |
+|  | BF16 | 0.18-hotfix | BW1000 | 2 | IFB | [**`>_`**](#qwen3-32b-ifb-bw1000-2x-vllm-018-hotfix) |
 |  | BF16 | 0.18-hotfix | K100_AI | 2 | IFB | [**`>_`**](#qwen3-32b-ifb-k100_ai-2x-vllm-018-hotfix) |
-|                                                                               | BF16 | 0.15 | BW1100  | 1 | IFB | [**`>_`**](#qwen3-32b-ifb-bw1100-1x-vllm-015)           |
-|                                                                               | BF16 | 0.15 | BW1000  | 2   | IFB | [**`>_`**](#qwen3-32b-ifb-bw1000-2x-vllm-015) |
-|                                                                               | BF16 | 0.15 | K100_AI | 2   | IFB | [**`>_`**](#qwen3-32b-ifb-k100_ai-2x-vllm-015) |
+|  | BF16 | 0.15 | BW1100 | 1 | IFB | [**`>_`**](#qwen3-32b-ifb-bw1100-1x-vllm-015) |
+|  | BF16 | 0.15 | BW1000 | 2 | IFB | [**`>_`**](#qwen3-32b-ifb-bw1000-2x-vllm-015) |
+|  | BF16 | 0.15 | K100_AI | 2 | IFB | [**`>_`**](#qwen3-32b-ifb-k100_ai-2x-vllm-015) |
 | Qwen3-32B.w8a8 | INT8 W8A8 | 0.18 | BW1100 | 1 | IFB | [**`>_`**](#qwen3-32bw8a8-ifb-bw1100-1x-vllm-018) |
 |  | INT8 W8A8 | 0.18 | BW1000 | 1 | IFB | [**`>_`**](#qwen3-32bw8a8-ifb-bw1000-1x-vllm-018) |
 |  | INT8 W8A8 | 0.18 | K100_AI | 4 | IFB | [**`>_`**](#qwen3-32bw8a8-ifb-k100_ai-4x-vllm-018) |
 | [Qwen/Qwen3-30B-A3B-Instruct-2507](https://www.modelscope.cn/models/Qwen/Qwen3-30B-A3B-Instruct-2507) | BF16 | 0.21 | BW1100 | 1 | IFB | [**`>_`**](#qwen3-30b-a3b-instruct-2507-ifb-bw1100-1x-vllm-021) |
-|  | BF16 | 0.18 | BW1100 | 1 | IFB | [**`>_`**](#qwen3-30b-a3b-instruct-2507-ifb-bw1100-1x-vllm-018) |
-|  | BF16 | 0.18-hotfix | BW1100 | 1 | IFB | [**`>_`**](#qwen3-30b-a3b-instruct-2507-ifb-bw1100-1x-vllm-018-hotfix) |
 |  | BF16 | 0.21 | BW1000 | 2 | IFB | [**`>_`**](#qwen3-30b-a3b-instruct-2507-ifb-bw1000-2x-vllm-021) |
-|                                                                               | BF16 | 0.18 | BW1000 | 2 | IFB | [**`>_`**](#qwen3-30b-a3b-instruct-2507-ifb-bw1000-2x-vllm-018) |
-|  | BF16 | 0.18-hotfix | BW1000 | 2 | IFB | [**`>_`**](#qwen3-30b-a3b-instruct-2507-ifb-bw1000-2x-vllm-018-hotfix) |
 |  | BF16 | 0.21 | K100_AI | 2 | IFB | [**`>_`**](#qwen3-30b-a3b-instruct-2507-ifb-k100_ai-2x-vllm-021) |
-|                                                                               | BF16 | 0.18 | K100_AI | 2 | IFB | [**`>_`**](#qwen3-30b-a3b-instruct-2507-ifb-k100_ai-2x-vllm-018) |
+|  | BF16 | 0.18 | BW1100 | 1 | IFB | [**`>_`**](#qwen3-30b-a3b-instruct-2507-ifb-bw1100-1x-vllm-018) |
+|  | BF16 | 0.18 | BW1000 | 2 | IFB | [**`>_`**](#qwen3-30b-a3b-instruct-2507-ifb-bw1000-2x-vllm-018) |
+|  | BF16 | 0.18 | K100_AI | 2 | IFB | [**`>_`**](#qwen3-30b-a3b-instruct-2507-ifb-k100_ai-2x-vllm-018) |
+|  | BF16 | 0.18-hotfix | BW1100 | 1 | IFB | [**`>_`**](#qwen3-30b-a3b-instruct-2507-ifb-bw1100-1x-vllm-018-hotfix) |
+|  | BF16 | 0.18-hotfix | BW1000 | 2 | IFB | [**`>_`**](#qwen3-30b-a3b-instruct-2507-ifb-bw1000-2x-vllm-018-hotfix) |
 |  | BF16 | 0.18-hotfix | K100_AI | 2 | IFB | [**`>_`**](#qwen3-30b-a3b-instruct-2507-ifb-k100_ai-2x-vllm-018-hotfix) |
-|                                                                               | BF16 | 0.15 | BW1100  | 1 | IFB | [**`>_`**](#qwen3-30b-a3b-instruct-2507-ifb-bw1100-1x-vllm-015) |
-|                                                                               | BF16 | 0.15 | BW1000  | 2 | IFB | [**`>_`**](#qwen3-30b-a3b-instruct-2507-ifb-bw1000-2x-vllm-015) |
-|                                                                               | BF16 | 0.15 | K100_AI | 2   | IFB | [**`>_`**](#qwen3-30b-a3b-instruct-2507-ifb-k100_ai-2x-vllm-015) |
+|  | BF16 | 0.15 | BW1100 | 1 | IFB | [**`>_`**](#qwen3-30b-a3b-instruct-2507-ifb-bw1100-1x-vllm-015) |
+|  | BF16 | 0.15 | BW1000 | 2 | IFB | [**`>_`**](#qwen3-30b-a3b-instruct-2507-ifb-bw1000-2x-vllm-015) |
+|  | BF16 | 0.15 | K100_AI | 2 | IFB | [**`>_`**](#qwen3-30b-a3b-instruct-2507-ifb-k100_ai-2x-vllm-015) |
 | [Qwen/Qwen3-30B-A3B-Channel-INT8-w8a8](https://www.modelscope.cn/models/hygon/Qwen3-30B-A3B-Channel-INT8-w8a8) | INT8 W8A8 | 0.21 | BW1100 | 1 | IFB | [**`>_`**](#qwen3-30b-a3b-instruct-2507-w8a8-int8-ifb-bw1100-1x-vllm-021) |
-|  | INT8 W8A8 | 0.18 | BW1100 | 1 | IFB | [**`>_`**](#qwen3-30b-a3b-instruct-2507-w8a8-int8-ifb-bw1100-1x-vllm-018) |
-|  | INT8 W8A8 | 0.18-hotfix | BW1100 | 1 | IFB | [**`>_`**](#qwen3-30b-a3b-instruct-2507-w8a8-int8-ifb-bw1100-1x-vllm-018-hotfix) |
 |  | INT8 W8A8 | 0.21 | BW1000 | 1 | IFB | [**`>_`**](#qwen3-30b-a3b-instruct-2507-w8a8-int8-ifb-bw1000-1x-vllm-021) |
-|                                                                               | INT8 W8A8 | 0.18 | BW1000 | 1 | IFB | [**`>_`**](#qwen3-30b-a3b-instruct-2507-w8a8-int8-ifb-bw1000-1x-vllm-018) |
+|  | INT8 W8A8 | 0.18 | BW1100 | 1 | IFB | [**`>_`**](#qwen3-30b-a3b-instruct-2507-w8a8-int8-ifb-bw1100-1x-vllm-018) |
+|  | INT8 W8A8 | 0.18 | BW1000 | 1 | IFB | [**`>_`**](#qwen3-30b-a3b-instruct-2507-w8a8-int8-ifb-bw1000-1x-vllm-018) |
+|  | INT8 W8A8 | 0.18 | K100_AI | 1 | IFB | [**`>_`**](#qwen3-30b-a3b-instruct-2507-w8a8-int8-ifb-k100_ai-1x-vllm-018) |
+|  | INT8 W8A8 | 0.18-hotfix | BW1100 | 1 | IFB | [**`>_`**](#qwen3-30b-a3b-instruct-2507-w8a8-int8-ifb-bw1100-1x-vllm-018-hotfix) |
 |  | INT8 W8A8 | 0.18-hotfix | BW1000 | 1 | IFB | [**`>_`**](#qwen3-30b-a3b-instruct-2507-w8a8-int8-ifb-bw1000-1x-vllm-018-hotfix) |
-|                                                                               | INT8 W8A8 | 0.18 | K100_AI | 1 | IFB | [**`>_`**](#qwen3-30b-a3b-instruct-2507-w8a8-int8-ifb-k100_ai-1x-vllm-018) |
-|                                                                               | INT8 W8A8 | 0.15 | BW1100 | 1 | IFB | [**`>_`**](#qwen3-30b-a3b-instruct-2507-w8a8-int8-ifb-bw1100-1x-vllm-015) |
-|                                                                               | INT8 W8A8 | 0.15 | BW1000 | 1 | IFB | [**`>_`**](#qwen3-30b-a3b-instruct-2507-w8a8-int8-ifb-bw1000-1x-vllm-015) |
-|                                                                               | INT8 W8A8 | 0.15 | K100_AI | 1 | IFB | [**`>_`**](#qwen3-30b-a3b-instruct-2507-w8a8-int8-ifb-k100_ai-1x-vllm-015) |
+|  | INT8 W8A8 | 0.15 | BW1100 | 1 | IFB | [**`>_`**](#qwen3-30b-a3b-instruct-2507-w8a8-int8-ifb-bw1100-1x-vllm-015) |
+|  | INT8 W8A8 | 0.15 | BW1000 | 1 | IFB | [**`>_`**](#qwen3-30b-a3b-instruct-2507-w8a8-int8-ifb-bw1000-1x-vllm-015) |
+|  | INT8 W8A8 | 0.15 | K100_AI | 1 | IFB | [**`>_`**](#qwen3-30b-a3b-instruct-2507-w8a8-int8-ifb-k100_ai-1x-vllm-015) |
 | [Qwen/Qwen3-235B-A22B-Instruct-2507](https://www.modelscope.cn/models/Qwen/Qwen3-235B-A22B-Instruct-2507) | BF16 | 0.21 | BW1100 | 4 | IFB | [**`>_`**](#qwen3-235b-a22b-instruct-2507-ifb-bw1100-4x-vllm-021) |
 |  | BF16 | 0.21 | BW1000 | 8 | IFB | [**`>_`**](#qwen3-235b-a22b-instruct-2507-ifb-bw1000-8x-vllm-021) |
-|  | BF16 | [0.18](../docker_images.md) | BW1100 | 4 | IFB | [**`>_`**](#qwen3-235b-a22b-instruct-2507-ifb-bw1100-4x-vllm-018) |
 |  | BF16 | 0.18 | BW1000 | 8 | IFB | [**`>_`**](#qwen3-235b-a22b-instruct-2507-ifb-bw1000-8x-vllm-018) |
 |  | BF16 | 0.18 | K100_AI | 8 | IFB | [**`>_`**](#qwen3-235b-a22b-instruct-2507-ifb-k100_ai-8x-vllm-018) |
 |  | BF16 | 0.18-hotfix | BW1100 | 4 | IFB | [**`>_`**](#qwen3-235b-a22b-instruct-2507-ifb-bw1100-4x-vllm-018-hotfix) |
@@ -148,24 +147,24 @@ Qwen3 是阿里通义千问第三代大语言模型，支持 0.6B ~ 235B 多种�
 |  | BF16 | 0.15 | BW1100 | 4 | IFB | [**`>_`**](#qwen3-235b-a22b-instruct-2507-ifb-bw1100-4x-vllm-015) |
 |  | BF16 | 0.15 | BW1000 | 8 | IFB | [**`>_`**](#qwen3-235b-a22b-instruct-2507-ifb-bw1000-8x-vllm-015) |
 |  | BF16 | 0.15 | K100_AI | 8 | IFB | [**`>_`**](#qwen3-235b-a22b-instruct-2507-ifb-k100_ai-8x-vllm-015) |
+|  | BF16 | [0.18](../docker_images.md) | BW1100 | 4 | IFB | [**`>_`**](#qwen3-235b-a22b-instruct-2507-ifb-bw1100-4x-vllm-018) |
 | [Qwen/Qwen3-235B-A22B](https://www.modelscope.cn/models/Qwen/Qwen3-235B-A22B) | BF16 | [0.18](../docker_images.md) | BW1100 | 4 | IFB | [**`>_`**](#qwen3-235b-a22b-ifb-bw1100-4x-vllm-018) |
 |  | BF16 | [0.18](../docker_images.md) | BW1000 | 8 | IFB | [**`>_`**](#qwen3-235b-a22b-ifb-bw1000-8x-vllm-018) |
 |  | BF16 | [0.18](../docker_images.md) | K100_AI | 8 | IFB | [**`>_`**](#qwen3-235b-a22b-ifb-k100_ai-8x-vllm-018) |
 | [hygon/Qwen3-235B-A22B-Channel-INT8-w8a8](https://www.modelscope.cn/models/hygon/Qwen3-235B-A22B-Channel-INT8-w8a8) | INT8 W8A8 | 0.21 | BW1100 | 2 | IFB | [**`>_`**](#qwen3-235b-a22b-channel-int8-w8a8-ifb-bw1100-2x-vllm-021) |
-|  | INT8 W8A8 | 0.18 | BW1100 | 2 | IFB | [**`>_`**](#qwen3-235b-a22b-channel-int8-w8a8-ifb-bw1100-2x-vllm-018) |
-|  | INT8 W8A8 | 0.18-hotfix | BW1100 | 2 | IFB | [**`>_`**](#qwen3-235b-a22b-channel-int8-w8a8-ifb-bw1100-2x-vllm-018-hotfix) |
 |  | INT8 W8A8 | 0.21 | BW1000 | 4 | IFB | [**`>_`**](#qwen3-235b-a22b-channel-int8-w8a8-ifb-bw1000-4x-vllm-021) |
-|                                                                               | INT8 W8A8 | 0.18 | BW1000 | 4 | IFB | [**`>_`**](#qwen3-235b-a22b-channel-int8-w8a8-ifb-bw1000-4x-vllm-018) |
+|  | INT8 W8A8 | 0.18 | BW1100 | 2 | IFB | [**`>_`**](#qwen3-235b-a22b-channel-int8-w8a8-ifb-bw1100-2x-vllm-018) |
+|  | INT8 W8A8 | 0.18 | BW1000 | 4 | IFB | [**`>_`**](#qwen3-235b-a22b-channel-int8-w8a8-ifb-bw1000-4x-vllm-018) |
+|  | INT8 W8A8 | 0.18 | K100_AI | 4 | IFB | [**`>_`**](#qwen3-235b-a22b-channel-int8-w8a8-ifb-k100_ai-4x-vllm-018) |
+|  | INT8 W8A8 | 0.18-hotfix | BW1100 | 2 | IFB | [**`>_`**](#qwen3-235b-a22b-channel-int8-w8a8-ifb-bw1100-2x-vllm-018-hotfix) |
 |  | INT8 W8A8 | 0.18-hotfix | BW1000 | 4 | IFB | [**`>_`**](#qwen3-235b-a22b-channel-int8-w8a8-ifb-bw1000-4x-vllm-018-hotfix) |
-|                                                                               | INT8 W8A8 | 0.18 | K100_AI | 4 | IFB | [**`>_`**](#qwen3-235b-a22b-channel-int8-w8a8-ifb-k100_ai-4x-vllm-018) |
-|                                                                               | INT8 W8A8 | 0.15 | BW1100 | 4 | IFB | [**`>_`**](#qwen3-235b-a22b-channel-int8-w8a8-ifb-bw1100-4x-vllm-015) |
-|                                                                               | INT8 W8A8 | 0.15 | BW1000 | 4 | IFB | [**`>_`**](#qwen3-235b-a22b-channel-int8-w8a8-ifb-bw1000-4x-vllm-015) |
-|                                                                               | INT8 W8A8 | 0.15 | K100_AI | 4 | IFB | [**`>_`**](#qwen3-235b-a22b-channel-int8-w8a8-ifb-k100_ai-4x-vllm-015) |
+|  | INT8 W8A8 | 0.15 | BW1100 | 4 | IFB | [**`>_`**](#qwen3-235b-a22b-channel-int8-w8a8-ifb-bw1100-4x-vllm-015) |
+|  | INT8 W8A8 | 0.15 | BW1000 | 4 | IFB | [**`>_`**](#qwen3-235b-a22b-channel-int8-w8a8-ifb-bw1000-4x-vllm-015) |
+|  | INT8 W8A8 | 0.15 | K100_AI | 4 | IFB | [**`>_`**](#qwen3-235b-a22b-channel-int8-w8a8-ifb-k100_ai-4x-vllm-015) |
 | [Qwen/Qwen3-235B-A22B-FP8-Channel](https://www.modelscope.cn/models/hygon/Qwen3-235B-A22B-W8A8) | FP8 | 0.21 | BW1100 | 4 | IFB | [**`>_`**](#qwen3-235b-a22b-fp8-channelwise-ifb-bw1100-4x-vllm-021) |
 |  | FP8 | 0.18 | BW1100 | 4 | IFB | [**`>_`**](#qwen3-235b-a22b-fp8-channelwise-ifb-bw1100-4x-vllm-018) |
 |  | FP8 | 0.18-hotfix | BW1100 | 4 | IFB | [**`>_`**](#qwen3-235b-a22b-fp8-channelwise-ifb-bw1100-4x-vllm-018-hotfix) |
-|                                                                               | FP8  | 0.15 | BW1100 | 4 | IFB | [**`>_`**](#qwen3-235b-a22b-fp8-channelwise-ifb-bw1100-4x-vllm-015) |
-
+|  | FP8 | 0.15 | BW1100 | 4 | IFB | [**`>_`**](#qwen3-235b-a22b-fp8-channelwise-ifb-bw1100-4x-vllm-015) |
 
 ## 启动命令
 
@@ -180,6 +179,28 @@ vllm serve Qwen/Qwen3-0.6B \
   --kv-cache-dtype fp8_e4m3 \
   --attention-backend FLASH_ATTN_CUSTOM
 ```
+
+### Qwen3-0.6B IFB BW1000 1x vLLM 0.21
+
+```bash
+export VLLM_HCU_USE_PD_SPLIT=1
+
+vllm serve Qwen/Qwen3-0.6B \
+  -tp 1 \
+  --trust-remote-code \
+  --attention-backend FLASH_ATTN_CUSTOM
+```
+
+### Qwen3-0.6B IFB K100_AI 1x vLLM 0.21
+
+```bash
+
+vllm serve Qwen/Qwen3-0.6B \
+  -tp 1 \
+  --trust-remote-code \
+  --attention-backend FLASH_ATTN_CUSTOM
+```
+
 ### Qwen3-0.6B IFB BW1100 1x vLLM 0.18
 
 ```bash
@@ -190,6 +211,29 @@ vllm serve Qwen/Qwen3-0.6B \
   -tp 1 \
   --trust-remote-code \
   --kv-cache-dtype fp8_e4m3
+```
+
+### Qwen3-0.6B IFB BW1000 1x vLLM 0.18
+
+```bash
+export VLLM_HCU_USE_PD_SPLIT=1
+export VLLM_HCU_USE_CUSTOM_FLASH_ATTN=1
+
+vllm serve Qwen/Qwen3-0.6B \
+  -tp 1 \
+  --trust-remote-code \
+  --kv-cache-dtype fp8_e5m2 
+```
+
+### Qwen3-0.6B IFB K100_AI 1x vLLM 0.18
+
+```bash
+export VLLM_HCU_USE_PD_SPLIT=1
+export VLLM_HCU_USE_CUSTOM_FLASH_ATTN=1
+
+vllm serve Qwen/Qwen3-0.6B \
+  -tp 1 \
+  --trust-remote-code 
 ```
 
 ### Qwen3-0.6B IFB BW1100 1x vLLM 0.18-hotfix
@@ -203,27 +247,6 @@ vllm serve Qwen/Qwen3-0.6B \
   --kv-cache-dtype fp8_e4m3 \
   --attention-backend FLASH_ATTN_CUSTOM
 ```
-### Qwen3-0.6B IFB BW1000 1x vLLM 0.21
-
-```bash
-export VLLM_HCU_USE_PD_SPLIT=1
-
-vllm serve Qwen/Qwen3-0.6B \
-  -tp 1 \
-  --trust-remote-code \
-  --attention-backend FLASH_ATTN_CUSTOM
-```
-### Qwen3-0.6B IFB BW1000 1x vLLM 0.18
-
-```bash
-export VLLM_HCU_USE_PD_SPLIT=1
-export VLLM_HCU_USE_CUSTOM_FLASH_ATTN=1
-
-vllm serve Qwen/Qwen3-0.6B \
-  -tp 1 \
-  --trust-remote-code \
-  --kv-cache-dtype fp8_e5m2 
-```
 
 ### Qwen3-0.6B IFB BW1000 1x vLLM 0.18-hotfix
 
@@ -235,25 +258,6 @@ vllm serve Qwen/Qwen3-0.6B \
   --trust-remote-code \
   --attention-backend FLASH_ATTN_CUSTOM
 ```
-### Qwen3-0.6B IFB K100_AI 1x vLLM 0.21
-
-```bash
-
-vllm serve Qwen/Qwen3-0.6B \
-  -tp 1 \
-  --trust-remote-code \
-  --attention-backend FLASH_ATTN_CUSTOM
-```
-### Qwen3-0.6B IFB K100_AI 1x vLLM 0.18
-
-```bash
-export VLLM_HCU_USE_PD_SPLIT=1
-export VLLM_HCU_USE_CUSTOM_FLASH_ATTN=1
-
-vllm serve Qwen/Qwen3-0.6B \
-  -tp 1 \
-  --trust-remote-code 
-```
 
 ### Qwen3-0.6B IFB K100_AI 1x vLLM 0.18-hotfix
 
@@ -264,6 +268,7 @@ vllm serve Qwen/Qwen3-0.6B \
   --trust-remote-code \
   --attention-backend FLASH_ATTN_CUSTOM
 ```
+
 ### Qwen3-0.6B IFB BW1100 1x vLLM 0.15
 
 ### Qwen3-0.6B IFB BW1000 1x vLLM 0.15
@@ -293,6 +298,29 @@ vllm serve Qwen/Qwen3-1.7B \
   --kv-cache-dtype fp8_e4m3 \
   --attention-backend FLASH_ATTN_CUSTOM
 ```
+
+### Qwen3-1.7B IFB BW1000 1x vLLM 0.21
+
+```bash
+export VLLM_HCU_USE_PD_SPLIT=1
+
+vllm serve Qwen/Qwen3-1.7B \
+  -tp 1 \
+  --trust-remote-code \
+  --attention-backend FLASH_ATTN_CUSTOM
+```
+
+### Qwen3-1.7B IFB K100_AI 1x vLLM 0.21
+
+```bash
+export VLLM_HCU_USE_CUSTOM_QUANTIZATION_GEMM=0
+export VLLM_HCU_USE_CUSTOM_OPS=0
+
+vllm serve Qwen/Qwen3-1.7B \
+  -tp 1 \
+  --trust-remote-code
+```
+
 ### Qwen3-1.7B IFB BW1100 1x vLLM 0.18
 
 ```bash
@@ -303,6 +331,27 @@ vllm serve Qwen/Qwen3-1.7B \
   -tp 1 \
   --trust-remote-code \
   --kv-cache-dtype fp8_e4m3 
+```
+
+### Qwen3-1.7B IFB BW1000 1x vLLM 0.18
+```bash
+export VLLM_HCU_USE_PD_SPLIT=1
+export VLLM_HCU_USE_CUSTOM_FLASH_ATTN=1
+
+vllm serve Qwen/Qwen3-1.7B \
+  -tp 1 \
+  --trust-remote-code \
+  --kv-cache-dtype fp8_e5m2 
+```
+
+### Qwen3-1.7B IFB K100_AI 1x vLLM 0.18
+```bash
+export VLLM_HCU_USE_CUSTOM_QUANTIZATION_GEMM=0
+export VLLM_HCU_USE_CUSTOM_OPS=0
+
+vllm serve Qwen/Qwen3-1.7B \
+  -tp 1 \
+  --trust-remote-code
 ```
 
 ### Qwen3-1.7B IFB BW1100 1x vLLM 0.18-hotfix
@@ -316,26 +365,6 @@ vllm serve Qwen/Qwen3-1.7B \
   --kv-cache-dtype fp8_e4m3 \
   --attention-backend FLASH_ATTN_CUSTOM
 ```
-### Qwen3-1.7B IFB BW1000 1x vLLM 0.21
-
-```bash
-export VLLM_HCU_USE_PD_SPLIT=1
-
-vllm serve Qwen/Qwen3-1.7B \
-  -tp 1 \
-  --trust-remote-code \
-  --attention-backend FLASH_ATTN_CUSTOM
-```
-### Qwen3-1.7B IFB BW1000 1x vLLM 0.18
-```bash
-export VLLM_HCU_USE_PD_SPLIT=1
-export VLLM_HCU_USE_CUSTOM_FLASH_ATTN=1
-
-vllm serve Qwen/Qwen3-1.7B \
-  -tp 1 \
-  --trust-remote-code \
-  --kv-cache-dtype fp8_e5m2 
-```
 
 ### Qwen3-1.7B IFB BW1000 1x vLLM 0.18-hotfix
 
@@ -346,25 +375,6 @@ vllm serve Qwen/Qwen3-1.7B \
   -tp 1 \
   --trust-remote-code \
   --attention-backend FLASH_ATTN_CUSTOM
-```
-### Qwen3-1.7B IFB K100_AI 1x vLLM 0.21
-
-```bash
-export VLLM_HCU_USE_CUSTOM_QUANTIZATION_GEMM=0
-export VLLM_HCU_USE_CUSTOM_OPS=0
-
-vllm serve Qwen/Qwen3-1.7B \
-  -tp 1 \
-  --trust-remote-code
-```
-### Qwen3-1.7B IFB K100_AI 1x vLLM 0.18
-```bash
-export VLLM_HCU_USE_CUSTOM_QUANTIZATION_GEMM=0
-export VLLM_HCU_USE_CUSTOM_OPS=0
-
-vllm serve Qwen/Qwen3-1.7B \
-  -tp 1 \
-  --trust-remote-code
 ```
 
 ### Qwen3-1.7B IFB K100_AI 1x vLLM 0.18-hotfix
@@ -377,6 +387,7 @@ vllm serve Qwen/Qwen3-1.7B \
   -tp 1 \
   --trust-remote-code
 ```
+
 ### Qwen3-1.7B IFB BW1100 1x vLLM 0.15
 
 ### Qwen3-1.7B IFB BW1000 1x vLLM 0.15
@@ -399,6 +410,31 @@ vllm serve Qwen/Qwen3-4B \
   --max-num-batched-tokens 10240 \
   --attention-backend FLASH_ATTN_CUSTOM
 ```
+
+### Qwen3-4B IFB BW1000 1x vLLM 0.21
+
+```bash
+export VLLM_HCU_USE_PD_SPLIT=1
+
+vllm serve Qwen/Qwen3-4B \
+  -tp 1 \
+  --trust-remote-code \
+  --max-num-batched-tokens 10240 \
+  --attention-backend FLASH_ATTN_CUSTOM
+```
+
+### Qwen3-4B IFB K100_AI 1x vLLM 0.21
+
+```bash
+export VLLM_HCU_USE_CUSTOM_QUANTIZATION_GEMM=0
+export VLLM_HCU_USE_CUSTOM_OPS=0
+
+vllm serve Qwen/Qwen3-4B \
+  -tp 1 \
+  --trust-remote-code \
+  --max-num-batched-tokens 10240 
+```
+
 ### Qwen3-4B IFB BW1100 1x vLLM 0.18
 ```bash
 export VLLM_HCU_USE_PD_SPLIT=1
@@ -409,6 +445,29 @@ vllm serve Qwen/Qwen3-4B \
   --trust-remote-code \
   --kv-cache-dtype fp8_e4m3 \
   --max-num-batched-tokens 10240
+```
+
+### Qwen3-4B IFB BW1000 1x vLLM 0.18
+```bash
+export VLLM_HCU_USE_PD_SPLIT=1
+export VLLM_HCU_USE_CUSTOM_FLASH_ATTN=1
+
+vllm serve Qwen/Qwen3-4B \
+  -tp 1 \
+  --trust-remote-code \
+  --kv-cache-dtype fp8_e5m2 \
+  --max-num-batched-tokens 10240
+```
+
+### Qwen3-4B IFB K100_AI 1x vLLM 0.18
+```bash
+export VLLM_HCU_USE_CUSTOM_QUANTIZATION_GEMM=0
+export VLLM_HCU_USE_CUSTOM_OPS=0
+
+vllm serve Qwen/Qwen3-4B \
+  -tp 1 \
+  --trust-remote-code \
+  --max-num-batched-tokens 10240 
 ```
 
 ### Qwen3-4B IFB BW1100 1x vLLM 0.18-hotfix
@@ -423,28 +482,6 @@ vllm serve Qwen/Qwen3-4B \
   --max-num-batched-tokens 10240 \
   --attention-backend FLASH_ATTN_CUSTOM
 ```
-### Qwen3-4B IFB BW1000 1x vLLM 0.21
-
-```bash
-export VLLM_HCU_USE_PD_SPLIT=1
-
-vllm serve Qwen/Qwen3-4B \
-  -tp 1 \
-  --trust-remote-code \
-  --max-num-batched-tokens 10240 \
-  --attention-backend FLASH_ATTN_CUSTOM
-```
-### Qwen3-4B IFB BW1000 1x vLLM 0.18
-```bash
-export VLLM_HCU_USE_PD_SPLIT=1
-export VLLM_HCU_USE_CUSTOM_FLASH_ATTN=1
-
-vllm serve Qwen/Qwen3-4B \
-  -tp 1 \
-  --trust-remote-code \
-  --kv-cache-dtype fp8_e5m2 \
-  --max-num-batched-tokens 10240
-```
 
 ### Qwen3-4B IFB BW1000 1x vLLM 0.18-hotfix
 
@@ -456,27 +493,6 @@ vllm serve Qwen/Qwen3-4B \
   --trust-remote-code \
   --max-num-batched-tokens 10240 \
   --attention-backend FLASH_ATTN_CUSTOM
-```
-### Qwen3-4B IFB K100_AI 1x vLLM 0.21
-
-```bash
-export VLLM_HCU_USE_CUSTOM_QUANTIZATION_GEMM=0
-export VLLM_HCU_USE_CUSTOM_OPS=0
-
-vllm serve Qwen/Qwen3-4B \
-  -tp 1 \
-  --trust-remote-code \
-  --max-num-batched-tokens 10240 
-```
-### Qwen3-4B IFB K100_AI 1x vLLM 0.18
-```bash
-export VLLM_HCU_USE_CUSTOM_QUANTIZATION_GEMM=0
-export VLLM_HCU_USE_CUSTOM_OPS=0
-
-vllm serve Qwen/Qwen3-4B \
-  -tp 1 \
-  --trust-remote-code \
-  --max-num-batched-tokens 10240 
 ```
 
 ### Qwen3-4B IFB K100_AI 1x vLLM 0.18-hotfix
@@ -490,6 +506,7 @@ vllm serve Qwen/Qwen3-4B \
   --trust-remote-code \
   --max-num-batched-tokens 10240 
 ```
+
 ### Qwen3-4B IFB BW1100 1x vLLM 0.15
 
 ### Qwen3-4B IFB BW1000 1x vLLM 0.15
@@ -509,6 +526,20 @@ vllm serve Qwen/Qwen3-4B-Channel-INT8-w8a8 \
   --kv-cache-dtype fp8_e4m3 \
   --attention-backend FLASH_ATTN_CUSTOM
 ```
+
+### Qwen3-4B-Channel-INT8-w8a8 IFB BW1000 1x vLLM 0.21
+
+```bash
+export VLLM_HCU_USE_PD_SPLIT=1
+
+vllm serve Qwen/Qwen3-4B-Channel-INT8-w8a8 \
+  -tp  1 \
+  --trust-remote-code \
+  --max-num-batched-tokens 10240 \
+  --q slimquant_marlin \
+  --attention-backend FLASH_ATTN_CUSTOM
+```
+
 ### Qwen3-4B-Channel-INT8-w8a8 IFB BW1100 1x vLLM 0.18
 ```bash
 export VLLM_HCU_USE_CUSTOM_FLASH_ATTN=1
@@ -519,6 +550,19 @@ vllm serve Qwen/Qwen3-4B-Channel-INT8-w8a8 \
   --max-num-batched-tokens 10240 \
   --q slimquant_marlin
 ```
+
+### Qwen3-4B-Channel-INT8-w8a8 IFB BW1000 1x vLLM 0.18
+```bash
+export VLLM_HCU_USE_CUSTOM_FLASH_ATTN=1
+
+vllm serve Qwen/Qwen3-4B-Channel-INT8-w8a8 \
+  -tp  1 \
+  --trust-remote-code \
+  --max-num-batched-tokens 10240 \
+  --q slimquant_marlin
+```
+
+### Qwen3-4B-Channel-INT8-w8a8 IFB K100_AI 1x vLLM 0.18
 
 ### Qwen3-4B-Channel-INT8-w8a8 IFB BW1100 1x vLLM 0.18-hotfix
 
@@ -533,28 +577,6 @@ vllm serve Qwen/Qwen3-4B-Channel-INT8-w8a8 \
   --kv-cache-dtype fp8_e4m3 \
   --attention-backend FLASH_ATTN_CUSTOM
 ```
-### Qwen3-4B-Channel-INT8-w8a8 IFB BW1000 1x vLLM 0.21
-
-```bash
-export VLLM_HCU_USE_PD_SPLIT=1
-
-vllm serve Qwen/Qwen3-4B-Channel-INT8-w8a8 \
-  -tp  1 \
-  --trust-remote-code \
-  --max-num-batched-tokens 10240 \
-  --q slimquant_marlin \
-  --attention-backend FLASH_ATTN_CUSTOM
-```
-### Qwen3-4B-Channel-INT8-w8a8 IFB BW1000 1x vLLM 0.18
-```bash
-export VLLM_HCU_USE_CUSTOM_FLASH_ATTN=1
-
-vllm serve Qwen/Qwen3-4B-Channel-INT8-w8a8 \
-  -tp  1 \
-  --trust-remote-code \
-  --max-num-batched-tokens 10240 \
-  --q slimquant_marlin
-```
 
 ### Qwen3-4B-Channel-INT8-w8a8 IFB BW1000 1x vLLM 0.18-hotfix
 
@@ -568,7 +590,6 @@ vllm serve Qwen/Qwen3-4B-Channel-INT8-w8a8 \
   --q slimquant_marlin \
   --attention-backend FLASH_ATTN_CUSTOM
 ```
-### Qwen3-4B-Channel-INT8-w8a8 IFB K100_AI 1x vLLM 0.18
 
 ### Qwen3-4B-Channel-INT8-w8a8 IFB BW1100 1x vLLM 0.15
 
@@ -626,6 +647,31 @@ vllm serve Qwen/Qwen3-8B \
   --max-num-batched-tokens 10240 \
   --attention-backend FLASH_ATTN_CUSTOM
 ```
+
+### Qwen3-8B IFB BW1000 1x vLLM 0.21
+
+```bash
+export VLLM_HCU_USE_PD_SPLIT=1
+
+vllm serve Qwen/Qwen3-8B \
+  -tp 1 \
+  --trust-remote-code \
+  --max-num-batched-tokens 10240 \
+  --attention-backend FLASH_ATTN_CUSTOM
+```
+
+### Qwen3-8B IFB K100_AI 1x vLLM 0.21
+
+```bash
+export VLLM_HCU_USE_CUSTOM_QUANTIZATION_GEMM=0
+export VLLM_HCU_USE_CUSTOM_OPS=0
+
+vllm serve Qwen/Qwen3-8B \
+  -tp 1 \
+  --trust-remote-code \
+  --max-num-batched-tokens 10240 
+```
+
 ### Qwen3-8B IFB BW1100 1x vLLM 0.18
 ```bash
 export VLLM_HCU_USE_PD_SPLIT=1
@@ -636,6 +682,29 @@ vllm serve Qwen/Qwen3-8B \
   --trust-remote-code \
   --kv-cache-dtype fp8_e4m3 \
   --max-num-batched-tokens 10240
+```
+
+### Qwen3-8B IFB BW1000 1x vLLM 0.18
+```bash
+export VLLM_HCU_USE_PD_SPLIT=1
+export VLLM_HCU_USE_CUSTOM_FLASH_ATTN=1
+
+vllm serve Qwen/Qwen3-8B \
+  -tp 1 \
+  --trust-remote-code \
+  --kv-cache-dtype fp8_e5m2 \
+  --max-num-batched-tokens 10240 
+```
+
+### Qwen3-8B IFB K100_AI 1x vLLM 0.18
+```bash
+export VLLM_HCU_USE_CUSTOM_QUANTIZATION_GEMM=0
+export VLLM_HCU_USE_CUSTOM_OPS=0
+
+vllm serve Qwen/Qwen3-8B \
+  -tp 1 \
+  --trust-remote-code \
+  --max-num-batched-tokens 10240 
 ```
 
 ### Qwen3-8B IFB BW1100 1x vLLM 0.18-hotfix
@@ -650,28 +719,6 @@ vllm serve Qwen/Qwen3-8B \
   --max-num-batched-tokens 10240 \
   --attention-backend FLASH_ATTN_CUSTOM
 ```
-### Qwen3-8B IFB BW1000 1x vLLM 0.21
-
-```bash
-export VLLM_HCU_USE_PD_SPLIT=1
-
-vllm serve Qwen/Qwen3-8B \
-  -tp 1 \
-  --trust-remote-code \
-  --max-num-batched-tokens 10240 \
-  --attention-backend FLASH_ATTN_CUSTOM
-```
-### Qwen3-8B IFB BW1000 1x vLLM 0.18
-```bash
-export VLLM_HCU_USE_PD_SPLIT=1
-export VLLM_HCU_USE_CUSTOM_FLASH_ATTN=1
-
-vllm serve Qwen/Qwen3-8B \
-  -tp 1 \
-  --trust-remote-code \
-  --kv-cache-dtype fp8_e5m2 \
-  --max-num-batched-tokens 10240 
-```
 
 ### Qwen3-8B IFB BW1000 1x vLLM 0.18-hotfix
 
@@ -683,27 +730,6 @@ vllm serve Qwen/Qwen3-8B \
   --trust-remote-code \
   --max-num-batched-tokens 10240 \
   --attention-backend FLASH_ATTN_CUSTOM
-```
-### Qwen3-8B IFB K100_AI 1x vLLM 0.21
-
-```bash
-export VLLM_HCU_USE_CUSTOM_QUANTIZATION_GEMM=0
-export VLLM_HCU_USE_CUSTOM_OPS=0
-
-vllm serve Qwen/Qwen3-8B \
-  -tp 1 \
-  --trust-remote-code \
-  --max-num-batched-tokens 10240 
-```
-### Qwen3-8B IFB K100_AI 1x vLLM 0.18
-```bash
-export VLLM_HCU_USE_CUSTOM_QUANTIZATION_GEMM=0
-export VLLM_HCU_USE_CUSTOM_OPS=0
-
-vllm serve Qwen/Qwen3-8B \
-  -tp 1 \
-  --trust-remote-code \
-  --max-num-batched-tokens 10240 
 ```
 
 ### Qwen3-8B IFB K100_AI 1x vLLM 0.18-hotfix
@@ -717,6 +743,7 @@ vllm serve Qwen/Qwen3-8B \
   --trust-remote-code \
   --max-num-batched-tokens 10240 
 ```
+
 ### Qwen3-8B IFB BW1100 1x vLLM 0.15
 
 ### Qwen3-8B IFB BW1000 1x vLLM 0.15
@@ -736,6 +763,20 @@ vllm serve Qwen/Qwen3-8B-Channel-INT8-w8a8 \
   --kv-cache-dtype fp8_e4m3 \
   --attention-backend FLASH_ATTN_CUSTOM
 ```
+
+### Qwen3-8B-Channel-INT8-w8a8 IFB BW1000 1x vLLM 0.21
+
+```bash
+export VLLM_HCU_USE_PD_SPLIT=1
+
+vllm serve Qwen/Qwen3-8B-Channel-INT8-w8a8 \
+  -tp  1 \
+  --trust-remote-code \
+  --max-num-batched-tokens 10240 \
+  --q slimquant_marlin \
+  --attention-backend FLASH_ATTN_CUSTOM
+```
+
 ### Qwen3-8B-Channel-INT8-w8a8 IFB BW1100 1x vLLM 0.18
 ```bash
 export VLLM_HCU_USE_CUSTOM_FLASH_ATTN=1
@@ -746,6 +787,19 @@ vllm serve Qwen/Qwen3-8B-Channel-INT8-w8a8 \
   --max-num-batched-tokens 10240 \
   --q slimquant_marlin
 ```
+
+### Qwen3-8B-Channel-INT8-w8a8 IFB BW1000 1x vLLM 0.18
+```bash
+export VLLM_HCU_USE_CUSTOM_FLASH_ATTN=1
+
+vllm serve Qwen/Qwen3-8B-Channel-INT8-w8a8 \
+  -tp  1 \
+  --trust-remote-code \
+  --max-num-batched-tokens 10240 \
+  --q slimquant_marlin
+```
+
+### Qwen3-8B-Channel-INT8-w8a8 IFB K100_AI 1x vLLM 0.18
 
 ### Qwen3-8B-Channel-INT8-w8a8 IFB BW1100 1x vLLM 0.18-hotfix
 
@@ -760,28 +814,6 @@ vllm serve Qwen/Qwen3-8B-Channel-INT8-w8a8 \
   --kv-cache-dtype fp8_e4m3 \
   --attention-backend FLASH_ATTN_CUSTOM
 ```
-### Qwen3-8B-Channel-INT8-w8a8 IFB BW1000 1x vLLM 0.21
-
-```bash
-export VLLM_HCU_USE_PD_SPLIT=1
-
-vllm serve Qwen/Qwen3-8B-Channel-INT8-w8a8 \
-  -tp  1 \
-  --trust-remote-code \
-  --max-num-batched-tokens 10240 \
-  --q slimquant_marlin \
-  --attention-backend FLASH_ATTN_CUSTOM
-```
-### Qwen3-8B-Channel-INT8-w8a8 IFB BW1000 1x vLLM 0.18
-```bash
-export VLLM_HCU_USE_CUSTOM_FLASH_ATTN=1
-
-vllm serve Qwen/Qwen3-8B-Channel-INT8-w8a8 \
-  -tp  1 \
-  --trust-remote-code \
-  --max-num-batched-tokens 10240 \
-  --q slimquant_marlin
-```
 
 ### Qwen3-8B-Channel-INT8-w8a8 IFB BW1000 1x vLLM 0.18-hotfix
 
@@ -795,7 +827,6 @@ vllm serve Qwen/Qwen3-8B-Channel-INT8-w8a8 \
   --q slimquant_marlin \
   --attention-backend FLASH_ATTN_CUSTOM
 ```
-### Qwen3-8B-Channel-INT8-w8a8 IFB K100_AI 1x vLLM 0.18
 
 ### Qwen3-8B-Channel-INT8-w8a8 IFB BW1100 1x vLLM 0.15
 
@@ -815,6 +846,31 @@ vllm serve Qwen/Qwen3-14B \
   --max-num-batched-tokens 10240 \
   --attention-backend FLASH_ATTN_CUSTOM
 ```
+
+### Qwen3-14B IFB BW1000 1x vLLM 0.21
+
+```bash
+export VLLM_HCU_USE_PD_SPLIT=1
+
+vllm serve Qwen/Qwen3-14B \
+  -tp 1 \
+  --trust-remote-code \
+  --max-num-batched-tokens 10240 \
+  --attention-backend FLASH_ATTN_CUSTOM
+```
+
+### Qwen3-14B IFB K100_AI 1x vLLM 0.21
+
+```bash
+export VLLM_HCU_USE_CUSTOM_QUANTIZATION_GEMM=0
+export VLLM_HCU_USE_CUSTOM_OPS=0
+
+vllm serve Qwen/Qwen3-14B \
+  -tp 1 \
+  --trust-remote-code \
+  --max-num-batched-tokens 10240 
+```
+
 ### Qwen3-14B IFB BW1100 1x vLLM 0.18
 ```bash
 export VLLM_HCU_USE_PD_SPLIT=1
@@ -825,6 +881,29 @@ vllm serve Qwen/Qwen3-14B \
   --trust-remote-code \
   --kv-cache-dtype fp8_e4m3 \
   --max-num-batched-tokens 10240
+```
+
+### Qwen3-14B IFB BW1000 1x vLLM 0.18
+```bash
+export VLLM_HCU_USE_PD_SPLIT=1
+export VLLM_HCU_USE_CUSTOM_FLASH_ATTN=1
+
+vllm serve Qwen/Qwen3-14B \
+  -tp 1 \
+  --trust-remote-code \
+  --kv-cache-dtype fp8_e5m2 \
+  --max-num-batched-tokens 10240
+```
+
+### Qwen3-14B IFB K100_AI 1x vLLM 0.18
+```bash
+export VLLM_HCU_USE_CUSTOM_QUANTIZATION_GEMM=0
+export VLLM_HCU_USE_CUSTOM_OPS=0
+
+vllm serve Qwen/Qwen3-14B \
+  -tp 1 \
+  --trust-remote-code \
+  --max-num-batched-tokens 10240 
 ```
 
 ### Qwen3-14B IFB BW1100 1x vLLM 0.18-hotfix
@@ -839,28 +918,6 @@ vllm serve Qwen/Qwen3-14B \
   --max-num-batched-tokens 10240 \
   --attention-backend FLASH_ATTN_CUSTOM
 ```
-### Qwen3-14B IFB BW1000 1x vLLM 0.21
-
-```bash
-export VLLM_HCU_USE_PD_SPLIT=1
-
-vllm serve Qwen/Qwen3-14B \
-  -tp 1 \
-  --trust-remote-code \
-  --max-num-batched-tokens 10240 \
-  --attention-backend FLASH_ATTN_CUSTOM
-```
-### Qwen3-14B IFB BW1000 1x vLLM 0.18
-```bash
-export VLLM_HCU_USE_PD_SPLIT=1
-export VLLM_HCU_USE_CUSTOM_FLASH_ATTN=1
-
-vllm serve Qwen/Qwen3-14B \
-  -tp 1 \
-  --trust-remote-code \
-  --kv-cache-dtype fp8_e5m2 \
-  --max-num-batched-tokens 10240
-```
 
 ### Qwen3-14B IFB BW1000 1x vLLM 0.18-hotfix
 
@@ -872,27 +929,6 @@ vllm serve Qwen/Qwen3-14B \
   --trust-remote-code \
   --max-num-batched-tokens 10240 \
   --attention-backend FLASH_ATTN_CUSTOM
-```
-### Qwen3-14B IFB K100_AI 1x vLLM 0.21
-
-```bash
-export VLLM_HCU_USE_CUSTOM_QUANTIZATION_GEMM=0
-export VLLM_HCU_USE_CUSTOM_OPS=0
-
-vllm serve Qwen/Qwen3-14B \
-  -tp 1 \
-  --trust-remote-code \
-  --max-num-batched-tokens 10240 
-```
-### Qwen3-14B IFB K100_AI 1x vLLM 0.18
-```bash
-export VLLM_HCU_USE_CUSTOM_QUANTIZATION_GEMM=0
-export VLLM_HCU_USE_CUSTOM_OPS=0
-
-vllm serve Qwen/Qwen3-14B \
-  -tp 1 \
-  --trust-remote-code \
-  --max-num-batched-tokens 10240 
 ```
 
 ### Qwen3-14B IFB K100_AI 1x vLLM 0.18-hotfix
@@ -906,6 +942,7 @@ vllm serve Qwen/Qwen3-14B \
   --trust-remote-code \
   --max-num-batched-tokens 10240 
 ```
+
 ### Qwen3-14B IFB BW1100 1x vLLM 0.15
 
 ### Qwen3-14B IFB BW1000 1x vLLM 0.15
@@ -925,6 +962,20 @@ vllm serve Qwen/Qwen3-14B-Channel-INT8-w8a8 \
   --kv-cache-dtype fp8_e4m3 \
   --attention-backend FLASH_ATTN_CUSTOM
 ```
+
+### Qwen3-14B-Channel-INT8-w8a8 IFB BW1000 1x vLLM 0.21
+
+```bash
+export VLLM_HCU_USE_PD_SPLIT=1
+
+vllm serve Qwen/Qwen3-14B-Channel-INT8-w8a8 \
+  -tp  1 \
+  --trust-remote-code \
+  --max-num-batched-tokens 10240 \
+  --q slimquant_marlin \
+  --attention-backend FLASH_ATTN_CUSTOM
+```
+
 ### Qwen3-14B-Channel-INT8-w8a8 IFB BW1100 1x vLLM 0.18
 ```bash
 export VLLM_HCU_USE_CUSTOM_FLASH_ATTN=1
@@ -935,6 +986,19 @@ vllm serve Qwen/Qwen3-14B-Channel-INT8-w8a8 \
   --max-num-batched-tokens 10240 \
   --q slimquant_marlin
 ```
+
+### Qwen3-14B-Channel-INT8-w8a8 IFB BW1000 1x vLLM 0.18
+```bash
+export VLLM_HCU_USE_CUSTOM_FLASH_ATTN=1
+
+vllm serve Qwen/Qwen3-14B-Channel-INT8-w8a8 \
+  -tp  1 \
+  --trust-remote-code \
+  --max-num-batched-tokens 10240 \
+  --q slimquant_marlin
+```
+
+### Qwen3-14B-Channel-INT8-w8a8 IFB K100_AI 1x vLLM 0.18
 
 ### Qwen3-14B-Channel-INT8-w8a8 IFB BW1100 1x vLLM 0.18-hotfix
 
@@ -949,28 +1013,6 @@ vllm serve Qwen/Qwen3-14B-Channel-INT8-w8a8 \
   --kv-cache-dtype fp8_e4m3 \
   --attention-backend FLASH_ATTN_CUSTOM
 ```
-### Qwen3-14B-Channel-INT8-w8a8 IFB BW1000 1x vLLM 0.21
-
-```bash
-export VLLM_HCU_USE_PD_SPLIT=1
-
-vllm serve Qwen/Qwen3-14B-Channel-INT8-w8a8 \
-  -tp  1 \
-  --trust-remote-code \
-  --max-num-batched-tokens 10240 \
-  --q slimquant_marlin \
-  --attention-backend FLASH_ATTN_CUSTOM
-```
-### Qwen3-14B-Channel-INT8-w8a8 IFB BW1000 1x vLLM 0.18
-```bash
-export VLLM_HCU_USE_CUSTOM_FLASH_ATTN=1
-
-vllm serve Qwen/Qwen3-14B-Channel-INT8-w8a8 \
-  -tp  1 \
-  --trust-remote-code \
-  --max-num-batched-tokens 10240 \
-  --q slimquant_marlin
-```
 
 ### Qwen3-14B-Channel-INT8-w8a8 IFB BW1000 1x vLLM 0.18-hotfix
 
@@ -984,7 +1026,6 @@ vllm serve Qwen/Qwen3-14B-Channel-INT8-w8a8 \
   --q slimquant_marlin \
   --attention-backend FLASH_ATTN_CUSTOM
 ```
-### Qwen3-14B-Channel-INT8-w8a8 IFB K100_AI 1x vLLM 0.18
 
 ### Qwen3-14B-Channel-INT8-w8a8 IFB BW1100 1x vLLM 0.15
 
@@ -1004,6 +1045,31 @@ vllm serve Qwen/Qwen3-32B \
   --max-num-batched-tokens 10240 \
   --attention-backend FLASH_ATTN_CUSTOM
 ```
+
+### Qwen3-32B IFB BW1000 2x vLLM 0.21
+
+```bash
+export VLLM_HCU_USE_PD_SPLIT=1
+
+vllm serve Qwen/Qwen3-32B \
+  -tp 2 \
+  --trust-remote-code \
+  --max-num-batched-tokens 10240 \
+  --attention-backend FLASH_ATTN_CUSTOM
+```
+
+### Qwen3-32B IFB K100_AI 2x vLLM 0.21
+
+```bash
+export VLLM_HCU_USE_CUSTOM_QUANTIZATION_GEMM=0
+export VLLM_HCU_USE_CUSTOM_OPS=0
+
+vllm serve Qwen/Qwen3-32B \
+  -tp 2 \
+  --trust-remote-code \
+  --max-num-batched-tokens 10240 
+```
+
 ### Qwen3-32B IFB BW1100 1x vLLM 0.18
 ```bash
 export VLLM_HCU_USE_PD_SPLIT=1
@@ -1014,6 +1080,30 @@ vllm serve Qwen/Qwen3-32B \
   --trust-remote-code \
   --kv-cache-dtype fp8_e4m3 \
   --max-num-batched-tokens 10240
+```
+
+### Qwen3-32B IFB BW1000 2x vLLM 0.18
+```bash
+export VLLM_HCU_USE_PD_SPLIT=1
+export VLLM_HCU_USE_CUSTOM_FLASH_ATTN=1
+
+vllm serve Qwen/Qwen3-32B \
+  -tp 2 \
+  --trust-remote-code \
+  --kv-cache-dtype fp8_e5m2 \
+  --max-num-batched-tokens 10240
+```
+
+### Qwen3-32B IFB K100_AI 2x vLLM 0.18
+
+```bash
+export VLLM_HCU_USE_CUSTOM_QUANTIZATION_GEMM=0
+export VLLM_HCU_USE_CUSTOM_OPS=0
+
+vllm serve Qwen/Qwen3-32B \
+  -tp 2 \
+  --trust-remote-code \
+  --max-num-batched-tokens 10240 
 ```
 
 ### Qwen3-32B IFB BW1100 1x vLLM 0.18-hotfix
@@ -1028,28 +1118,6 @@ vllm serve Qwen/Qwen3-32B \
   --max-num-batched-tokens 10240 \
   --attention-backend FLASH_ATTN_CUSTOM
 ```
-### Qwen3-32B IFB BW1000 2x vLLM 0.21
-
-```bash
-export VLLM_HCU_USE_PD_SPLIT=1
-
-vllm serve Qwen/Qwen3-32B \
-  -tp 2 \
-  --trust-remote-code \
-  --max-num-batched-tokens 10240 \
-  --attention-backend FLASH_ATTN_CUSTOM
-```
-### Qwen3-32B IFB BW1000 2x vLLM 0.18
-```bash
-export VLLM_HCU_USE_PD_SPLIT=1
-export VLLM_HCU_USE_CUSTOM_FLASH_ATTN=1
-
-vllm serve Qwen/Qwen3-32B \
-  -tp 2 \
-  --trust-remote-code \
-  --kv-cache-dtype fp8_e5m2 \
-  --max-num-batched-tokens 10240
-```
 
 ### Qwen3-32B IFB BW1000 2x vLLM 0.18-hotfix
 
@@ -1061,28 +1129,6 @@ vllm serve Qwen/Qwen3-32B \
   --trust-remote-code \
   --max-num-batched-tokens 10240 \
   --attention-backend FLASH_ATTN_CUSTOM
-```
-### Qwen3-32B IFB K100_AI 2x vLLM 0.21
-
-```bash
-export VLLM_HCU_USE_CUSTOM_QUANTIZATION_GEMM=0
-export VLLM_HCU_USE_CUSTOM_OPS=0
-
-vllm serve Qwen/Qwen3-32B \
-  -tp 2 \
-  --trust-remote-code \
-  --max-num-batched-tokens 10240 
-```
-### Qwen3-32B IFB K100_AI 2x vLLM 0.18
-
-```bash
-export VLLM_HCU_USE_CUSTOM_QUANTIZATION_GEMM=0
-export VLLM_HCU_USE_CUSTOM_OPS=0
-
-vllm serve Qwen/Qwen3-32B \
-  -tp 2 \
-  --trust-remote-code \
-  --max-num-batched-tokens 10240 
 ```
 
 ### Qwen3-32B IFB K100_AI 2x vLLM 0.18-hotfix
@@ -1096,6 +1142,7 @@ vllm serve Qwen/Qwen3-32B \
   --trust-remote-code \
   --max-num-batched-tokens 10240 
 ```
+
 ### Qwen3-32B IFB BW1100 1x vLLM 0.15
 
 ### Qwen3-32B IFB BW1000 2x vLLM 0.15
@@ -1158,6 +1205,31 @@ vllm serve Qwen/Qwen3-30B-A3B-Instruct-2507 \
   --attention-backend FLASH_ATTN_CUSTOM \
   --moe-backend aiter
 ```
+
+### Qwen3-30B-A3B-Instruct-2507 IFB BW1000 2x vLLM 0.21
+
+```bash
+export VLLM_HCU_USE_PD_SPLIT=1
+vllm serve Qwen/Qwen3-30B-A3B-Instruct-2507 \
+  -tp 2 \
+  --trust-remote-code \
+  --max-num-batched-tokens 10240 \
+  --attention-backend FLASH_ATTN_CUSTOM \
+  --moe-backend aiter
+```
+
+### Qwen3-30B-A3B-Instruct-2507 IFB K100_AI 2x vLLM 0.21
+
+```bash
+export VLLM_HCU_USE_CUSTOM_QUANTIZATION_GEMM=0
+export VLLM_HCU_USE_CUSTOM_OPS=0
+
+vllm serve Qwen/Qwen3-30B-A3B-Instruct-2507 \
+  -tp 2 \
+  --trust-remote-code \
+  --max-num-batched-tokens 10240 
+```
+
 ### Qwen3-30B-A3B-Instruct-2507 IFB BW1100 1x vLLM 0.18
 ```bash
 export VLLM_HCU_USE_PD_SPLIT=1
@@ -1167,6 +1239,30 @@ export VLLM_ROCM_USE_AITER_MOE=1
 
 vllm serve Qwen/Qwen3-30B-A3B-Instruct-2507 \
   -tp 1 \
+  --trust-remote-code \
+  --max-num-batched-tokens 10240 
+```
+
+### Qwen3-30B-A3B-Instruct-2507 IFB BW1000 2x vLLM 0.18
+```bash
+export VLLM_HCU_USE_PD_SPLIT=1
+export VLLM_HCU_USE_CUSTOM_FLASH_ATTN=1
+export VLLM_ROCM_USE_AITER=1
+export VLLM_ROCM_USE_AITER_MOE=1
+
+vllm serve Qwen/Qwen3-30B-A3B-Instruct-2507 \
+  -tp 2 \
+  --trust-remote-code \
+  --max-num-batched-tokens 10240 
+```
+
+### Qwen3-30B-A3B-Instruct-2507 IFB K100_AI 2x vLLM 0.18
+```bash
+export VLLM_HCU_USE_CUSTOM_QUANTIZATION_GEMM=0
+export VLLM_HCU_USE_CUSTOM_OPS=0
+
+vllm serve Qwen/Qwen3-30B-A3B-Instruct-2507 \
+  -tp 2 \
   --trust-remote-code \
   --max-num-batched-tokens 10240 
 ```
@@ -1183,29 +1279,6 @@ vllm serve Qwen/Qwen3-30B-A3B-Instruct-2507 \
   --attention-backend FLASH_ATTN_CUSTOM \
   --moe-backend aiter
 ```
-### Qwen3-30B-A3B-Instruct-2507 IFB BW1000 2x vLLM 0.21
-
-```bash
-export VLLM_HCU_USE_PD_SPLIT=1
-vllm serve Qwen/Qwen3-30B-A3B-Instruct-2507 \
-  -tp 2 \
-  --trust-remote-code \
-  --max-num-batched-tokens 10240 \
-  --attention-backend FLASH_ATTN_CUSTOM \
-  --moe-backend aiter
-```
-### Qwen3-30B-A3B-Instruct-2507 IFB BW1000 2x vLLM 0.18
-```bash
-export VLLM_HCU_USE_PD_SPLIT=1
-export VLLM_HCU_USE_CUSTOM_FLASH_ATTN=1
-export VLLM_ROCM_USE_AITER=1
-export VLLM_ROCM_USE_AITER_MOE=1
-
-vllm serve Qwen/Qwen3-30B-A3B-Instruct-2507 \
-  -tp 2 \
-  --trust-remote-code \
-  --max-num-batched-tokens 10240 
-```
 
 ### Qwen3-30B-A3B-Instruct-2507 IFB BW1000 2x vLLM 0.18-hotfix
 
@@ -1217,27 +1290,6 @@ vllm serve Qwen/Qwen3-30B-A3B-Instruct-2507 \
   --max-num-batched-tokens 10240 \
   --attention-backend FLASH_ATTN_CUSTOM \
   --moe-backend aiter
-```
-### Qwen3-30B-A3B-Instruct-2507 IFB K100_AI 2x vLLM 0.21
-
-```bash
-export VLLM_HCU_USE_CUSTOM_QUANTIZATION_GEMM=0
-export VLLM_HCU_USE_CUSTOM_OPS=0
-
-vllm serve Qwen/Qwen3-30B-A3B-Instruct-2507 \
-  -tp 2 \
-  --trust-remote-code \
-  --max-num-batched-tokens 10240 
-```
-### Qwen3-30B-A3B-Instruct-2507 IFB K100_AI 2x vLLM 0.18
-```bash
-export VLLM_HCU_USE_CUSTOM_QUANTIZATION_GEMM=0
-export VLLM_HCU_USE_CUSTOM_OPS=0
-
-vllm serve Qwen/Qwen3-30B-A3B-Instruct-2507 \
-  -tp 2 \
-  --trust-remote-code \
-  --max-num-batched-tokens 10240 
 ```
 
 ### Qwen3-30B-A3B-Instruct-2507 IFB K100_AI 2x vLLM 0.18-hotfix
@@ -1251,6 +1303,7 @@ vllm serve Qwen/Qwen3-30B-A3B-Instruct-2507 \
   --trust-remote-code \
   --max-num-batched-tokens 10240 
 ```
+
 ### Qwen3-30B-A3B-Instruct-2507 IFB BW1100 1x vLLM 0.15
 
 ### Qwen3-30B-A3B-Instruct-2507 IFB BW1000 2x vLLM 0.15
@@ -1281,6 +1334,20 @@ vllm serve Qwen/Qwen3-30B-A3B-Instruct-2507-W8A8 \
   --kv-cache-dtype fp8_e4m3 \
   --attention-backend FLASH_ATTN_CUSTOM
 ```
+
+### Qwen3-30B-A3B-Instruct-2507-W8A8-INT8 IFB BW1000 1x vLLM 0.21
+
+```bash
+export VLLM_HCU_USE_PD_SPLIT=1
+
+vllm serve Qwen/Qwen3-30B-A3B-Instruct-2507-W8A8 \
+  -tp 1 \
+  --trust-remote-code \
+  --max-num-batched-tokens 10240 \
+  --q slimquant_marlin \
+  --attention-backend FLASH_ATTN_CUSTOM
+```
+
 ### Qwen3-30B-A3B-Instruct-2507-W8A8-INT8 IFB BW1100 1x vLLM 0.18
 ```bash
 export VLLM_HCU_USE_PD_SPLIT=1
@@ -1292,6 +1359,21 @@ vllm serve Qwen/Qwen3-30B-A3B-Instruct-2507-W8A8 \
   --max-num-batched-tokens 10240 \
   --q slimquant_marlin
 ```
+
+### Qwen3-30B-A3B-Instruct-2507-W8A8-INT8 IFB BW1000 1x vLLM 0.18
+
+```bash
+export VLLM_HCU_USE_PD_SPLIT=1
+export VLLM_HCU_USE_CUSTOM_FLASH_ATTN=1
+
+vllm serve Qwen/Qwen3-30B-A3B-Instruct-2507-W8A8 \
+  -tp 1 \
+  --trust-remote-code \
+  --max-num-batched-tokens 10240 \
+  --q slimquant_marlin 
+```
+
+### Qwen3-30B-A3B-Instruct-2507-W8A8-INT8 IFB K100_AI 1x vLLM 0.18
 
 ### Qwen3-30B-A3B-Instruct-2507-W8A8-INT8 IFB BW1100 1x vLLM 0.18-hotfix
 
@@ -1306,30 +1388,6 @@ vllm serve Qwen/Qwen3-30B-A3B-Instruct-2507-W8A8 \
   --kv-cache-dtype fp8_e4m3 \
   --attention-backend FLASH_ATTN_CUSTOM
 ```
-### Qwen3-30B-A3B-Instruct-2507-W8A8-INT8 IFB BW1000 1x vLLM 0.21
-
-```bash
-export VLLM_HCU_USE_PD_SPLIT=1
-
-vllm serve Qwen/Qwen3-30B-A3B-Instruct-2507-W8A8 \
-  -tp 1 \
-  --trust-remote-code \
-  --max-num-batched-tokens 10240 \
-  --q slimquant_marlin \
-  --attention-backend FLASH_ATTN_CUSTOM
-```
-### Qwen3-30B-A3B-Instruct-2507-W8A8-INT8 IFB BW1000 1x vLLM 0.18
-
-```bash
-export VLLM_HCU_USE_PD_SPLIT=1
-export VLLM_HCU_USE_CUSTOM_FLASH_ATTN=1
-
-vllm serve Qwen/Qwen3-30B-A3B-Instruct-2507-W8A8 \
-  -tp 1 \
-  --trust-remote-code \
-  --max-num-batched-tokens 10240 \
-  --q slimquant_marlin 
-```
 
 ### Qwen3-30B-A3B-Instruct-2507-W8A8-INT8 IFB BW1000 1x vLLM 0.18-hotfix
 
@@ -1343,7 +1401,6 @@ vllm serve Qwen/Qwen3-30B-A3B-Instruct-2507-W8A8 \
   --q slimquant_marlin \
   --attention-backend FLASH_ATTN_CUSTOM
 ```
-### Qwen3-30B-A3B-Instruct-2507-W8A8-INT8 IFB K100_AI 1x vLLM 0.18
 
 ### Qwen3-30B-A3B-Instruct-2507-W8A8-INT8 IFB BW1100 1x vLLM 0.15
 
@@ -1364,6 +1421,7 @@ vllm serve Qwen/Qwen3-235B-A22B-Instruct-2507 \
   --kv-cache-dtype fp8_e4m3 \
   --attention-backend FLASH_ATTN_CUSTOM
 ```
+
 ### Qwen3-235B-A22B-Instruct-2507 IFB BW1000 8x vLLM 0.21
 
 ```bash
@@ -1377,6 +1435,7 @@ vllm serve Qwen/Qwen3-235B-A22B-Instruct-2507 \
   --gpu-memory-utilization 0.95 \
   --attention-backend FLASH_ATTN_CUSTOM
 ```
+
 ### Qwen3-235B-A22B-Instruct-2507 IFB BW1100 4x vLLM 0.18
 ```bash
 export VLLM_HCU_USE_PD_SPLIT=1
@@ -1389,6 +1448,7 @@ vllm serve Qwen/Qwen3-235B-A22B-Instruct-2507 \
   --trust-remote-code \
   --max-num-batched-tokens 10240 
 ```
+
 ### Qwen3-235B-A22B-Instruct-2507 IFB BW1000 8x vLLM 0.18
 
 ```bash
@@ -1403,9 +1463,11 @@ vllm serve Qwen/Qwen3-235B-A22B-Instruct-2507 \
   --max-num-batched-tokens 10240 \
   --gpu-memory-utilization 0.95
 ```
+
 ### Qwen3-235B-A22B-Instruct-2507 IFB K100_AI 8x vLLM 0.18
 
 <!-- TODO: 启动命令待补充 -->
+
 ### Qwen3-235B-A22B-Instruct-2507 IFB BW1100 4x vLLM 0.18-hotfix
 
 ```bash
@@ -1418,6 +1480,7 @@ vllm serve Qwen/Qwen3-235B-A22B-Instruct-2507 \
   --attention-backend FLASH_ATTN_CUSTOM \
   --moe-backend aiter
 ```
+
 ### Qwen3-235B-A22B-Instruct-2507 IFB BW1000 8x vLLM 0.18-hotfix
 
 ```bash
@@ -1430,6 +1493,7 @@ vllm serve Qwen/Qwen3-235B-A22B-Instruct-2507 \
   --attention-backend FLASH_ATTN_CUSTOM \
   --moe-backend aiter
 ```
+
 ### Qwen3-235B-A22B-Instruct-2507 IFB BW1100 4x vLLM 0.15
 
 ```bash
@@ -1440,6 +1504,7 @@ vllm serve Qwen/Qwen3-235B-A22B-Instruct-2507 \
   -tp 4 \
   --disable-cascade-attn 
 ```
+
 ### Qwen3-235B-A22B-Instruct-2507 IFB BW1000 8x vLLM 0.15
 
 ```bash
@@ -1452,6 +1517,7 @@ vllm serve Qwen/Qwen3-235B-A22B-Instruct-2507 \
   --max-model-len 40960 \
   --disable-cascade-attn
 ```
+
 ### Qwen3-235B-A22B-Instruct-2507 IFB K100_AI 8x vLLM 0.15
 
 ```bash
@@ -1465,6 +1531,7 @@ vllm serve Qwen/Qwen3-235B-A22B-Instruct-2507 \
   --max-model-len 40960 \
   --disable-cascade-attn
 ```
+
 ### Qwen3-235B-A22B IFB BW1100 4x vLLM 0.18
 
 ```bash
@@ -1526,6 +1593,21 @@ vllm serve Qwen/Qwen3-235B-A22B-Channel-INT8-w8a8  \
   --attention-backend FLASH_ATTN_CUSTOM
 
 ```
+
+### Qwen3-235B-A22B-Channel-INT8-w8a8 IFB BW1000 4x vLLM 0.21
+
+```bash
+export VLLM_HCU_USE_PD_SPLIT=1
+
+vllm serve Qwen/Qwen3-235B-A22B-Channel-INT8-w8a8 \
+  -tp  4 \
+  --trust-remote-code \
+  --max-num-batched-tokens 10240 \
+  --max-model-len 40960 \
+  --gpu-memory-utilization 0.95 \
+  --attention-backend FLASH_ATTN_CUSTOM
+```
+
 ### Qwen3-235B-A22B-Channel-INT8-w8a8 IFB BW1100 2x vLLM 0.18
 ```bash
 export VLLM_HCU_USE_CUSTOM_FLASH_ATTN=1
@@ -1536,6 +1618,31 @@ vllm serve Qwen/Qwen3-235B-A22B-Channel-INT8-w8a8  \
   --max-num-batched-tokens 10240 \
   --max-model-len 40960 \
   --gpu-memory-utilization 0.95
+```
+
+### Qwen3-235B-A22B-Channel-INT8-w8a8 IFB BW1000 4x vLLM 0.18
+```bash
+export VLLM_HCU_USE_CUSTOM_FLASH_ATTN=1
+
+vllm serve Qwen/Qwen3-235B-A22B-Channel-INT8-w8a8 \
+  -tp  4 \
+  --trust-remote-code \
+  --max-num-batched-tokens 10240 \
+  --max-model-len 40960 \
+  --gpu-memory-utilization 0.95
+```
+
+### Qwen3-235B-A22B-Channel-INT8-w8a8 IFB K100_AI 4x vLLM 0.18
+
+```bash
+export VLLM_HCU_USE_CUSTOM_QUANTIZATION_GEMM=0
+export VLLM_HCU_USE_CUSTOM_OPS=0
+
+vllm serve hygon/Qwen3-235B-A22B-Channel-INT8-w8a8 \
+  -tp 4 \
+  --gpu-memory-utilization 0.9 \
+  --trust-remote-code \
+  --max-num-batched-tokens 10240
 ```
 
 ### Qwen3-235B-A22B-Channel-INT8-w8a8 IFB BW1100 2x vLLM 0.18-hotfix
@@ -1553,30 +1660,6 @@ vllm serve Qwen/Qwen3-235B-A22B-Channel-INT8-w8a8  \
   --attention-backend FLASH_ATTN_CUSTOM
 
 ```
-### Qwen3-235B-A22B-Channel-INT8-w8a8 IFB BW1000 4x vLLM 0.21
-
-```bash
-export VLLM_HCU_USE_PD_SPLIT=1
-
-vllm serve Qwen/Qwen3-235B-A22B-Channel-INT8-w8a8 \
-  -tp  4 \
-  --trust-remote-code \
-  --max-num-batched-tokens 10240 \
-  --max-model-len 40960 \
-  --gpu-memory-utilization 0.95 \
-  --attention-backend FLASH_ATTN_CUSTOM
-```
-### Qwen3-235B-A22B-Channel-INT8-w8a8 IFB BW1000 4x vLLM 0.18
-```bash
-export VLLM_HCU_USE_CUSTOM_FLASH_ATTN=1
-
-vllm serve Qwen/Qwen3-235B-A22B-Channel-INT8-w8a8 \
-  -tp  4 \
-  --trust-remote-code \
-  --max-num-batched-tokens 10240 \
-  --max-model-len 40960 \
-  --gpu-memory-utilization 0.95
-```
 
 ### Qwen3-235B-A22B-Channel-INT8-w8a8 IFB BW1000 4x vLLM 0.18-hotfix
 
@@ -1590,18 +1673,6 @@ vllm serve Qwen/Qwen3-235B-A22B-Channel-INT8-w8a8 \
   --max-model-len 40960 \
   --gpu-memory-utilization 0.95 \
   --attention-backend FLASH_ATTN_CUSTOM
-```
-### Qwen3-235B-A22B-Channel-INT8-w8a8 IFB K100_AI 4x vLLM 0.18
-
-```bash
-export VLLM_HCU_USE_CUSTOM_QUANTIZATION_GEMM=0
-export VLLM_HCU_USE_CUSTOM_OPS=0
-
-vllm serve hygon/Qwen3-235B-A22B-Channel-INT8-w8a8 \
-  -tp 4 \
-  --gpu-memory-utilization 0.9 \
-  --trust-remote-code \
-  --max-num-batched-tokens 10240
 ```
 
 ### Qwen3-235B-A22B-Channel-INT8-w8a8 IFB BW1100 2x vLLM 0.15
@@ -1622,6 +1693,7 @@ vllm serve Qwen/Qwen3-235B-A22B-FP8-Channelwise \
   --kv-cache-dtype fp8_e4m3 \
   --attention-backend FLASH_ATTN_CUSTOM
 ```
+
 ### Qwen3-235B-A22B-FP8-Channelwise IFB BW1100 4x vLLM 0.18
 ```bash
 export VLLM_HCU_USE_PD_SPLIT=1
@@ -1645,6 +1717,7 @@ vllm serve Qwen/Qwen3-235B-A22B-FP8-Channelwise \
   --kv-cache-dtype fp8_e4m3 \
   --attention-backend FLASH_ATTN_CUSTOM
 ```
+
 ### Qwen3-235B-A22B-FP8-Channelwise IFB BW1100 4x vLLM 0.15
 ```bash
 export VLLM_USE_LIGHTOP=1

--- a/docs/model-deployment/vllm/qwen3.md
+++ b/docs/model-deployment/vllm/qwen3.md
@@ -171,7 +171,6 @@ Qwen3 是阿里通义千问第三代大语言模型，支持 0.6B ~ 235B 多种�
 ### Qwen3-0.6B IFB BW1100 1x vLLM 0.21
 
 ```bash
-export VLLM_HCU_USE_PD_SPLIT=1
 
 vllm serve Qwen/Qwen3-0.6B \
   -tp 1 \
@@ -183,7 +182,6 @@ vllm serve Qwen/Qwen3-0.6B \
 ### Qwen3-0.6B IFB BW1000 1x vLLM 0.21
 
 ```bash
-export VLLM_HCU_USE_PD_SPLIT=1
 
 vllm serve Qwen/Qwen3-0.6B \
   -tp 1 \
@@ -290,7 +288,6 @@ vllm serve Qwen/Qwen3-0.6B \
 ### Qwen3-1.7B IFB BW1100 1x vLLM 0.21
 
 ```bash
-export VLLM_HCU_USE_PD_SPLIT=1
 
 vllm serve Qwen/Qwen3-1.7B \
   -tp 1 \
@@ -302,7 +299,6 @@ vllm serve Qwen/Qwen3-1.7B \
 ### Qwen3-1.7B IFB BW1000 1x vLLM 0.21
 
 ```bash
-export VLLM_HCU_USE_PD_SPLIT=1
 
 vllm serve Qwen/Qwen3-1.7B \
   -tp 1 \
@@ -401,7 +397,6 @@ vllm serve Qwen/Qwen3-1.7B \
 ### Qwen3-4B IFB BW1100 1x vLLM 0.21
 
 ```bash
-export VLLM_HCU_USE_PD_SPLIT=1
 
 vllm serve Qwen/Qwen3-4B \
   -tp 1 \
@@ -414,7 +409,6 @@ vllm serve Qwen/Qwen3-4B \
 ### Qwen3-4B IFB BW1000 1x vLLM 0.21
 
 ```bash
-export VLLM_HCU_USE_PD_SPLIT=1
 
 vllm serve Qwen/Qwen3-4B \
   -tp 1 \
@@ -516,7 +510,6 @@ vllm serve Qwen/Qwen3-4B \
 ### Qwen3-4B-Channel-INT8-w8a8 IFB BW1100 1x vLLM 0.21
 
 ```bash
-export VLLM_HCU_USE_PD_SPLIT=1
 
 vllm serve Qwen/Qwen3-4B-Channel-INT8-w8a8 \
   -tp  1 \
@@ -530,7 +523,6 @@ vllm serve Qwen/Qwen3-4B-Channel-INT8-w8a8 \
 ### Qwen3-4B-Channel-INT8-w8a8 IFB BW1000 1x vLLM 0.21
 
 ```bash
-export VLLM_HCU_USE_PD_SPLIT=1
 
 vllm serve Qwen/Qwen3-4B-Channel-INT8-w8a8 \
   -tp  1 \
@@ -638,7 +630,6 @@ vllm serve Qwen/Qwen3-4B-Thinking-2507 \
 ### Qwen3-8B IFB BW1100 1x vLLM 0.21
 
 ```bash
-export VLLM_HCU_USE_PD_SPLIT=1
 
 vllm serve Qwen/Qwen3-8B \
   -tp 1 \
@@ -651,7 +642,6 @@ vllm serve Qwen/Qwen3-8B \
 ### Qwen3-8B IFB BW1000 1x vLLM 0.21
 
 ```bash
-export VLLM_HCU_USE_PD_SPLIT=1
 
 vllm serve Qwen/Qwen3-8B \
   -tp 1 \
@@ -753,7 +743,6 @@ vllm serve Qwen/Qwen3-8B \
 ### Qwen3-8B-Channel-INT8-w8a8 IFB BW1100 1x vLLM 0.21
 
 ```bash
-export VLLM_HCU_USE_PD_SPLIT=1
 
 vllm serve Qwen/Qwen3-8B-Channel-INT8-w8a8 \
   -tp  1 \
@@ -767,7 +756,6 @@ vllm serve Qwen/Qwen3-8B-Channel-INT8-w8a8 \
 ### Qwen3-8B-Channel-INT8-w8a8 IFB BW1000 1x vLLM 0.21
 
 ```bash
-export VLLM_HCU_USE_PD_SPLIT=1
 
 vllm serve Qwen/Qwen3-8B-Channel-INT8-w8a8 \
   -tp  1 \
@@ -837,7 +825,6 @@ vllm serve Qwen/Qwen3-8B-Channel-INT8-w8a8 \
 ### Qwen3-14B IFB BW1100 1x vLLM 0.21
 
 ```bash
-export VLLM_HCU_USE_PD_SPLIT=1
 
 vllm serve Qwen/Qwen3-14B \
   -tp 1 \
@@ -850,7 +837,6 @@ vllm serve Qwen/Qwen3-14B \
 ### Qwen3-14B IFB BW1000 1x vLLM 0.21
 
 ```bash
-export VLLM_HCU_USE_PD_SPLIT=1
 
 vllm serve Qwen/Qwen3-14B \
   -tp 1 \
@@ -952,7 +938,6 @@ vllm serve Qwen/Qwen3-14B \
 ### Qwen3-14B-Channel-INT8-w8a8 IFB BW1100 1x vLLM 0.21
 
 ```bash
-export VLLM_HCU_USE_PD_SPLIT=1
 
 vllm serve Qwen/Qwen3-14B-Channel-INT8-w8a8 \
   -tp  1 \
@@ -966,7 +951,6 @@ vllm serve Qwen/Qwen3-14B-Channel-INT8-w8a8 \
 ### Qwen3-14B-Channel-INT8-w8a8 IFB BW1000 1x vLLM 0.21
 
 ```bash
-export VLLM_HCU_USE_PD_SPLIT=1
 
 vllm serve Qwen/Qwen3-14B-Channel-INT8-w8a8 \
   -tp  1 \
@@ -1036,7 +1020,6 @@ vllm serve Qwen/Qwen3-14B-Channel-INT8-w8a8 \
 ### Qwen3-32B IFB BW1100 1x vLLM 0.21
 
 ```bash
-export VLLM_HCU_USE_PD_SPLIT=1
 
 vllm serve Qwen/Qwen3-32B \
   -tp 1 \
@@ -1049,7 +1032,6 @@ vllm serve Qwen/Qwen3-32B \
 ### Qwen3-32B IFB BW1000 2x vLLM 0.21
 
 ```bash
-export VLLM_HCU_USE_PD_SPLIT=1
 
 vllm serve Qwen/Qwen3-32B \
   -tp 2 \
@@ -1196,7 +1178,6 @@ vllm serve Qwen3-32B.w8a8 \
 ### Qwen3-30B-A3B-Instruct-2507 IFB BW1100 1x vLLM 0.21
 
 ```bash
-export VLLM_HCU_USE_PD_SPLIT=1
 vllm serve Qwen/Qwen3-30B-A3B-Instruct-2507 \
   -tp 1 \
   --trust-remote-code \
@@ -1209,7 +1190,6 @@ vllm serve Qwen/Qwen3-30B-A3B-Instruct-2507 \
 ### Qwen3-30B-A3B-Instruct-2507 IFB BW1000 2x vLLM 0.21
 
 ```bash
-export VLLM_HCU_USE_PD_SPLIT=1
 vllm serve Qwen/Qwen3-30B-A3B-Instruct-2507 \
   -tp 2 \
   --trust-remote-code \
@@ -1324,7 +1304,6 @@ vllm serve Qwen/Qwen3-30B-A3B \
 ### Qwen3-30B-A3B-Instruct-2507-W8A8-INT8 IFB BW1100 1x vLLM 0.21
 
 ```bash
-export VLLM_HCU_USE_PD_SPLIT=1
 
 vllm serve Qwen/Qwen3-30B-A3B-Instruct-2507-W8A8 \
   -tp  1 \
@@ -1338,7 +1317,6 @@ vllm serve Qwen/Qwen3-30B-A3B-Instruct-2507-W8A8 \
 ### Qwen3-30B-A3B-Instruct-2507-W8A8-INT8 IFB BW1000 1x vLLM 0.21
 
 ```bash
-export VLLM_HCU_USE_PD_SPLIT=1
 
 vllm serve Qwen/Qwen3-30B-A3B-Instruct-2507-W8A8 \
   -tp 1 \
@@ -1581,7 +1559,6 @@ vllm serve Qwen/Qwen3-235B-A22B \
 ### Qwen3-235B-A22B-Channel-INT8-w8a8 IFB BW1100 2x vLLM 0.21
 
 ```bash
-export VLLM_HCU_USE_PD_SPLIT=1
 
 vllm serve Qwen/Qwen3-235B-A22B-Channel-INT8-w8a8  \
   -tp  2 \
@@ -1597,7 +1574,6 @@ vllm serve Qwen/Qwen3-235B-A22B-Channel-INT8-w8a8  \
 ### Qwen3-235B-A22B-Channel-INT8-w8a8 IFB BW1000 4x vLLM 0.21
 
 ```bash
-export VLLM_HCU_USE_PD_SPLIT=1
 
 vllm serve Qwen/Qwen3-235B-A22B-Channel-INT8-w8a8 \
   -tp  4 \
@@ -1684,7 +1660,6 @@ vllm serve Qwen/Qwen3-235B-A22B-Channel-INT8-w8a8 \
 ### Qwen3-235B-A22B-FP8-Channelwise IFB BW1100 4x vLLM 0.21
 
 ```bash
-export VLLM_HCU_USE_PD_SPLIT=1
 
 vllm serve Qwen/Qwen3-235B-A22B-FP8-Channelwise \
   -tp 4 \

--- a/docs/model-deployment/vllm/qwen3.md
+++ b/docs/model-deployment/vllm/qwen3.md
@@ -140,6 +140,7 @@ Qwen3 是阿里通义千问第三代大语言模型，支持 0.6B ~ 235B 多种�
 |  | INT8 W8A8 | 0.15 | K100_AI | 1 | IFB | [**`>_`**](#qwen3-30b-a3b-instruct-2507-w8a8-int8-ifb-k100_ai-1x-vllm-015) |
 | [Qwen/Qwen3-235B-A22B-Instruct-2507](https://www.modelscope.cn/models/Qwen/Qwen3-235B-A22B-Instruct-2507) | BF16 | 0.21 | BW1100 | 4 | IFB | [**`>_`**](#qwen3-235b-a22b-instruct-2507-ifb-bw1100-4x-vllm-021) |
 |  | BF16 | 0.21 | BW1000 | 8 | IFB | [**`>_`**](#qwen3-235b-a22b-instruct-2507-ifb-bw1000-8x-vllm-021) |
+|  | BF16 | [0.18](../docker_images.md) | BW1100 | 4 | IFB | [**`>_`**](#qwen3-235b-a22b-instruct-2507-ifb-bw1100-4x-vllm-018) |
 |  | BF16 | 0.18 | BW1000 | 8 | IFB | [**`>_`**](#qwen3-235b-a22b-instruct-2507-ifb-bw1000-8x-vllm-018) |
 |  | BF16 | 0.18 | K100_AI | 8 | IFB | [**`>_`**](#qwen3-235b-a22b-instruct-2507-ifb-k100_ai-8x-vllm-018) |
 |  | BF16 | 0.18-hotfix | BW1100 | 4 | IFB | [**`>_`**](#qwen3-235b-a22b-instruct-2507-ifb-bw1100-4x-vllm-018-hotfix) |
@@ -147,7 +148,6 @@ Qwen3 是阿里通义千问第三代大语言模型，支持 0.6B ~ 235B 多种�
 |  | BF16 | 0.15 | BW1100 | 4 | IFB | [**`>_`**](#qwen3-235b-a22b-instruct-2507-ifb-bw1100-4x-vllm-015) |
 |  | BF16 | 0.15 | BW1000 | 8 | IFB | [**`>_`**](#qwen3-235b-a22b-instruct-2507-ifb-bw1000-8x-vllm-015) |
 |  | BF16 | 0.15 | K100_AI | 8 | IFB | [**`>_`**](#qwen3-235b-a22b-instruct-2507-ifb-k100_ai-8x-vllm-015) |
-|  | BF16 | [0.18](../docker_images.md) | BW1100 | 4 | IFB | [**`>_`**](#qwen3-235b-a22b-instruct-2507-ifb-bw1100-4x-vllm-018) |
 | [Qwen/Qwen3-235B-A22B](https://www.modelscope.cn/models/Qwen/Qwen3-235B-A22B) | BF16 | [0.18](../docker_images.md) | BW1100 | 4 | IFB | [**`>_`**](#qwen3-235b-a22b-ifb-bw1100-4x-vllm-018) |
 |  | BF16 | [0.18](../docker_images.md) | BW1000 | 8 | IFB | [**`>_`**](#qwen3-235b-a22b-ifb-bw1000-8x-vllm-018) |
 |  | BF16 | [0.18](../docker_images.md) | K100_AI | 8 | IFB | [**`>_`**](#qwen3-235b-a22b-ifb-k100_ai-8x-vllm-018) |


### PR DESCRIPTION
## Summary
- Reorder qwen3.5.md vLLM table rows and startup command sections by version first, then hardware.
- Reorder qwen3.6.md vLLM table rows and startup command sections by version first, then hardware.
- Reorder qwen3.md vLLM table rows and startup command sections by version first, then hardware.

## Notes
- qwen3.5.md and qwen3.6.md currently have 0.21, 0.18, and 0.18-hotfix entries.
- qwen3.md also keeps 0.15 entries after the 0.18-hotfix entries.