### PR TITLE
vllm: remove Qwen2-0.5B BW1100 kv cache dtype

### DIFF
--- a/docs/model-deployment/vllm/qwen2.md
+++ b/docs/model-deployment/vllm/qwen2.md
@@ -64,7 +64,6 @@ export VLLM_USE_MODELSCOPE=1
 vllm serve Qwen/Qwen2-0.5B-Instruct \
   -tp 1 \
   --trust-remote-code \
-  --kv-cache-dtype fp8_e4m3 \
   --attention-backend FLASH_ATTN_CUSTOM
 ```
 


### PR DESCRIPTION
## Summary
- Remove `--kv-cache-dtype fp8_e4m3` from Qwen2-0.5B-Instruct BW1100 vLLM 0.21 command.

## Verification
- Remote compare against `main` confirms only `docs/model-deployment/vllm/qwen2.md` changes.