### PR TITLE
docs: use TRITON_ATTN for Qwen K100_AI vLLM 0.21

### DIFF
--- a/docs/model-deployment/vllm/deepseek-r1.md
+++ b/docs/model-deployment/vllm/deepseek-r1.md
@@ -37,8 +37,8 @@ DeepSeek-R1 是 DeepSeek 推出的推理强化模型，面向复杂推理、数�
 |                                                                                                             | FP8 W8A8 | [0.15](../docker_images.md) | BW1100 | 8 | IFB | [**`>_`**](#deepseek-r1-channel-fp8-w8a8-ifb-bw1100-8x-vllm-015) |
 | [hygon/DeepSeek-R1-W4A8-V2_6](https://www.modelscope.cn/models/hygon/DeepSeek-R1-W4A8-V2_6) | INT4 W4A8 | 0.21 | BW1100 | 8 | IFB | [**`>_`**](#deepseek-r1-w4a8-v2_6-ifb-bw1100-8x-vllm-021) |
 |                                                                                              | INT4 W4A8 | 0.21 | BW1000 | 8 | IFB | [**`>_`**](#deepseek-r1-w4a8-v2_6-ifb-bw1000-8x-vllm-021) |
-|                                                                                              | INT4 W4A8 | [0.18] | BW1100 | 8 | IFB | [**`>_`**](#deepseek-r1-w4a8-v2_6-ifb-bw1100-8x-vllm-018) |
-|                                                                                              | INT4 W4A8 | [0.18] | BW1000 | 8 | IFB | [**`>_`**](#deepseek-r1-w4a8-v2_6-ifb-bw1000-8x-vllm-018) |
+|                                                                                              | INT4 W4A8 | 0.18 | BW1100 | 8 | IFB | [**`>_`**](#deepseek-r1-w4a8-v2_6-ifb-bw1100-8x-vllm-018) |
+|                                                                                              | INT4 W4A8 | 0.18 | BW1000 | 8 | IFB | [**`>_`**](#deepseek-r1-w4a8-v2_6-ifb-bw1000-8x-vllm-018) |
 | [hygon/DeepSeek-R1-0528-W4A8-V2](https://www.modelscope.cn/models/hygon/DeepSeek-R1-0528-W4A8-V2) | INT4 W4A8 | 0.21 | BW1100 | 8 | IFB | [**`>_`**](#deepseek-r1-0528-w4a8-v2-ifb-bw1100-8x-vllm-021) |
 |                                      | INT4 W4A8 | 0.21 | BW1000 | 8 | IFB | [**`>_`**](#deepseek-r1-0528-w4a8-v2-ifb-bw1000-8x-vllm-021) |
 |                                      | INT4 W4A8 | [0.18](../docker_images.md) | BW1100 | 4 | IFB | [**`>_`**](#deepseek-r1-0528-w4a8-v2-ifb-bw1100-4x-vllm-018) |

--- a/docs/model-deployment/vllm/qwen2-vl.md
+++ b/docs/model-deployment/vllm/qwen2-vl.md
@@ -53,7 +53,8 @@ vllm serve Qwen/Qwen2-VL-2B-Instruct \
     -tp 1 \
     --trust-remote-code \
     --gpu-memory-utilization 0.95 \
-    --chat-template-content-format openai
+    --chat-template-content-format openai \
+    --attention-backend TRITON_ATTN
 ```
 ### Qwen2-VL-2B IFB BW1100 1x vLLM 0.18
 

--- a/docs/model-deployment/vllm/qwen2.5-vl.md
+++ b/docs/model-deployment/vllm/qwen2.5-vl.md
@@ -63,6 +63,7 @@ vllm serve Qwen/Qwen2.5-VL-32B-Instruct \
     --trust-remote-code \
     --max-model-len 32768 \
     --allowed-local-media-path /path-to/VL_data/ \
+    --attention-backend TRITON_ATTN
 ```
 ### Qwen2.5-VL-32B-Instruct IFB BW1100 1x vLLM 0.18
 
@@ -171,7 +172,7 @@ vllm serve Qwen/Qwen2.5-VL-72B-Instruct \
   --trust-remote-code \
   --enable-chunked-prefill \
   --max-model-len 32768 \
-  --attention-backend FLASH_ATTN_CUSTOM
+  --attention-backend TRITON_ATTN
 ```
 
 ### Qwen2.5-VL-72B-Instruct IFB BW1100 4x vLLM 0.18

--- a/docs/model-deployment/vllm/qwen2.md
+++ b/docs/model-deployment/vllm/qwen2.md
@@ -89,7 +89,8 @@ export VLLM_ROCM_USE_AITER=0
 
 vllm serve Qwen/Qwen2-0.5B-Instruct \
   -tp 1 \
-  --trust-remote-code
+  --trust-remote-code \
+  --attention-backend TRITON_ATTN
 ```
 
 ### Qwen2-0.5B-Instruct IFB BW1100 1x vLLM 0.18
@@ -196,7 +197,8 @@ export VLLM_ROCM_USE_AITER=0
 
 vllm serve Qwen/Qwen2-1.5B-Instruct \
   -tp 1 \
-  --trust-remote-code
+  --trust-remote-code \
+  --attention-backend TRITON_ATTN
 ```
 
 ### Qwen2-1.5B-Instruct IFB BW1100 1x vLLM 0.18
@@ -303,7 +305,8 @@ export VLLM_ROCM_USE_AITER=0
 
 vllm serve Qwen/Qwen2-7B-Instruct \
   -tp 1 \
-  --trust-remote-code
+  --trust-remote-code \
+  --attention-backend TRITON_ATTN
 ```
 
 ### Qwen2-7B-Instruct IFB BW1100 1x vLLM 0.18
@@ -410,7 +413,8 @@ export VLLM_ROCM_USE_AITER=0
 
 vllm serve Qwen/Qwen2-57B-A14B-Instruct \
   -tp 4 \
-  --trust-remote-code
+  --trust-remote-code \
+  --attention-backend TRITON_ATTN
 ```
 
 ### Qwen2-57B-A14B-Instruct IFB BW1100 2x vLLM 0.18
@@ -517,7 +521,8 @@ export VLLM_ROCM_USE_AITER=0
 
 vllm serve Qwen/Qwen2-72B-Instruct \
   -tp 4 \
-  --trust-remote-code
+  --trust-remote-code \
+  --attention-backend TRITON_ATTN
 ```
 
 ### Qwen2-72B-Instruct IFB BW1100 2x vLLM 0.18

--- a/docs/model-deployment/vllm/qwen3-vl.md
+++ b/docs/model-deployment/vllm/qwen3-vl.md
@@ -151,7 +151,8 @@ export VLLM_HCU_USE_CUSTOM_OPS=0
 export VLLM_ROCM_USE_AITER=0
 vllm serve Qwen/Qwen3-VL-2B-Instruct \
   -tp 1 \
-  --trust-remote-code 
+  --trust-remote-code \
+  --attention-backend TRITON_ATTN
 ```
 ### Qwen3-VL-2B-Instruct IFB BW1100 1x vLLM 0.18
 ```bash
@@ -239,7 +240,8 @@ export VLLM_HCU_USE_CUSTOM_OPS=0
 export VLLM_ROCM_USE_AITER=0
 vllm serve Qwen/Qwen3-VL-2B-Thinking \
   -tp 1 \
-  --trust-remote-code 
+  --trust-remote-code \
+  --attention-backend TRITON_ATTN
 ```
 ### Qwen3-VL-2B-Thinking IFB BW1100 1x vLLM 0.18
 ```bash
@@ -327,7 +329,8 @@ export VLLM_HCU_USE_CUSTOM_OPS=0
 export VLLM_ROCM_USE_AITER=0
 vllm serve Qwen/Qwen3-VL-4B-Instruct \
   -tp 1 \
-  --trust-remote-code 
+  --trust-remote-code \
+  --attention-backend TRITON_ATTN
 ```
 ### Qwen3-VL-4B-Instruct IFB BW1100 1x vLLM 0.18
 ```bash
@@ -415,7 +418,8 @@ export VLLM_HCU_USE_CUSTOM_OPS=0
 export VLLM_ROCM_USE_AITER=0
 vllm serve Qwen/Qwen3-VL-4B-Thinking \
   -tp 1 \
-  --trust-remote-code 
+  --trust-remote-code \
+  --attention-backend TRITON_ATTN
 ```
 ### Qwen3-VL-4B-Thinking IFB BW1100 1x vLLM 0.18
 ```bash
@@ -503,7 +507,8 @@ export VLLM_HCU_USE_CUSTOM_OPS=0
 export VLLM_ROCM_USE_AITER=0
 vllm serve Qwen/Qwen3-VL-8B-Instruct \
   -tp 1 \
-  --trust-remote-code 
+  --trust-remote-code \
+  --attention-backend TRITON_ATTN
 ```
 ### Qwen3-VL-8B-Instruct IFB BW1100 1x vLLM 0.18
 ```bash
@@ -591,7 +596,8 @@ export VLLM_HCU_USE_CUSTOM_OPS=0
 export VLLM_ROCM_USE_AITER=0
 vllm serve Qwen/Qwen3-VL-8B-Thinking \
   -tp 1 \
-  --trust-remote-code 
+  --trust-remote-code \
+  --attention-backend TRITON_ATTN
 ```
 ### Qwen3-VL-8B-Thinking IFB BW1100 1x vLLM 0.18
 ```bash
@@ -679,7 +685,8 @@ export VLLM_HCU_USE_CUSTOM_OPS=0
 export VLLM_ROCM_USE_AITER=0
 vllm serve Qwen/Qwen3-VL-30B-A3B-Instruct \
   -tp 2 \
-  --trust-remote-code 
+  --trust-remote-code \
+  --attention-backend TRITON_ATTN
 ```
 ### Qwen3-VL-30B-A3B-Instruct IFB BW1100 1x vLLM 0.18
 ```bash
@@ -769,7 +776,8 @@ export VLLM_HCU_USE_CUSTOM_OPS=0
 export VLLM_ROCM_USE_AITER=0
 vllm serve Qwen/Qwen3-VL-30B-A3B-Thinking \
   -tp 2 \
-  --trust-remote-code 
+  --trust-remote-code \
+  --attention-backend TRITON_ATTN
 ```
 ### Qwen3-VL-30B-A3B-Thinking IFB BW1100 1x vLLM 0.18
 ```bash
@@ -857,7 +865,8 @@ export VLLM_HCU_USE_CUSTOM_OPS=0
 export VLLM_ROCM_USE_AITER=0
 vllm serve Qwen/Qwen3-VL-32B-Instruct \
   -tp 2 \
-  --trust-remote-code 
+  --trust-remote-code \
+  --attention-backend TRITON_ATTN
 ```
 ### Qwen3-VL-32B-Instruct IFB BW1100 1x vLLM 0.18
 ```bash
@@ -971,7 +980,8 @@ export VLLM_ROCM_USE_AITER=0
 vllm serve Qwen/Qwen3-VL-235B-A22B-Instruct \
   -tp 8 \
   -pp 2 \
-  --trust-remote-code 
+  --trust-remote-code \
+  --attention-backend TRITON_ATTN
 ```
 ### Qwen3-VL-235B-A22B-Instruct IFB BW1100 8x vLLM 0.18
 
@@ -1090,7 +1100,8 @@ export VLLM_ROCM_USE_AITER=0
 vllm serve Qwen/Qwen3-VL-235B-A22B-Thinking \
   -tp 8 \
   -pp 2 \
-  --trust-remote-code 
+  --trust-remote-code \
+  --attention-backend TRITON_ATTN
 ```
 ### Qwen3-VL-235B-A22B-Thinking IFB BW1100 8x vLLM 0.18
 ```bash

--- a/docs/model-deployment/vllm/qwen3.5.md
+++ b/docs/model-deployment/vllm/qwen3.5.md
@@ -91,10 +91,10 @@ Qwen3.5 是 Qwen3 系列的增强版本，在推理能力、代码生成、多�
 |  | INT8 W8A8 | 0.21 | K100_AI | 8 | IFB | [**`>_`**](#qwen35-397b-a17b-w8a8-int8-ifb-k100_ai-8x-vllm-021) |
 |  | INT8 W8A8 | 0.18 | BW1000 | 8 | IFB | [**`>_`**](#qwen35-397b-a17b-w8a8-int8-ifb-bw1000-8x-vllm-018) |
 |  | INT8 W8A8 | 0.18 | K100_AI | 8 | IFB | [**`>_`**](#qwen35-397b-a17b-w8a8-int8-ifb-k100_ai-8x-vllm-018) |
+|  | INT8 W8A8 | [0.18](../docker_images.md) | BW1100 | 8 | IFB | [**`>_`**](#qwen35-397b-a17b-w8a8-int8-ifb-bw1100-8x-vllm-018) |
 |  | INT8 W8A8 | 0.18-hotfix | BW1100 | 8 | IFB | [**`>_`**](#qwen35-397b-a17b-w8a8-int8-ifb-bw1100-8x-vllm-018-hotfix) |
 |  | INT8 W8A8 | 0.18-hotfix | BW1000 | 8 | IFB | [**`>_`**](#qwen35-397b-a17b-w8a8-int8-ifb-bw1000-8x-vllm-018-hotfix) |
 |  | INT8 W8A8 | 0.18-hotfix | K100_AI | 8 | IFB | [**`>_`**](#qwen35-397b-a17b-w8a8-int8-ifb-k100_ai-8x-vllm-018-hotfix) |
-|  | INT8 W8A8 | [0.18](../docker_images.md) | BW1100 | 8 | IFB | [**`>_`**](#qwen35-397b-a17b-w8a8-int8-ifb-bw1100-8x-vllm-018) |
 | [hygon/Qwen3.5-397B-A17B-Channel-FP8](https://www.modelscope.cn/models/hygon/Qwen3.5-397B-A17B-Channel-FP8) | FP8 W8A8 | 0.21 | BW1100 | 4 | IFB | [**`>_`**](#qwen35-397b-a17b-channel-fp8-ifb-bw1100-4x-vllm-021) |
 |  | FP8 W8A8 | [0.18](../docker_images.md) | BW1100 | 4 | IFB | [**`>_`**](#qwen35-397b-a17b-channel-fp8-ifb-bw1100-4x-vllm-018) |
 |  | FP8 W8A8 | 0.18-hotfix | BW1100 | 4 | IFB | [**`>_`**](#qwen35-397b-a17b-channel-fp8-ifb-bw1100-4x-vllm-018-hotfix) |
@@ -140,7 +140,9 @@ vllm serve Qwen/Qwen3.5-4B \
   --max-num-batched-tokens 16384 \
   --speculative-config.method mtp \
   --speculative-config.num_speculative_tokens 3 \
-  --max-num-seqs 128
+  --speculative-config.attention_backend TRITON_ATTN \
+  --max-num-seqs 128 \
+  --attention-backend TRITON_ATTN
 ```
 
 ### Qwen3.5-4B IFB BW1100 1x vLLM 0.18
@@ -264,7 +266,9 @@ vllm serve Qwen/Qwen3.5-9B \
   --max-num-batched-tokens 16384 \
   --speculative-config.method mtp \
   --speculative-config.num_speculative_tokens 3 \
-  --max-num-seqs 128
+  --speculative-config.attention_backend TRITON_ATTN \
+  --max-num-seqs 128 \
+  --attention-backend TRITON_ATTN
 ```
 
 ### Qwen3.5-9B IFB BW1100 1x vLLM 0.18
@@ -388,7 +392,9 @@ vllm serve Qwen/Qwen3.5-27B \
   --max-num-batched-tokens 16384 \
   --speculative-config.method mtp \
   --speculative-config.num_speculative_tokens 3 \
-  --max-num-seqs 128
+  --speculative-config.attention_backend TRITON_ATTN \
+  --max-num-seqs 128 \
+  --attention-backend TRITON_ATTN
 ```
 
 ### Qwen3.5-27B IFB BW1100 1x vLLM 0.18
@@ -516,7 +522,9 @@ vllm serve hygon/Qwen3.5-27B-Channel-INT8-w8a8 \
   --max-num-batched-tokens 16384 \
   --speculative-config.method mtp \
   --speculative-config.num_speculative_tokens 3 \
-  --max-num-seqs 128
+  --speculative-config.attention_backend TRITON_ATTN \
+  --max-num-seqs 128 \
+  --attention-backend TRITON_ATTN
 ```
 
 ### Qwen3.5-27B-Channel-INT8-w8a8 IFB BW1100 1x vLLM 0.18
@@ -650,7 +658,9 @@ vllm serve Qwen/Qwen3.5-35B-A3B \
   --max-num-batched-tokens 16384 \
   --speculative-config.method mtp \
   --speculative-config.num_speculative_tokens 3 \
-  --max-num-seqs 128
+  --speculative-config.attention_backend TRITON_ATTN \
+  --max-num-seqs 128 \
+  --attention-backend TRITON_ATTN
 ```
 
 ### Qwen3.5-35B-A3B IFB BW1100 1x vLLM 0.18
@@ -786,7 +796,9 @@ vllm serve hygon/Qwen3.5-35B-A3B-Channel-INT8-w8a8 \
   --max-num-batched-tokens 16384 \
   --speculative-config.method mtp \
   --speculative-config.num_speculative_tokens 3 \
-  --max-num-seqs 128
+  --speculative-config.attention_backend TRITON_ATTN \
+  --max-num-seqs 128 \
+  --attention-backend TRITON_ATTN
 ```
 
 ### Qwen3.5-35B-A3B-Channel-INT8-w8a8 IFB BW1100 1x vLLM 0.18
@@ -967,7 +979,9 @@ vllm serve Qwen/Qwen3.5-122B-A10B \
   --max-num-batched-tokens 16384 \
   --speculative-config.method mtp \
   --speculative-config.num_speculative_tokens 3 \
-  --max-num-seqs 128
+  --speculative-config.attention_backend TRITON_ATTN \
+  --max-num-seqs 128 \
+  --attention-backend TRITON_ATTN
 ```
 
 ### Qwen3.5-122B-A10B IFB BW1100 4x vLLM 0.18
@@ -1103,7 +1117,9 @@ vllm serve Qwen/Qwen3.5-122B-A10B-W8A8-INT8 \
   --max-num-batched-tokens 16384 \
   --speculative-config.method mtp \
   --speculative-config.num_speculative_tokens 3 \
-  --max-num-seqs 128
+  --speculative-config.attention_backend TRITON_ATTN \
+  --max-num-seqs 128 \
+  --attention-backend TRITON_ATTN
 ```
 
 ### Qwen3.5-122B-A10B-W8A8-INT8 IFB BW1100 2x vLLM 0.18
@@ -1286,7 +1302,9 @@ vllm serve Qwen/Qwen3.5-397B-A17B-W8A8-INT8 \
   --max-num-batched-tokens 16384 \
   --speculative-config.method mtp \
   --speculative-config.num_speculative_tokens 3 \
-  --max-num-seqs 128
+  --speculative-config.attention_backend TRITON_ATTN \
+  --max-num-seqs 128 \
+  --attention-backend TRITON_ATTN
 ```
 
 ### Qwen3.5-397B-A17B-W8A8-INT8 IFB BW1100 8x vLLM 0.18

--- a/docs/model-deployment/vllm/qwen3.6.md
+++ b/docs/model-deployment/vllm/qwen3.6.md
@@ -68,7 +68,9 @@ vllm serve Qwen/Qwen3.6-27B \
   --trust-remote-code \
   --max-num-batched-tokens 10240 \
   --speculative-config.method mtp \
-  --speculative-config.num_speculative_tokens 3
+  --speculative-config.num_speculative_tokens 3 \
+  --speculative-config.attention_backend TRITON_ATTN \
+  --attention-backend TRITON_ATTN
 ```
 
 ### Qwen3.6-27B IFB BW1100 1x vLLM 0.18
@@ -195,7 +197,9 @@ vllm serve Qwen/Qwen3.6-35B-A3B \
   --trust-remote-code \
   --max-num-batched-tokens 10240 \
   --speculative-config.method mtp \
-  --speculative-config.num_speculative_tokens 3
+  --speculative-config.num_speculative_tokens 3 \
+  --speculative-config.attention_backend TRITON_ATTN \
+  --attention-backend TRITON_ATTN
 ```
 
 ### Qwen3.6-35B-A3B IFB BW1100 1x vLLM 0.18

--- a/docs/model-deployment/vllm/qwen3.md
+++ b/docs/model-deployment/vllm/qwen3.md
@@ -42,9 +42,9 @@ Qwen3 是阿里通义千问第三代大语言模型，支持 0.6B ~ 235B 多种�
 |  | INT8 W8A8 | 0.18 | BW1000 | 1 | IFB | [**`>_`**](#qwen3-4b-channel-int8-w8a8-ifb-bw1000-1x-vllm-018) |
 |  | INT8 W8A8 | 0.18-hotfix | BW1100 | 1 | IFB | [**`>_`**](#qwen3-4b-channel-int8-w8a8-ifb-bw1100-1x-vllm-018-hotfix) |
 |  | INT8 W8A8 | 0.18-hotfix | BW1000 | 1 | IFB | [**`>_`**](#qwen3-4b-channel-int8-w8a8-ifb-bw1000-1x-vllm-018-hotfix) |
-| [Qwen/Qwen3-4B-Thinking-2507](https://www.modelscope.cn/models/Qwen/Qwen3-4B-Thinking-2507) | BF16 | [0.18](../docker_images.md) | BW1100 | 1 | IFB | [**`>_`**](#qwen3-4b-thinking-2507-ifb-bw1100-1x-vllm-018) |
+| [Qwen/Qwen3-4B-Thinking-2507](https://www.modelscope.cn/models/Qwen/Qwen3-4B-Thinking-2507) | BF16 | 0.21 | K100_AI | 1 | IFB | [**`>_`**](#qwen3-4b-thinking-2507-ifb-k100ai-1x-vllm-021) |
+|  | BF16 | [0.18](../docker_images.md) | BW1100 | 1 | IFB | [**`>_`**](#qwen3-4b-thinking-2507-ifb-bw1100-1x-vllm-018) |
 |  | BF16 | [0.18](../docker_images.md) | BW1000 | 1 | IFB | [**`>_`**](#qwen3-4b-thinking-2507-ifb-bw1000-1x-vllm-018) |
-|  | BF16 | 0.21 | K100_AI | 1 | IFB | [**`>_`**](#qwen3-4b-thinking-2507-ifb-k100ai-1x-vllm-021) |
 |  | BF16 | [0.18](../docker_images.md) | K100_AI | 1 | IFB | [**`>_`**](#qwen3-4b-thinking-2507-ifb-k100ai-1x-vllm-018) |
 | [Qwen/Qwen3-8B](https://www.modelscope.cn/models/Qwen/Qwen3-8B) | BF16 | 0.21 | BW1100 | 1 | IFB | [**`>_`**](#qwen3-8b-ifb-bw1100-1x-vllm-021) |
 |  | BF16 | 0.21 | BW1000 | 1 | IFB | [**`>_`**](#qwen3-8b-ifb-bw1000-1x-vllm-021) |
@@ -85,9 +85,9 @@ Qwen3 是阿里通义千问第三代大语言模型，支持 0.6B ~ 235B 多种�
 |  | BF16 | 0.18-hotfix | BW1100 | 1 | IFB | [**`>_`**](#qwen3-32b-ifb-bw1100-1x-vllm-018-hotfix) |
 |  | BF16 | 0.18-hotfix | BW1000 | 2 | IFB | [**`>_`**](#qwen3-32b-ifb-bw1000-2x-vllm-018-hotfix) |
 |  | BF16 | 0.18-hotfix | K100_AI | 2 | IFB | [**`>_`**](#qwen3-32b-ifb-k100_ai-2x-vllm-018-hotfix) |
-| Qwen3-32B.w8a8 | INT8 W8A8 | 0.18 | BW1100 | 1 | IFB | [**`>_`**](#qwen3-32bw8a8-ifb-bw1100-1x-vllm-018) |
+| Qwen3-32B.w8a8 | INT8 W8A8 | 0.21 | K100_AI | 4 | IFB | [**`>_`**](#qwen3-32bw8a8-ifb-k100_ai-4x-vllm-021) |
+|  | INT8 W8A8 | 0.18 | BW1100 | 1 | IFB | [**`>_`**](#qwen3-32bw8a8-ifb-bw1100-1x-vllm-018) |
 |  | INT8 W8A8 | 0.18 | BW1000 | 1 | IFB | [**`>_`**](#qwen3-32bw8a8-ifb-bw1000-1x-vllm-018) |
-|  | INT8 W8A8 | 0.21 | K100_AI | 4 | IFB | [**`>_`**](#qwen3-32bw8a8-ifb-k100_ai-4x-vllm-021) |
 |  | INT8 W8A8 | 0.18 | K100_AI | 4 | IFB | [**`>_`**](#qwen3-32bw8a8-ifb-k100_ai-4x-vllm-018) |
 | [Qwen/Qwen3-30B-A3B-Instruct-2507](https://www.modelscope.cn/models/Qwen/Qwen3-30B-A3B-Instruct-2507) | BF16 | 0.21 | BW1100 | 1 | IFB | [**`>_`**](#qwen3-30b-a3b-instruct-2507-ifb-bw1100-1x-vllm-021) |
 |  | BF16 | 0.21 | BW1000 | 2 | IFB | [**`>_`**](#qwen3-30b-a3b-instruct-2507-ifb-bw1000-2x-vllm-021) |
@@ -119,9 +119,9 @@ Qwen3 是阿里通义千问第三代大语言模型，支持 0.6B ~ 235B 多种�
 |  | BF16 | [0.18](../docker_images.md) | K100_AI | 8 | IFB | [**`>_`**](#qwen3-235b-a22b-ifb-k100_ai-8x-vllm-018) |
 | [hygon/Qwen3-235B-A22B-Channel-INT8-w8a8](https://www.modelscope.cn/models/hygon/Qwen3-235B-A22B-Channel-INT8-w8a8) | INT8 W8A8 | 0.21 | BW1100 | 2 | IFB | [**`>_`**](#qwen3-235b-a22b-channel-int8-w8a8-ifb-bw1100-2x-vllm-021) |
 |  | INT8 W8A8 | 0.21 | BW1000 | 4 | IFB | [**`>_`**](#qwen3-235b-a22b-channel-int8-w8a8-ifb-bw1000-4x-vllm-021) |
+|  | INT8 W8A8 | 0.21 | K100_AI | 4 | IFB | [**`>_`**](#qwen3-235b-a22b-channel-int8-w8a8-ifb-k100_ai-4x-vllm-021) |
 |  | INT8 W8A8 | 0.18 | BW1100 | 2 | IFB | [**`>_`**](#qwen3-235b-a22b-channel-int8-w8a8-ifb-bw1100-2x-vllm-018) |
 |  | INT8 W8A8 | 0.18 | BW1000 | 4 | IFB | [**`>_`**](#qwen3-235b-a22b-channel-int8-w8a8-ifb-bw1000-4x-vllm-018) |
-|  | INT8 W8A8 | 0.21 | K100_AI | 4 | IFB | [**`>_`**](#qwen3-235b-a22b-channel-int8-w8a8-ifb-k100_ai-4x-vllm-021) |
 |  | INT8 W8A8 | 0.18 | K100_AI | 4 | IFB | [**`>_`**](#qwen3-235b-a22b-channel-int8-w8a8-ifb-k100_ai-4x-vllm-018) |
 |  | INT8 W8A8 | 0.18-hotfix | BW1100 | 2 | IFB | [**`>_`**](#qwen3-235b-a22b-channel-int8-w8a8-ifb-bw1100-2x-vllm-018-hotfix) |
 |  | INT8 W8A8 | 0.18-hotfix | BW1000 | 4 | IFB | [**`>_`**](#qwen3-235b-a22b-channel-int8-w8a8-ifb-bw1000-4x-vllm-018-hotfix) |
@@ -163,7 +163,7 @@ export VLLM_ROCM_USE_AITER=0
 vllm serve Qwen/Qwen3-0.6B \
   -tp 1 \
   --trust-remote-code \
-  --attention-backend FLASH_ATTN_CUSTOM
+  --attention-backend TRITON_ATTN
 ```
 
 ### Qwen3-0.6B IFB BW1100 1x vLLM 0.18
@@ -278,7 +278,8 @@ export VLLM_HCU_USE_CUSTOM_OPS=0
 export VLLM_ROCM_USE_AITER=0
 vllm serve Qwen/Qwen3-1.7B \
   -tp 1 \
-  --trust-remote-code
+  --trust-remote-code \
+  --attention-backend TRITON_ATTN
 ```
 
 ### Qwen3-1.7B IFB BW1100 1x vLLM 0.18
@@ -381,7 +382,8 @@ export VLLM_ROCM_USE_AITER=0
 vllm serve Qwen/Qwen3-4B \
   -tp 1 \
   --trust-remote-code \
-  --max-num-batched-tokens 10240 
+  --max-num-batched-tokens 10240 \
+  --attention-backend TRITON_ATTN
 ```
 
 ### Qwen3-4B IFB BW1100 1x vLLM 0.18
@@ -530,6 +532,20 @@ vllm serve Qwen/Qwen3-4B-Channel-INT8-w8a8 \
   --attention-backend FLASH_ATTN_CUSTOM
 ```
 
+### Qwen3-4B-Thinking-2507 IFB K100_AI 1x vLLM 0.21
+
+```bash
+
+export VLLM_HCU_USE_CUSTOM_QUANTIZATION_GEMM=0
+export VLLM_HCU_USE_CUSTOM_OPS=0
+export VLLM_ROCM_USE_AITER=0
+vllm serve Qwen/Qwen3-4B-Thinking-2507 \
+  -tp 1 \
+  --trust-remote-code \
+  --max-num-batched-tokens 10240 \
+  --attention-backend TRITON_ATTN
+```
+
 ### Qwen3-4B-Thinking-2507 IFB BW1100 1x vLLM 0.18
 
 ```bash
@@ -553,19 +569,6 @@ vllm serve Qwen/Qwen3-4B-Thinking-2507 \
   -tp 1 \
   --trust-remote-code \
   --kv-cache-dtype fp8_e5m2 \
-  --max-num-batched-tokens 10240
-```
-
-### Qwen3-4B-Thinking-2507 IFB K100_AI 1x vLLM 0.21
-
-```bash
-
-export VLLM_HCU_USE_CUSTOM_QUANTIZATION_GEMM=0
-export VLLM_HCU_USE_CUSTOM_OPS=0
-export VLLM_ROCM_USE_AITER=0
-vllm serve Qwen/Qwen3-4B-Thinking-2507 \
-  -tp 1 \
-  --trust-remote-code \
   --max-num-batched-tokens 10240
 ```
 
@@ -614,7 +617,8 @@ export VLLM_ROCM_USE_AITER=0
 vllm serve Qwen/Qwen3-8B \
   -tp 1 \
   --trust-remote-code \
-  --max-num-batched-tokens 10240 
+  --max-num-batched-tokens 10240 \
+  --attention-backend TRITON_ATTN
 ```
 
 ### Qwen3-8B IFB BW1100 1x vLLM 0.18
@@ -796,7 +800,8 @@ export VLLM_ROCM_USE_AITER=0
 vllm serve Qwen/Qwen3-14B \
   -tp 1 \
   --trust-remote-code \
-  --max-num-batched-tokens 10240 
+  --max-num-batched-tokens 10240 \
+  --attention-backend TRITON_ATTN
 ```
 
 ### Qwen3-14B IFB BW1100 1x vLLM 0.18
@@ -978,7 +983,8 @@ export VLLM_ROCM_USE_AITER=0
 vllm serve Qwen/Qwen3-32B \
   -tp 2 \
   --trust-remote-code \
-  --max-num-batched-tokens 10240 
+  --max-num-batched-tokens 10240 \
+  --attention-backend TRITON_ATTN
 ```
 
 ### Qwen3-32B IFB BW1100 1x vLLM 0.18
@@ -1054,6 +1060,21 @@ vllm serve Qwen/Qwen3-32B \
   --max-num-batched-tokens 10240 
 ```
 
+### Qwen3-32B.w8a8 IFB K100_AI 4x vLLM 0.21
+
+```bash
+
+
+export VLLM_HCU_USE_CUSTOM_QUANTIZATION_GEMM=0
+export VLLM_HCU_USE_CUSTOM_OPS=0
+export VLLM_ROCM_USE_AITER=0
+vllm serve Qwen3-32B.w8a8 \
+  -tp 4 \
+  --trust-remote-code \
+  --max-num-batched-tokens 10240 \
+  --attention-backend TRITON_ATTN
+```
+
 ### Qwen3-32B.w8a8 IFB BW1100 1x vLLM 0.18
 
 ```bash
@@ -1078,20 +1099,6 @@ export VLLM_RANK0_NUMA=1
 
 vllm serve Qwen3-32B.w8a8 \
   -tp 1 \
-  --trust-remote-code \
-  --max-num-batched-tokens 10240
-```
-
-### Qwen3-32B.w8a8 IFB K100_AI 4x vLLM 0.21
-
-```bash
-
-
-export VLLM_HCU_USE_CUSTOM_QUANTIZATION_GEMM=0
-export VLLM_HCU_USE_CUSTOM_OPS=0
-export VLLM_ROCM_USE_AITER=0
-vllm serve Qwen3-32B.w8a8 \
-  -tp 4 \
   --trust-remote-code \
   --max-num-batched-tokens 10240
 ```
@@ -1145,7 +1152,8 @@ export VLLM_ROCM_USE_AITER=0
 vllm serve Qwen/Qwen3-30B-A3B-Instruct-2507 \
   -tp 2 \
   --trust-remote-code \
-  --max-num-batched-tokens 10240 
+  --max-num-batched-tokens 10240 \
+  --attention-backend TRITON_ATTN
 ```
 
 ### Qwen3-30B-A3B-Instruct-2507 IFB BW1100 1x vLLM 0.18
@@ -1508,6 +1516,21 @@ vllm serve Qwen/Qwen3-235B-A22B-Channel-INT8-w8a8 \
   --attention-backend FLASH_ATTN_CUSTOM
 ```
 
+### Qwen3-235B-A22B-Channel-INT8-w8a8 IFB K100_AI 4x vLLM 0.21
+
+```bash
+
+export VLLM_HCU_USE_CUSTOM_QUANTIZATION_GEMM=0
+export VLLM_HCU_USE_CUSTOM_OPS=0
+export VLLM_ROCM_USE_AITER=0
+vllm serve hygon/Qwen3-235B-A22B-Channel-INT8-w8a8 \
+  -tp 4 \
+  --gpu-memory-utilization 0.9 \
+  --trust-remote-code \
+  --max-num-batched-tokens 10240 \
+  --attention-backend TRITON_ATTN
+```
+
 ### Qwen3-235B-A22B-Channel-INT8-w8a8 IFB BW1100 2x vLLM 0.18
 ```bash
 export VLLM_HCU_USE_CUSTOM_FLASH_ATTN=1
@@ -1530,20 +1553,6 @@ vllm serve Qwen/Qwen3-235B-A22B-Channel-INT8-w8a8 \
   --max-num-batched-tokens 10240 \
   --max-model-len 40960 \
   --gpu-memory-utilization 0.95
-```
-
-### Qwen3-235B-A22B-Channel-INT8-w8a8 IFB K100_AI 4x vLLM 0.21
-
-```bash
-
-export VLLM_HCU_USE_CUSTOM_QUANTIZATION_GEMM=0
-export VLLM_HCU_USE_CUSTOM_OPS=0
-export VLLM_ROCM_USE_AITER=0
-vllm serve hygon/Qwen3-235B-A22B-Channel-INT8-w8a8 \
-  -tp 4 \
-  --gpu-memory-utilization 0.9 \
-  --trust-remote-code \
-  --max-num-batched-tokens 10240
 ```
 
 ### Qwen3-235B-A22B-Channel-INT8-w8a8 IFB K100_AI 4x vLLM 0.18


### PR DESCRIPTION
## Summary
- add `--attention-backend TRITON_ATTN` to Qwen-series vLLM 0.21 K100_AI commands
- add `--speculative-config.attention_backend TRITON_ATTN` for Qwen K100_AI vLLM 0.21 commands that use MTP

## Verification
- Compared branch against main: one commit, 7 Qwen vLLM docs changed
- Verified 40 `K100_AI` + `vLLM 0.21` sections contain `--attention-backend TRITON_ATTN`
- Verified all 11 MTP sections contain `--speculative-config.attention_backend TRITON_ATTN`
