### PR TITLE
docs: add GLM-5.2 INT8 vLLM 0.25.1 BW1100 command

### DIFF
--- a/docs/model-deployment/vllm/glm-5.2.md
+++ b/docs/model-deployment/vllm/glm-5.2.md
@@ -15,7 +15,8 @@ GLM-5.2 是智谱 AI 推出的新一代大语言模型，在中文理解、长�
 | [hygon/GLM-5.2-Channel-FP8-w8a8](https://www.modelscope.cn/models/hygon/GLM-5.2-Channel-FP8-w8a8) | FP8 W8A8 | 0.21 | BW1100 | 8 | IFB | [**`>_`**](#glm-52-channel-fp8-w8a8-ifb-bw1100-8x-vllm-021) |
 |  | FP8 W8A8 | [0.18](../docker_images.md) | BW1100 | 8 | IFB | [**`>_`**](#glm-52-channel-fp8-w8a8-ifb-bw1100-8x-vllm-018) |
 |  | FP8 W8A8 | [0.15](../docker_images.md) | BW1100 | 8 | IFB | [**`>_`**](#glm-52-channel-fp8-w8a8-ifb-bw1100-8x-vllm-015) |
-| [hygon/GLM-5.2-Channel-INT8-w8a8](https://www.modelscope.cn/models/hygon/GLM-5.2-Channel-INT8-w8a8) | INT8 W8A8 | 0.21 | BW1100 | 8 | IFB | [**`>_`**](#glm-52-channel-int8-w8a8-ifb-bw1100-8x-vllm-021) |
+| [hygon/GLM-5.2-Channel-INT8-w8a8](https://www.modelscope.cn/models/hygon/GLM-5.2-Channel-INT8-w8a8) | INT8 W8A8 | 0.25.1 | BW1100 | 8 | IFB | [**`>_`**](#glm-52-channel-int8-w8a8-ifb-bw1100-8x-vllm-0251) |
+|  | INT8 W8A8 | 0.21 | BW1100 | 8 | IFB | [**`>_`**](#glm-52-channel-int8-w8a8-ifb-bw1100-8x-vllm-021) |
 |  | INT8 W8A8 | 0.21 | BW1000 | 16 | IFB | [**`>_`**](#glm-52-channel-int8-w8a8-ifb-bw1000-16x-vllm-021) |
 |  | INT8 W8A8 | [0.18](../docker_images.md) | BW1100 | 8 | IFB | [**`>_`**](#glm-52-channel-int8-w8a8-ifb-bw1100-8x-vllm-018) |
 |  | INT8 W8A8 | [0.18](../docker_images.md) | BW1000 | 16 | IFB | [**`>_`**](#glm-52-channel-int8-w8a8-ifb-bw1000-16x-vllm-018) |
@@ -255,6 +256,24 @@ vllm serve hygon/GLM-5.2-Channel-FP8-w8a8 \
   --kv-cache-dtype fp8_ds_mla \
   -cc '{"pass_config": {"fuse_act_quant": false}}' \
   --speculative_config '{"method": "mtp", "num_speculative_tokens": 2, "quantization": "slimquant_marlin"}'
+```
+
+### GLM-5.2-Channel-INT8-w8a8 IFB BW1100 8x vLLM 0.25.1
+
+```bash
+vllm serve hygon/GLM-5.2-Channel-INT8-w8a8 \
+  --tensor-parallel-size 8 \
+  --trust-remote-code \
+  --max-model-len 32768 \
+  --max-num-batched-tokens 10240 \
+  --max-num-seqs 128 \
+  --gpu-memory-utilization 0.9 \
+  --enable-chunked-prefill \
+  --enable-prefix-caching \
+  --block-size 64 \
+  --generation-config vllm \
+  --quantization slimquant_marlin \
+  --speculative-config '{"method":"mtp","num_speculative_tokens":2,"quantization":"slimquant_marlin"}'
 ```
 
 ### GLM-5.2-Channel-INT8-w8a8 IFB BW1100 8x vLLM 0.21


### PR DESCRIPTION
## Summary
- add hygon/GLM-5.2-Channel-INT8-w8a8 vLLM 0.25.1 BW1100 8-card IFB table row
- add the requested vLLM 0.25.1 BW1100 launch command with slimquant_marlin and MTP speculative config

## Verification
- Verified GLM-5.2 INT8 0.25.1 BW1100 table row and command section are present
- Verified the existing GLM-5.2 INT8 0.21 row remains as the same model group continuation row
- Verified branch only changes `docs/model-deployment/vllm/glm-5.2.md`