### PR TITLE
vllm: update Qwen3-VL 235B vLLM 0.21 commands

### DIFF
--- a/docs/model-deployment/vllm/qwen3-vl.md
+++ b/docs/model-deployment/vllm/qwen3-vl.md
@@ -935,8 +935,8 @@ export VLLM_USE_MODELSCOPE=1
 vllm serve Qwen/Qwen3-VL-235B-A22B-Instruct \
   -tp 8 \
   --trust-remote-code \
-  --kv-cache-dtype fp8_e4m3 \
-  --attention-backend FLASH_ATTN_CUSTOM
+  --attention-backend FLASH_ATTN_CUSTOM \
+  --moe-backend aiter
 ```
 ### Qwen3-VL-235B-A22B-Instruct IFB BW1000 16x vLLM 0.21
 
@@ -1055,8 +1055,9 @@ export VLLM_USE_MODELSCOPE=1
 vllm serve Qwen/Qwen3-VL-235B-A22B-Thinking \
   -tp 8 \
   --trust-remote-code \
-  --kv-cache-dtype fp8_e4m3 \
-  --attention-backend FLASH_ATTN_CUSTOM
+  --attention-backend FLASH_ATTN_CUSTOM \
+  --moe-backend aiter \
+  --reasoning-parser qwen3
 ```
 ### Qwen3-VL-235B-A22B-Thinking IFB BW1000 16x vLLM 0.21
 

--- a/docs/model-deployment/vllm/qwen3-vl.md
+++ b/docs/model-deployment/vllm/qwen3-vl.md
@@ -936,7 +936,8 @@ vllm serve Qwen/Qwen3-VL-235B-A22B-Instruct \
   -tp 8 \
   --trust-remote-code \
   --attention-backend FLASH_ATTN_CUSTOM \
-  --moe-backend aiter
+  --moe-backend aiter \
+  --kv-cache-dtype fp8_e4m3
 ```
 ### Qwen3-VL-235B-A22B-Instruct IFB BW1000 16x vLLM 0.21
 
@@ -1057,6 +1058,7 @@ vllm serve Qwen/Qwen3-VL-235B-A22B-Thinking \
   --trust-remote-code \
   --attention-backend FLASH_ATTN_CUSTOM \
   --moe-backend aiter \
+  --kv-cache-dtype fp8_e4m3 \
   --reasoning-parser qwen3
 ```
 ### Qwen3-VL-235B-A22B-Thinking IFB BW1000 16x vLLM 0.21


### PR DESCRIPTION
## Summary

- update Qwen3-VL-235B-A22B Instruct and Thinking BW1100 8x vLLM 0.21 commands
- use AITER MoE for both commands
- add the qwen3 reasoning parser for the Thinking command
- remove the FP8 KV cache override from both commands

## Verification

- verified only the two BW1100 8x vLLM 0.21 command sections changed
- verified BW1000, K100_AI, vLLM 0.18, and vLLM 0.18-hotfix sections are unchanged
- git diff --check