### PR TITLE
docs: add Step-3.5-Flash and Step-3.7-Flash vLLM deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,10 +268,19 @@
       <td align="center">-</td><td align="center">-</td><td align="center">-</td>
     </tr>
     <tr>
-      <td rowspan="2" align="center"><img src="https://cdn-avatars.huggingface.co/v1/production/uploads/644f7e6233ac8f46fa0b9e26/CmF2ocXhkr2UtHXgmwq7-.png" height="40"/><br/>StepFun</td>
+      <td rowspan="4" align="center"><img src="https://cdn-avatars.huggingface.co/v1/production/uploads/644f7e6233ac8f46fa0b9e26/CmF2ocXhkr2UtHXgmwq7-.png" height="40"/><br/>StepFun</td>
+      <td rowspan="2">Step-3.7-Flash</td>
+      <td>vLLM</td>
+      <td align="center">-</td><td align="center">-</td><td align="center"><a href="docs/model-deployment/vllm/step-3.7-flash.md">✅</a></td>
+    </tr>
+    <tr>
+      <td>SGLang</td>
+      <td align="center">-</td><td align="center">-</td><td align="center">-</td>
+    </tr>
+    <tr>
       <td rowspan="2">Step-3.5</td>
       <td>vLLM</td>
-      <td align="center">🚧</td><td align="center">🚧</td><td align="center">🚧</td>
+      <td align="center">🚧</td><td align="center">🚧</td><td align="center"><a href="docs/model-deployment/vllm/step-3.5.md">✅</a></td>
     </tr>
     <tr>
       <td>SGLang</td>

--- a/docs/model-deployment/vllm/step-3.5.md
+++ b/docs/model-deployment/vllm/step-3.5.md
@@ -1,0 +1,77 @@
+# Step-3.5-Flash on vLLM
+
+## 模型简介
+
+Step-3.5-Flash 是 StepFun 发布的 Step 系列大语言模型，本文档提供其在 vLLM 上的部署示例。
+
+## 模型列表
+
+| 模型权重 | 量化方式 | vLLM 版本 | 推荐硬件 | 卡数 | 部署方式 | 启动命令 |
+| -------- | -------- | --------- | -------- | ---- | -------- | -------- |
+| [stepfun-ai/Step-3.5-Flash-FP8](https://www.modelscope.cn/models/stepfun-ai/Step-3.5-Flash-FP8) | FP8 | 0.21 | BW1100 | 8 | IFB | [**`>_`**](#step-35-flash-fp8-ifb-bw1100-8x-vllm-021) |
+|  | FP8 | 0.18 | BW1100 | 8 | IFB | [**`>_`**](#step-35-flash-fp8-ifb-bw1100-8x-vllm-018) |
+
+## 启动命令
+
+### Step-3.5-Flash-FP8 IFB BW1100 8x vLLM 0.21
+
+```bash
+export GPU_MAX_HW_QUEUES=4
+
+vllm serve stepfun-ai/Step-3.5-Flash-FP8 \
+  --tensor-parallel-size 8 \
+  --trust-remote-code \
+  -q slimquant_marlin \
+  --no-enable-prefix-caching \
+  --enable-chunked-prefill \
+  --max-num-batched-tokens 65536 \
+  --kv-cache-dtype fp8_e4m3 \
+  --speculative-config '{"method":"mtp","num_speculative_tokens":3,"enable_multi_layers_mtp":true,"quantization":"slimquant_marlin"}' \
+  --gpu-memory-utilization 0.9 \
+  --attention-backend FLASH_ATTN_CUTLASS
+```
+
+### Step-3.5-Flash-FP8 IFB BW1100 8x vLLM 0.18
+
+```bash
+export GPU_MAX_HW_QUEUES=4
+
+vllm serve stepfun-ai/Step-3.5-Flash-FP8 \
+  --tensor-parallel-size 8 \
+  --trust-remote-code \
+  -q slimquant_marlin \
+  --no-enable-prefix-caching \
+  --enable-chunked-prefill \
+  --max-num-batched-tokens 65536 \
+  --kv-cache-dtype fp8_e4m3 \
+  --speculative-config '{"method":"mtp","num_speculative_tokens":3,"enable_multi_layers_mtp":true,"quantization":"slimquant_marlin"}' \
+  --gpu-memory-utilization 0.9 \
+  --attention-backend FLASH_ATTN_CUTLASS
+```
+
+## API 调用
+
+### IFB
+
+```python
+from openai import OpenAI
+
+client = OpenAI(base_url="http://localhost:8000/v1", api_key="not-needed")
+
+response = client.chat.completions.create(
+    model="stepfun-ai/Step-3.5-Flash-FP8",  # 替换为实际使用的模型名
+    messages=[{"role": "user", "content": "中国的首都是什么？"}],
+    max_tokens=400,
+)
+```
+
+```bash
+curl http://localhost:8000/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+      "model": "stepfun-ai/Step-3.5-Flash-FP8",
+      "messages": [{"role": "user", "content": "中国的首都是什么？"}],
+      "temperature": 0,
+      "max_tokens": 400
+  }'
+```

--- a/docs/model-deployment/vllm/step-3.7-flash.md
+++ b/docs/model-deployment/vllm/step-3.7-flash.md
@@ -9,6 +9,7 @@ Step-3.7-Flash 是 Step 系列大语言模型，本文档提供其在 vLLM 上�
 | 模型权重 | 量化方式 | vLLM 版本 | 推荐硬件 | 卡数 | 部署方式 | 启动命令 |
 | -------- | -------- | --------- | -------- | ---- | -------- | -------- |
 | [hygon/Step-3.7-Flash-FP8-Channel](https://www.modelscope.cn/models/hygon/Step-3.7-Flash-FP8-Channel) | FP8 Channel | 0.21 | BW1100 | 8 | IFB | [**`>_`**](#step-37-flash-fp8-channel-ifb-bw1100-8x-vllm-021) |
+|  | FP8 Channel | 0.18 | BW1100 | 8 | IFB | [**`>_`**](#step-37-flash-fp8-channel-ifb-bw1100-8x-vllm-018) |
 
 ## 启动命令
 
@@ -28,6 +29,24 @@ vllm serve hygon/Step-3.7-Flash-FP8-Channel \
     --speculative-config '{"method":"mtp","num_speculative_tokens":3,"enable_multi_layers_mtp":true,"quantization":"slimquant_marlin"}' \
     --gpu-memory-utilization 0.9 \
     --attention-backend FLASH_ATTN_CUTLASS
+```
+
+### Step-3.7-Flash-FP8-Channel IFB BW1100 8x vLLM 0.18
+
+```bash
+export GPU_MAX_HW_QUEUES=4
+
+vllm serve hygon/Step-3.7-Flash-FP8-Channel \
+  --tensor-parallel-size 8 \
+  --trust-remote-code \
+  -q slimquant_marlin \
+  --no-enable-prefix-caching \
+  --enable-chunked-prefill \
+  --max-num-batched-tokens 65536 \
+  --kv-cache-dtype fp8_e4m3 \
+  --speculative-config '{"method":"mtp","num_speculative_tokens":3,"enable_multi_layers_mtp":true,"quantization":"slimquant_marlin"}' \
+  --gpu-memory-utilization 0.9 \
+  --attention-backend FLASH_ATTN_CUTLASS
 ```
 
 ## API 调用


### PR DESCRIPTION
新增 stepfun-ai/Step-3.5-Flash-FP8 部署文档，覆盖 vLLM 0.21 与 0.18 在 BW1100 上的 IFB 记录；为已有的 hygon/Step-3.7-Flash-FP8-Channel 补充 vLLM 0.18 记录。同步更新 README 支持矩阵，新增 Step-3.7-Flash 条目并将 Step-3.5 的 vLLM BW1100 标记为已验证。