### PR TITLE
vllm: update Qwen3.8 homepage support

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@
       <td rowspan="20" align="center"><img src="https://cdn-avatars.huggingface.co/v1/production/uploads/620760a26e3b7210c2ff1943/-s1gyJfvbE1RgO5iBeNOi.png" height="40"/><br/>Qwen</td>
       <td rowspan="2">Qwen3.8</td>
       <td>vLLM</td>
-      <td align="center"><a href="docs/model-deployment/vllm/qwen3.8.md">✅</a></td><td align="center"><a href="docs/model-deployment/vllm/qwen3.8.md">✅</a></td><td align="center"><a href="docs/model-deployment/vllm/qwen3.8.md">✅</a></td>
+      <td align="center">-</td><td align="center"><a href="docs/model-deployment/vllm/qwen3.8.md">✅</a></td><td align="center"><a href="docs/model-deployment/vllm/qwen3.8.md">✅</a></td>
     </tr>
     <tr>
       <td>SGLang</td>

--- a/README.md
+++ b/README.md
@@ -28,7 +28,16 @@
   </tr>
   <tbody>
     <tr>
-      <td rowspan="18" align="center"><img src="https://cdn-avatars.huggingface.co/v1/production/uploads/620760a26e3b7210c2ff1943/-s1gyJfvbE1RgO5iBeNOi.png" height="40"/><br/>Qwen</td>
+      <td rowspan="20" align="center"><img src="https://cdn-avatars.huggingface.co/v1/production/uploads/620760a26e3b7210c2ff1943/-s1gyJfvbE1RgO5iBeNOi.png" height="40"/><br/>Qwen</td>
+      <td rowspan="2">Qwen3.8</td>
+      <td>vLLM</td>
+      <td align="center"><a href="docs/model-deployment/vllm/qwen3.8.md">✅</a></td><td align="center"><a href="docs/model-deployment/vllm/qwen3.8.md">✅</a></td><td align="center"><a href="docs/model-deployment/vllm/qwen3.8.md">✅</a></td>
+    </tr>
+    <tr>
+      <td>SGLang</td>
+      <td align="center">-</td><td align="center">-</td><td align="center">-</td>
+    </tr>
+    <tr>
       <td rowspan="2">Qwen3.6</td>
       <td>vLLM</td>
       <td align="center"><a href="docs/model-deployment/vllm/qwen3.6.md">✅</a></td><td align="center"><a href="docs/model-deployment/vllm/qwen3.6.md">✅</a></td><td align="center"><a href="docs/model-deployment/vllm/qwen3.6.md">✅</a></td>


### PR DESCRIPTION
## Summary
- add Qwen3.8 vLLM support link to the homepage model list
- update the Qwen section rowspan for the new model row

## Verification
- checked README.md contains Qwen3.8 and links to docs/model-deployment/vllm/qwen3.8.md