### PR TITLE
vllm: update Qwen2 57B BW1100 command

### DIFF
--- a/docs/model-deployment/vllm/qwen2.md
+++ b/docs/model-deployment/vllm/qwen2.md
@@ -382,12 +382,13 @@ vllm serve Qwen/Qwen2-7B-Instruct \
 
 ```bash
 export VLLM_USE_MODELSCOPE=1
+export VLLM_HCU_USE_CUSTOM_OPS=0
 
 vllm serve Qwen/Qwen2-57B-A14B-Instruct \
   -tp 2 \
   --trust-remote-code \
-  --kv-cache-dtype fp8_e4m3 \
-  --attention-backend FLASH_ATTN_CUSTOM
+  --attention-backend FLASH_ATTN_CUSTOM \
+  --moe-backend triton
 ```
 
 ### Qwen2-57B-A14B-Instruct IFB BW1000 4x vLLM 0.21


### PR DESCRIPTION
## Summary
- update the Qwen2-57B-A14B-Instruct BW1100 vLLM 0.21 command
- add VLLM_HCU_USE_CUSTOM_OPS=0 and switch MoE backend to triton

## Verification
- checked the PR diff only changes docs/model-deployment/vllm/qwen2.md
- checked the target command block matches the requested command