### PR TITLE
vllm: merge Qwen3.8 model rows

### DIFF
--- a/docs/model-deployment/vllm/qwen3.8.md
+++ b/docs/model-deployment/vllm/qwen3.8.md
@@ -9,10 +9,13 @@ Qwen3.8 系列模型面向长上下文推理与工具调用场景，支持 vLLM 
 | 模型权重 | 量化方式 | vLLM 版本 | 推荐硬件 | 卡数 | 部署方式 | 启动命令 |
 | -------- | -------- | --------- | -------- | ---- | -------- | -------- |
 | [Qwen/Qwen3.8-27B](https://www.modelscope.cn/models/Qwen/Qwen3.8-27B) | BF16 | 0.21 | BW1100 | 1 | IFB | [**`>_`**](#qwen38-27b-ifb-bw1100-1x-vllm-021) |
-| [Qwen/Qwen3.8-27B](https://www.modelscope.cn/models/Qwen/Qwen3.8-27B) | BF16 | 0.21 | BW1000 | 2 | IFB | [**`>_`**](#qwen38-27b-ifb-bw1000-2x-vllm-021) |
+|  | BF16 | 0.21 | BW1000 | 2 | IFB | [**`>_`**](#qwen38-27b-ifb-bw1000-2x-vllm-021) |
+|  | BF16 | 0.18-hotfix | BW1000 | 2 | IFB | [**`>_`**](#qwen38-27b-ifb-bw1000-2x-vllm-018-hotfix) |
 | [hygon/Qwen3.8-27B-Channel-INT8-w8a8](https://www.modelscope.cn/models/hygon/Qwen3.8-27B-Channel-INT8-w8a8) | W8A8 | 0.21 | BW1100 | 1 | IFB | [**`>_`**](#qwen38-27b-channel-int8-w8a8-ifb-bw1100-1x-vllm-021) |
-| [hygon/Qwen3.8-27B-Channel-INT8-w8a8](https://www.modelscope.cn/models/hygon/Qwen3.8-27B-Channel-INT8-w8a8) | W8A8 | 0.21 | BW1000 | 1 | IFB | [**`>_`**](#qwen38-27b-channel-int8-w8a8-ifb-bw1000-1x-vllm-021) |
-| [hygon/Qwen3.8-27B-Channel-INT8-w8a8](https://www.modelscope.cn/models/hygon/Qwen3.8-27B-Channel-INT8-w8a8) | W8A8 | 0.21 | BW1000 | 2 | IFB | [**`>_`**](#qwen38-27b-channel-int8-w8a8-ifb-bw1000-2x-vllm-021) |
+|  | W8A8 | 0.21 | BW1000 | 1 | IFB | [**`>_`**](#qwen38-27b-channel-int8-w8a8-ifb-bw1000-1x-vllm-021) |
+|  | W8A8 | 0.21 | BW1000 | 2 | IFB | [**`>_`**](#qwen38-27b-channel-int8-w8a8-ifb-bw1000-2x-vllm-021) |
+|  | W8A8 | 0.18-hotfix | BW1000 | 1 | IFB | [**`>_`**](#qwen38-27b-channel-int8-w8a8-ifb-bw1000-1x-vllm-018-hotfix) |
+|  | W8A8 | 0.18-hotfix | BW1000 | 2 | IFB | [**`>_`**](#qwen38-27b-channel-int8-w8a8-ifb-bw1000-2x-vllm-018-hotfix) |
 
 ## 启动命令
 
@@ -29,7 +32,7 @@ vllm serve Qwen/Qwen3.8-27B \
   --compilation-config '{"cudagraph_mode":"FULL","max_cudagraph_capture_size":2048}' 
 ```
 
-### Qwen3.8-27B IFB BW1100 2x vLLM 0.21
+### Qwen3.8-27B IFB BW1000 2x vLLM 0.21
 
 ```bash
 vllm serve Qwen/Qwen3.8-27B \
@@ -40,6 +43,21 @@ vllm serve Qwen/Qwen3.8-27B \
   --speculative-config.method mtp \
   --speculative-config.num_speculative_tokens 3 \
   --compilation-config '{"cudagraph_mode":"FULL","max_cudagraph_capture_size":2048}'
+```
+
+### Qwen3.8-27B IFB BW1000 2x vLLM 0.18-hotfix
+
+```bash
+vllm serve Qwen/Qwen3.8-27B \
+  -tp 2 \
+  --served-model-name "$SERVED_MODEL_NAME" \
+  --trust-remote-code \
+  --attention-backend FLASH_ATTN_CUSTOM \
+  --no-enable-prefix-caching \
+  --max-num-batched-tokens 10240 \
+  --compilation-config '{"cudagraph_mode":"FULL","max_cudagraph_capture_size":2048}' \
+  --speculative-config.method mtp \
+  --speculative-config.num_speculative_tokens 3
 ```
 
 ### Qwen3.8-27B-Channel-INT8-w8a8 IFB BW1100 1x vLLM 0.21
@@ -85,6 +103,38 @@ vllm serve hygon/Qwen3.8-27B-Channel-INT8-w8a8 \
   -q slimquant_marlin \
   --compilation-config '{"cudagraph_mode":"FULL","max_cudagraph_capture_size":2048}' \
   --speculative-config.quantization "slimquant_marlin"
+```
+
+### Qwen3.8-27B-Channel-INT8-w8a8 IFB BW1000 1x vLLM 0.18-hotfix
+
+```bash
+vllm serve hygon/Qwen3.8-27B-Channel-INT8-w8a8 \
+  -tp 1 \
+  --served-model-name "$SERVED_MODEL_NAME" \
+  --trust-remote-code \
+  --attention-backend FLASH_ATTN_CUSTOM \
+  --max-num-batched-tokens 10240 \
+  --compilation-config '{"cudagraph_mode":"FULL","max_cudagraph_capture_size":2048}' \
+  --speculative-config.method mtp \
+  --speculative-config.quantization "slimquant_marlin" \
+  -q slimquant_marlin \
+  --speculative-config.num_speculative_tokens 3
+```
+
+### Qwen3.8-27B-Channel-INT8-w8a8 IFB BW1000 2x vLLM 0.18-hotfix
+
+```bash
+vllm serve hygon/Qwen3.8-27B-Channel-INT8-w8a8 \
+  -tp 2 \
+  --served-model-name "$SERVED_MODEL_NAME" \
+  --trust-remote-code \
+  --attention-backend FLASH_ATTN_CUSTOM \
+  --max-num-batched-tokens 10240 \
+  --compilation-config '{"cudagraph_mode":"FULL","max_cudagraph_capture_size":2048}' \
+  --speculative-config.method mtp \
+  --speculative-config.num_speculative_tokens 3 \
+  --speculative-config.quantization "slimquant_marlin" \
+  -q slimquant_marlin
 ```
 
 ## API 调用


### PR DESCRIPTION
## Summary
- Carry over #332 Qwen3.8 vLLM 0.18-hotfix additions.
- Merge model-list rows so each Qwen3.8 model name appears once and subsequent configurations use blank model cells.

## Note
- #332 uses a fork branch that this token cannot push to directly, so this PR provides the same content with the requested row merge from a writable branch.

## Verification
- Remote compare against `main` confirms only `docs/model-deployment/vllm/qwen3.8.md` changes.