### PR TITLE
docs: update Qwen2.5-VL 32B hotfix command

### DIFF
--- a/docs/model-deployment/vllm/qwen2.5-vl.md
+++ b/docs/model-deployment/vllm/qwen2.5-vl.md
@@ -123,7 +123,7 @@ export VLLM_HCU_USE_PD_SPLIT=1
 vllm serve Qwen/Qwen2.5-VL-32B-Instruct \
     -tp 2 \
     --trust-remote-code \
-    --max-model-len 20480 \
+    --max-model-len 32768 \
     --attention-backend FLASH_ATTN_CUSTOM
 ```
 

--- a/docs/model-deployment/vllm/qwen2.5-vl.md
+++ b/docs/model-deployment/vllm/qwen2.5-vl.md
@@ -123,7 +123,7 @@ export VLLM_HCU_USE_PD_SPLIT=1
 vllm serve Qwen/Qwen2.5-VL-32B-Instruct \
     -tp 2 \
     --trust-remote-code \
-    --allowed-local-media-path /path-to/VL_data/ \
+    --max-model-len 20480 \
     --attention-backend FLASH_ATTN_CUSTOM
 ```
 

--- a/docs/model-deployment/vllm/qwen3.md
+++ b/docs/model-deployment/vllm/qwen3.md
@@ -1401,6 +1401,7 @@ export VLLM_HCU_USE_PD_SPLIT=1
 vllm serve Qwen/Qwen3-235B-A22B-Instruct-2507 \
   -tp 8 \
   --trust-remote-code \
+  --max-model-len 20480 \
   --max-num-batched-tokens 10240 \
   --gpu-memory-utilization 0.95 \
   --attention-backend FLASH_ATTN_CUSTOM \


### PR DESCRIPTION
## Summary
- add `--max-model-len 32768` to the Qwen2.5-VL-32B-Instruct IFB BW1000 2x vLLM 0.18-hotfix command
- remove `--allowed-local-media-path /path-to/VL_data/` from the same command

## Verification
- Verified the target vLLM 0.18-hotfix BW1000 command contains `--max-model-len 32768`
- Verified the target command no longer contains `--allowed-local-media-path /path-to/VL_data/`
- Verified branch only changes `docs/model-deployment/vllm/qwen2.5-vl.md`
- Qwen3-235B-A22B-Instruct-2507 0.18-hotfix BW1000 添加 `--max-model-len 20480`。