### PR TITLE
vllm: use VL_DATA for 0.21 local media path

### DIFF
--- a/docs/model-deployment/vllm/qwen2.5-vl.md
+++ b/docs/model-deployment/vllm/qwen2.5-vl.md
@@ -38,7 +38,7 @@ vllm serve Qwen/Qwen2.5-VL-32B-Instruct \
     --trust-remote-code \
     --enable-chunked-prefill \
     --max-model-len 32768 \
-    --allowed-local-media-path /path-to/VL_data/ \
+    --allowed-local-media-path "${VL_DATA}" \
     --kv-cache-dtype fp8_e4m3 \
     --attention-backend FLASH_ATTN_CUSTOM
 ```
@@ -49,7 +49,7 @@ vllm serve Qwen/Qwen2.5-VL-32B-Instruct \
     -tp 2 \
     --trust-remote-code \
     --max-model-len 32768 \
-    --allowed-local-media-path /path-to/VL_data/ \
+    --allowed-local-media-path "${VL_DATA}" \
     --attention-backend FLASH_ATTN_CUSTOM
 ```
 ### Qwen2.5-VL-32B-Instruct IFB K100_AI 4x vLLM 0.21
@@ -62,7 +62,7 @@ vllm serve Qwen/Qwen2.5-VL-32B-Instruct \
     -tp 4 \
     --trust-remote-code \
     --max-model-len 32768 \
-    --allowed-local-media-path /path-to/VL_data/ \
+    --allowed-local-media-path "${VL_DATA}" \
     --attention-backend TRITON_ATTN
 ```
 ### Qwen2.5-VL-32B-Instruct IFB BW1100 1x vLLM 0.18
@@ -243,7 +243,7 @@ vllm serve hygon/Qwen2.5-VL-72B-Instruct-quantized.w8a8 \
   --max-model-len 40960 \
   -q slimquant_marlin \
   --attention-backend FLASH_ATTN_CUSTOM \
-  --allowed-local-media-path
+  --allowed-local-media-path "${VL_DATA}"
 ```
 
 ### Qwen2.5-VL-72B-Instruct-quantized.w8a8 IFB BW1100 4x vLLM 0.18


### PR DESCRIPTION
## Summary
- Update vLLM 0.21 `--allowed-local-media-path` usages to `--allowed-local-media-path "${VL_DATA}"`.

## Verification
- Remote compare against `main` confirms only `docs/model-deployment/vllm/qwen2.5-vl.md` changes.
- Add `--allowed-local-media-path "${VL_DATA}"` to the Qwen2.5-VL-72B quantized BW1100 vLLM 0.21 command.