### PR TITLE
vllm: update Qwen3.5 122B W8A8 BW1100 command

### DIFF
--- a/docs/model-deployment/vllm/qwen3.5.md
+++ b/docs/model-deployment/vllm/qwen3.5.md
@@ -933,13 +933,12 @@ vllm serve Qwen/Qwen3.5-122B-A10B-W8A8-INT8 \
   -tp 2 \
   --trust-remote-code \
   --max-num-batched-tokens 16384 \
-  -q slimquant_marlin \
   --speculative-config.method mtp \
   --speculative-config.num_speculative_tokens 3 \
-  --speculative-config.quantization "slimquant_marlin" \
   --kv-cache-dtype fp8_e4m3 \
   --attention-backend FLASH_ATTN_CUSTOM \
-  --max-num-seqs 128
+  --max-num-seqs 128 \
+  --moe-backend triton
 ```
 
 ### Qwen3.5-122B-A10B-W8A8-INT8 IFB BW1000 4x vLLM 0.21


### PR DESCRIPTION
## Summary
- update the Qwen3.5-122B-A10B-W8A8-INT8 BW1100 vLLM 0.21 command
- switch the command to the requested triton MoE backend form

## Verification
- checked the PR diff only changes docs/model-deployment/vllm/qwen3.5.md
- checked the target command block matches the requested command