### PR TITLE
vllm: fix GLM-5 INT4 speculative config

### DIFF
--- a/docs/model-deployment/vllm/glm-5.md
+++ b/docs/model-deployment/vllm/glm-5.md
@@ -44,7 +44,7 @@ vllm serve hygon/GLM-5-Channel-INT4-w4a8 \
     --block-size 64 \
     --speculative_config '{
         "method":"deepseek_mtp",
-        "num_speculative_tokens":2,
+        "num_speculative_tokens":2
     }' \
     --kv-cache-dtype fp8_ds_mla \
     --moe-backend aiter \
@@ -125,7 +125,7 @@ vllm serve hygon/GLM-5-Channel-INT4-w4a8 \
     --block-size 64 \
     --speculative_config '{
         "method":"deepseek_mtp",
-        "num_speculative_tokens":2,
+        "num_speculative_tokens":2
     }' \
     --kv-cache-dtype fp8_ds_mla
 ```


### PR DESCRIPTION
## Summary
- Remove the trailing comma after `"num_speculative_tokens":2` in GLM-5 INT4 BW1100 vLLM 0.21.
- Remove the same trailing comma in GLM-5 INT4 BW1100 vLLM 0.18.

## Verification
- Remote compare against `main` confirms only `docs/model-deployment/vllm/glm-5.md` changes.