### PR TITLE
vllm: update Qwen2.5-VL 72B BW1100 command

### DIFF
--- a/docs/model-deployment/vllm/qwen2.5-vl.md
+++ b/docs/model-deployment/vllm/qwen2.5-vl.md
@@ -23,7 +23,7 @@ Qwen2.5-VL 是阿里通义千问视觉语言模型系列，支持图像、视频
 |  | BF16 | [0.18](../docker_images.md) | BW1100 | 4 | IFB | [**`>_`**](#qwen25-vl-72b-instruct-ifb-bw1100-4x-vllm-018) |
 |  | BF16 | [0.18](../docker_images.md) | BW1000 | 4 | IFB | [**`>_`**](#qwen25-vl-72b-instruct-ifb-bw1000-4x-vllm-018) |
 |  | BF16 | [0.18](../docker_images.md) | K100_AI | 8 | IFB | [**`>_`**](#qwen25-vl-72b-instruct-ifb-k100_ai-8x-vllm-018) |
-| hygon/Qwen2.5-VL-72B-Instruct-quantized.w8a8| INT8 W8A8 | 0.21 | BW1100 | 4 | IFB | [**`>_`**](#qwen25-vl-72b-instruct-quantizedw8a8-ifb-bw1100-4x-vllm-021) |
+| hygon/Qwen2.5-VL-72B-Instruct-quantized.w8a8| INT8 W8A8 | 0.21 | BW1100 | 1 | IFB | [**`>_`**](#qwen25-vl-72b-instruct-quantizedw8a8-ifb-bw1100-1x-vllm-021) |
 |  | INT8 W8A8 | 0.21 | BW1000 | 4 | IFB | [**`>_`**](#qwen25-vl-72b-instruct-quantizedw8a8-ifb-bw1000-4x-vllm-021) |
 |  | INT8 W8A8 | [0.18](../docker_images.md) | BW1100 | 4 | IFB | [**`>_`**](#qwen25-vl-72b-instruct-quantizedw8a8-ifb-bw1100-4x-vllm-018) |
 |  | INT8 W8A8 | [0.18](../docker_images.md) | BW1000 | 4 | IFB | [**`>_`**](#qwen25-vl-72b-instruct-quantizedw8a8-ifb-bw1000-4x-vllm-018) |
@@ -221,17 +221,16 @@ vllm serve Qwen/Qwen2.5-VL-72B-Instruct \
   --max-model-len 32768
 ```
 
-### Qwen2.5-VL-72B-Instruct-quantized.w8a8 IFB BW1100 4x vLLM 0.21
+### Qwen2.5-VL-72B-Instruct-quantized.w8a8 IFB BW1100 1x vLLM 0.21
 
 ```bash
 vllm serve hygon/Qwen2.5-VL-72B-Instruct-quantized.w8a8 \
-  -tp 4 \
+  -tp 1 \
   --trust-remote-code \
   --enable-chunked-prefill \
   --max-model-len 40960 \
   -q slimquant_marlin \
-  --attention-backend FLASH_ATTN_CUSTOM \
-  --allowed-local-media-path
+  --attention-backend FLASH_ATTN_CUSTOM
 ```
 
 ### Qwen2.5-VL-72B-Instruct-quantized.w8a8 IFB BW1000 4x vLLM 0.21


### PR DESCRIPTION
## Summary
- Update `Qwen2.5-VL-72B-Instruct-quantized.w8a8` BW1100 vLLM 0.21 command to 1 card.
- Remove `--allowed-local-media-path` from that BW1100 vLLM 0.21 command.

## Verification
- Remote compare against `main` confirms only `docs/model-deployment/vllm/qwen2.5-vl.md` changes.