### PR TITLE
vllm: update Qwen3 235B FP8 BW1100 command

### DIFF
--- a/docs/model-deployment/vllm/qwen3.md
+++ b/docs/model-deployment/vllm/qwen3.md
@@ -1651,13 +1651,13 @@ vllm serve Qwen/Qwen3-235B-A22B-Channel-INT8-w8a8 \
 ### Qwen3-235B-A22B-FP8-Channelwise IFB BW1100 4x vLLM 0.21
 
 ```bash
-
 vllm serve Qwen/Qwen3-235B-A22B-FP8-Channelwise \
   -tp 4 \
   --trust-remote-code \
   --max-num-batched-tokens 10240 \
   --kv-cache-dtype fp8_e4m3 \
-  --attention-backend FLASH_ATTN_CUSTOM
+  --attention-backend FLASH_ATTN_CUSTOM \
+  --moe-backend triton
 ```
 
 ### Qwen3-235B-A22B-FP8-Channelwise IFB BW1100 4x vLLM 0.18


### PR DESCRIPTION
## Summary
- update the Qwen3-235B-A22B-FP8-Channelwise BW1100 vLLM 0.21 command
- add the requested triton MoE backend while preserving the existing fp8 kv-cache dtype

## Verification
- checked the PR diff only changes docs/model-deployment/vllm/qwen3.md
- checked the target command block matches the requested command