### PR TITLE
sglang: add Qwen3.5 and Qwen3.6 BW1000 configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@
     </tr>
     <tr>
       <td>SGLang</td>
-      <td align="center">🚧</td><td align="center">🚧</td><td align="center"><a href="docs/model-deployment/sglang/qwen3.6.md">✅</a></td>
+      <td align="center">🚧</td><td align="center"><a href="docs/model-deployment/sglang/qwen3.6.md">✅</a></td><td align="center"><a href="docs/model-deployment/sglang/qwen3.6.md">✅</a></td>
     </tr>
     <tr>
       <td rowspan="2">Qwen3.5</td>

--- a/docs/model-deployment/sglang/qwen3.5.md
+++ b/docs/model-deployment/sglang/qwen3.5.md
@@ -93,7 +93,6 @@ sglang serve \
   --dtype bfloat16 \
   --attention-backend fa3 \
   --mm-attention-backend fa3 \
-  --host xxxxx \
   --mem-fraction-static 0.9 \
   --page-size 64 \
   --tp-size 2 \
@@ -156,7 +155,6 @@ sglang serve \
   --dtype bfloat16 \
   --attention-backend fa3 \
   --mm-attention-backend fa3 \
-  --host xxxxx \
   --mem-fraction-static 0.9 \
   --page-size 64 \
   --tp-size 2 \

--- a/docs/model-deployment/sglang/qwen3.5.md
+++ b/docs/model-deployment/sglang/qwen3.5.md
@@ -105,6 +105,7 @@ sglang serve \
   --speculative-num-draft-tokens 4 \
   --mamba-scheduler-strategy extra_buffer \
   --chunked-prefill-size -1 \
+  --kv-cache-dtype fp8_e5m2 \
   --tool-call-parser qwen3_coder \
   --reasoning-parser qwen3
 ```
@@ -166,6 +167,7 @@ sglang serve \
   --speculative-num-draft-tokens 4 \
   --mamba-scheduler-strategy extra_buffer \
   --chunked-prefill-size -1 \
+  --kv-cache-dtype fp8_e5m2 \
   --quantization w8a8_int8 \
   --moe-runner-backend lightop \
   --tool-call-parser qwen3_coder \

--- a/docs/model-deployment/sglang/qwen3.5.md
+++ b/docs/model-deployment/sglang/qwen3.5.md
@@ -10,7 +10,9 @@ Qwen3.5 是 Qwen3 系列的增强版本，在推理能力、代码生成、多�
 | -------- | -------- | ----------- | -------- | ---- | -------- | -------- |
 | [Qwen/Qwen3.5-27B](https://www.modelscope.cn/models/Qwen/Qwen3.5-27B) | BF16 | 0.5.10 | BW1100 | 2 | IFB | [**`>_`**](#qwen35-27b-ifb-bw1100-2x-sglang-0510) |
 |                                                                       | BF16 | 0.5.10 | K100_AI | 2 | IFB | [**`>_`**](#qwen35-27b-ifb-k100_ai-2x-sglang-0510) |
-| [Qwen/Qwen3.5-35B-A3B](https://www.modelscope.cn/models/Qwen/Qwen3.5-35B-A3B) | BF16 | 0.5.10 | BW1100 | 2 | IFB | [**`>_`**](#qwen35-35b-a3b-ifb-bw1100-2x-sglang-0510) |
+| [Qwen/Qwen3.5-35B-A3B](https://www.modelscope.cn/models/Qwen/Qwen3.5-35B-A3B) | BF16 | 0.5.12 | BW1000 | 2 | IFB | [**`>_`**](#qwen35-35b-a3b-ifb-bw1000-2x-sglang-0512) |
+|                                                                       | BF16 | 0.5.10 | BW1100 | 2 | IFB | [**`>_`**](#qwen35-35b-a3b-ifb-bw1100-2x-sglang-0510) |
+| [hygon/Qwen3.5-35B-A3B-Channel-INT8-w8a8](https://www.modelscope.cn/models/hygon/Qwen3.5-35B-A3B-Channel-INT8-w8a8) | INT8 W8A8 | 0.5.12 | BW1000 | 2 | IFB | [**`>_`**](#qwen35-35b-a3b-channel-int8-w8a8-ifb-bw1000-2x-sglang-0512) |
 | [hygon/Qwen3.5-35B-A3B-Channel-FP8-w8a8](https://www.modelscope.cn/models/hygon/Qwen3.5-35B-A3B-Channel-FP8-w8a8) | FP8 W8A8 | 0.5.10 | BW1100 | 2 | IFB | [**`>_`**](#qwen35-35b-a3b-channel-fp8-w8a8-ifb-bw1100-2x-sglang-0510) |
 
 ### Qwen3.5-397B-A17B 部署配置
@@ -75,6 +77,40 @@ sglang serve --model-path Qwen/Qwen3.5-27B \
     --speculative-num-draft-tokens 2
 ```
 
+### Qwen3.5-35B-A3B IFB BW1000 2x SGLang 0.5.12
+
+```bash
+export SGLANG_ENABLE_SPEC_V2=1
+export SGLANG_USE_FUSED_TOPK_SOFTMAX=1
+export SGLANG_USE_LIGHTOP=1
+export SGLANG_USE_CAUSAL_CONV1D=1
+export SGLANG_USE_AITER_LINEAR_ATTN=1
+export SGLANG_USE_CUDA_IPC_TRANSPORT=1
+export SGLANG_USE_MODELSCOPE=1
+
+sglang serve \
+  --model-path Qwen/Qwen3.5-35B-A3B \
+  --dtype bfloat16 \
+  --attention-backend fa3 \
+  --mm-attention-backend fa3 \
+  --host xxxxx \
+  --mem-fraction-static 0.9 \
+  --page-size 64 \
+  --tp-size 2 \
+  --pp-size 1 \
+  --trust-remote-code \
+  --speculative-algorithm EAGLE \
+  --enable-piecewise-cuda-graph \
+  --speculative-num-steps 3 \
+  --speculative-eagle-topk 1 \
+  --speculative-num-draft-tokens 4 \
+  --mamba-scheduler-strategy extra_buffer \
+  --chunked-prefill-size -1 \
+  --kv-cache-dtype fp8_e5m2 \
+  --tool-call-parser qwen3_coder \
+  --reasoning-parser qwen3
+```
+
 ### Qwen3.5-35B-A3B IFB BW1100 2x SGLang 0.5.10
 
 ```bash
@@ -103,6 +139,42 @@ sglang serve --model-path Qwen/Qwen3.5-35B-A3B \
 ```
 
 > NMZ 卡使用 `fp8_e4m3`，非 NMZ 卡使用 `fp8_e5m2`，请按照使用硬件情况进行配置。
+
+### Qwen3.5-35B-A3B-Channel-INT8-w8a8 IFB BW1000 2x SGLang 0.5.12
+
+```bash
+export SGLANG_ENABLE_SPEC_V2=1
+export SGLANG_USE_FUSED_TOPK_SOFTMAX=1
+export SGLANG_USE_LIGHTOP=1
+export SGLANG_USE_CAUSAL_CONV1D=1
+export SGLANG_USE_AITER_LINEAR_ATTN=1
+export SGLANG_USE_CUDA_IPC_TRANSPORT=1
+export SGLANG_USE_MODELSCOPE=1
+
+sglang serve \
+  --model-path hygon/Qwen3.5-35B-A3B-Channel-INT8-w8a8 \
+  --dtype bfloat16 \
+  --attention-backend fa3 \
+  --mm-attention-backend fa3 \
+  --host xxxxx \
+  --mem-fraction-static 0.9 \
+  --page-size 64 \
+  --tp-size 2 \
+  --pp-size 1 \
+  --trust-remote-code \
+  --speculative-algorithm EAGLE \
+  --enable-piecewise-cuda-graph \
+  --speculative-num-steps 3 \
+  --speculative-eagle-topk 1 \
+  --speculative-num-draft-tokens 4 \
+  --mamba-scheduler-strategy extra_buffer \
+  --chunked-prefill-size -1 \
+  --kv-cache-dtype fp8_e5m2 \
+  --quantization w8a8_int8 \
+  --moe-runner-backend lightop \
+  --tool-call-parser qwen3_coder \
+  --reasoning-parser qwen3
+```
 
 ### Qwen3.5-35B-A3B-Channel-FP8-w8a8 IFB BW1100 2x SGLang 0.5.10
 

--- a/docs/model-deployment/sglang/qwen3.5.md
+++ b/docs/model-deployment/sglang/qwen3.5.md
@@ -105,7 +105,6 @@ sglang serve \
   --speculative-num-draft-tokens 4 \
   --mamba-scheduler-strategy extra_buffer \
   --chunked-prefill-size -1 \
-  --kv-cache-dtype fp8_e5m2 \
   --tool-call-parser qwen3_coder \
   --reasoning-parser qwen3
 ```
@@ -167,7 +166,6 @@ sglang serve \
   --speculative-num-draft-tokens 4 \
   --mamba-scheduler-strategy extra_buffer \
   --chunked-prefill-size -1 \
-  --kv-cache-dtype fp8_e5m2 \
   --quantization w8a8_int8 \
   --moe-runner-backend lightop \
   --tool-call-parser qwen3_coder \

--- a/docs/model-deployment/sglang/qwen3.6.md
+++ b/docs/model-deployment/sglang/qwen3.6.md
@@ -69,6 +69,7 @@ sglang serve \
   --speculative-num-draft-tokens 4 \
   --mamba-scheduler-strategy extra_buffer \
   --chunked-prefill-size -1 \
+  --kv-cache-dtype fp8_e5m2 \
   --tool-call-parser qwen3_coder \
   --reasoning-parser qwen3
 ```
@@ -130,6 +131,7 @@ sglang serve \
   --chunked-prefill-size -1 \
   --quantization w8a8_int8 \
   --moe-runner-backend lightop \
+  --kv-cache-dtype fp8_e5m2 \
   --tool-call-parser qwen3_coder \
   --reasoning-parser qwen3
 ```

--- a/docs/model-deployment/sglang/qwen3.6.md
+++ b/docs/model-deployment/sglang/qwen3.6.md
@@ -58,7 +58,6 @@ sglang serve \
   --attention-backend fa3 \
   --mm-attention-backend fa3 \
   --mem-fraction-static 0.9 \
-  --host xxxxx \
   --page-size 64 \
   --tp-size 2 \
   --pp-size 1 \
@@ -119,7 +118,6 @@ sglang serve \
   --attention-backend fa3 \
   --mm-attention-backend fa3 \
   --mem-fraction-static 0.9 \
-  --host xxxxx \
   --page-size 64 \
   --tp-size 2 \
   --pp-size 1 \

--- a/docs/model-deployment/sglang/qwen3.6.md
+++ b/docs/model-deployment/sglang/qwen3.6.md
@@ -10,7 +10,9 @@ Qwen3.6 模型相较于 Qwen3.5 模型，**在智能体编程能力、推理速�
 | 模型权重 | 量化方式 | SGLang 版本 | 推荐硬件 | 卡数 | 部署方式 | 启动命令 |
 | -------- | -------- | ----------- | -------- | ---- | -------- | -------- |
 | [Qwen/Qwen3.6-27B](https://www.modelscope.cn/models/Qwen/Qwen3.6-27B) | BF16 | 0.5.10 | BW1100 | 2 | IFB | [**`>_`**](#qwen36-27b-ifb-bw1100-2x-sglang-0510) |
-| [Qwen/Qwen3.6-35B-A3B](https://www.modelscope.cn/models/Qwen/Qwen3.6-35B-A3B) | BF16 | 0.5.10 | BW1100 | 2 | IFB | [**`>_`**](#qwen36-35b-a3b-ifb-bw1100-2x-sglang-0510) |
+| [Qwen/Qwen3.6-35B-A3B](https://www.modelscope.cn/models/Qwen/Qwen3.6-35B-A3B) | BF16 | 0.5.12 | BW1000 | 2 | IFB | [**`>_`**](#qwen36-35b-a3b-ifb-bw1000-2x-sglang-0512) |
+|                                                                       | BF16 | 0.5.10 | BW1100 | 2 | IFB | [**`>_`**](#qwen36-35b-a3b-ifb-bw1100-2x-sglang-0510) |
+| [hygon/Qwen3.6-35B-A3B-Channel-INT8-w8a8](https://www.modelscope.cn/models/hygon/Qwen3.6-35B-A3B-Channel-INT8-w8a8) | INT8 W8A8 | 0.5.12 | BW1000 | 2 | IFB | [**`>_`**](#qwen36-35b-a3b-channel-int8-w8a8-ifb-bw1000-2x-sglang-0512) |
 
 
 ## 启动命令
@@ -39,6 +41,40 @@ sglang serve --model-path Qwen/Qwen3.6-27B \
     --trust-remote-code
 ```
 
+### Qwen3.6-35B-A3B IFB BW1000 2x SGLang 0.5.12
+
+```bash
+export SGLANG_ENABLE_SPEC_V2=1
+export SGLANG_USE_FUSED_TOPK_SOFTMAX=1
+export SGLANG_USE_LIGHTOP=1
+export SGLANG_USE_CAUSAL_CONV1D=1
+export SGLANG_USE_AITER_LINEAR_ATTN=1
+export SGLANG_USE_CUDA_IPC_TRANSPORT=1
+export SGLANG_USE_MARLIN_W16A16_MOE=1
+
+sglang serve \
+  --model-path Qwen/Qwen3.6-35B-A3B \
+  --dtype bfloat16 \
+  --attention-backend fa3 \
+  --mm-attention-backend fa3 \
+  --mem-fraction-static 0.9 \
+  --host xxxxx \
+  --page-size 64 \
+  --tp-size 2 \
+  --pp-size 1 \
+  --trust-remote-code \
+  --speculative-algorithm EAGLE \
+  --enable-piecewise-cuda-graph \
+  --speculative-num-steps 3 \
+  --speculative-eagle-topk 1 \
+  --speculative-num-draft-tokens 4 \
+  --mamba-scheduler-strategy extra_buffer \
+  --chunked-prefill-size -1 \
+  --kv-cache-dtype fp8_e5m2 \
+  --tool-call-parser qwen3_coder \
+  --reasoning-parser qwen3
+```
+
 ### Qwen3.6-35B-A3B IFB BW1100 2x SGLang 0.5.10
 
 ```bash
@@ -64,6 +100,42 @@ sglang serve --model-path Qwen/Qwen3.6-35B-A3B \
     --kv-cache-dtype fp8_e4m3 \
     --trust-remote-code \
     --chunked-prefill-size -1
+```
+
+### Qwen3.6-35B-A3B-Channel-INT8-w8a8 IFB BW1000 2x SGLang 0.5.12
+
+```bash
+export SGLANG_ENABLE_SPEC_V2=1
+export SGLANG_USE_FUSED_TOPK_SOFTMAX=1
+export SGLANG_USE_LIGHTOP=1
+export SGLANG_USE_CAUSAL_CONV1D=1
+export SGLANG_USE_AITER_LINEAR_ATTN=1
+export SGLANG_USE_CUDA_IPC_TRANSPORT=1
+export SGLANG_ROCM_USE_AITER_MOE=0
+
+sglang serve \
+  --model-path hygon/Qwen3.6-35B-A3B-Channel-INT8-w8a8 \
+  --dtype bfloat16 \
+  --attention-backend fa3 \
+  --mm-attention-backend fa3 \
+  --mem-fraction-static 0.9 \
+  --host xxxxx \
+  --page-size 64 \
+  --tp-size 2 \
+  --pp-size 1 \
+  --trust-remote-code \
+  --speculative-algorithm EAGLE \
+  --enable-piecewise-cuda-graph \
+  --speculative-num-steps 3 \
+  --speculative-eagle-topk 1 \
+  --speculative-num-draft-tokens 4 \
+  --mamba-scheduler-strategy extra_buffer \
+  --chunked-prefill-size -1 \
+  --quantization w8a8_int8 \
+  --moe-runner-backend lightop \
+  --kv-cache-dtype fp8_e5m2 \
+  --tool-call-parser qwen3_coder \
+  --reasoning-parser qwen3
 ```
 
 ## API 调用

--- a/docs/model-deployment/sglang/qwen3.6.md
+++ b/docs/model-deployment/sglang/qwen3.6.md
@@ -69,7 +69,6 @@ sglang serve \
   --speculative-num-draft-tokens 4 \
   --mamba-scheduler-strategy extra_buffer \
   --chunked-prefill-size -1 \
-  --kv-cache-dtype fp8_e5m2 \
   --tool-call-parser qwen3_coder \
   --reasoning-parser qwen3
 ```
@@ -131,7 +130,6 @@ sglang serve \
   --chunked-prefill-size -1 \
   --quantization w8a8_int8 \
   --moe-runner-backend lightop \
-  --kv-cache-dtype fp8_e5m2 \
   --tool-call-parser qwen3_coder \
   --reasoning-parser qwen3
 ```


### PR DESCRIPTION
## Summary
- add SGLang 0.5.12 BW1000 IFB commands for Qwen3.5-35B-A3B and Qwen3.6-35B-A3B
- add INT8 W8A8 deployment entries for both model families
- update the README support matrix for Qwen3.6 on BW1000

## Verification
- git diff --check
- verified model table anchors match their command section headings