### PR TITLE
vllm: update Qwen3.5-122B-A10B BW1100 command

### DIFF
--- a/docs/model-deployment/vllm/qwen3.5.md
+++ b/docs/model-deployment/vllm/qwen3.5.md
@@ -793,15 +793,15 @@ vllm serve hygon/Qwen3.5-35B-A3B-Channel-FP8-w8a8 \
 ### Qwen3.5-122B-A10B IFB BW1100 4x vLLM 0.21
 
 ```bash
-vllm serve Qwen/Qwen3.5-122B-A10B \
+vllm serve /llm-models/qwen3.5/Qwen3.5-122B-A10B \
   -tp 4 \
   --trust-remote-code \
   --max-num-batched-tokens 16384 \
   --speculative-config.method mtp \
   --speculative-config.num_speculative_tokens 3 \
-  --kv-cache-dtype fp8_e4m3 \
   --attention-backend FLASH_ATTN_CUSTOM \
   --moe-backend aiter \
+  --kv-cache-dtype fp8_e4m3 \
   --max-num-seqs 128
 ```
 


### PR DESCRIPTION
## Summary
- update the Qwen3.5-122B-A10B BW1100 vLLM 0.21 command to use the local /llm-models path
- keep the existing 4x vLLM 0.21 table entry and update only its command block

## Verification
- checked the PR diff only changes docs/model-deployment/vllm/qwen3.5.md
- checked the updated command block contains the requested parameters