### PR TITLE
sglang: add 0.5.12 BW1100 and K100 configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@
     </tr>
     <tr>
       <td>SGLang</td>
-      <td align="center">🚧</td><td align="center">🚧</td><td align="center"><a href="docs/model-deployment/sglang/qwen3.6.md">✅</a></td>
+      <td align="center"><a href="docs/model-deployment/sglang/qwen3.6.md">✅</a></td><td align="center">🚧</td><td align="center"><a href="docs/model-deployment/sglang/qwen3.6.md">✅</a></td>
     </tr>
     <tr>
       <td rowspan="2">Qwen3.5</td>
@@ -53,7 +53,7 @@
     </tr>
     <tr>
       <td>SGLang</td>
-      <td align="center">-</td><td align="center"><a href="docs/model-deployment/sglang/qwen3.5.md">✅</a></td><td align="center"><a href="docs/model-deployment/sglang/qwen3.5.md">✅</a></td>
+      <td align="center"><a href="docs/model-deployment/sglang/qwen3.5.md">✅</a></td><td align="center"><a href="docs/model-deployment/sglang/qwen3.5.md">✅</a></td><td align="center"><a href="docs/model-deployment/sglang/qwen3.5.md">✅</a></td>
     </tr>
     <tr>
       <td rowspan="2">Qwen3-VL</td>
@@ -80,7 +80,7 @@
     </tr>
     <tr>
       <td>SGLang</td>
-      <td align="center">-</td><td align="center"><a href="docs/model-deployment/sglang/qwen3.md">✅</a></td><td align="center"><a href="docs/model-deployment/sglang/qwen3.md">✅</a></td>
+      <td align="center"><a href="docs/model-deployment/sglang/qwen3.md">✅</a></td><td align="center"><a href="docs/model-deployment/sglang/qwen3.md">✅</a></td><td align="center"><a href="docs/model-deployment/sglang/qwen3.md">✅</a></td>
     </tr>
     <tr>
       <td rowspan="2">Qwen2.5-VL</td>
@@ -162,7 +162,7 @@
     </tr>
     <tr>
       <td>SGLang</td>
-      <td align="center">-</td><td align="center">-</td><td align="center"><a href="docs/model-deployment/sglang/deepseek-r1.md">✅</a></td>
+      <td align="center"><a href="docs/model-deployment/sglang/deepseek-r1.md">✅</a></td><td align="center">-</td><td align="center"><a href="docs/model-deployment/sglang/deepseek-r1.md">✅</a></td>
     </tr>
     <tr>
       <td rowspan="8" align="center"><img src="https://cdn-avatars.huggingface.co/v1/production/uploads/62dc173789b4cf157d36ebee/i_pxzM2ZDo3Ub-BEgIkE9.png" height="40"/><br/>Z.ai</td>

--- a/docs/model-deployment/sglang/deepseek-r1.md
+++ b/docs/model-deployment/sglang/deepseek-r1.md
@@ -105,6 +105,7 @@ sglang serve \
 ### DeepSeek-R1-Distill-Llama-70B-Channel-INT8-w8a8 IFB BW1100 2x SGLang 0.5.12
 
 ```bash
+export SGLANG_ENABLE_SPEC_V2=1
 export HSA_ENABLE_COREDUMP=1
 export USE_DCU_CUSTOM_ALLREDUCE=1
 export ALLREDUCE_STREAM_WITH_COMPUTE=1

--- a/docs/model-deployment/sglang/deepseek-r1.md
+++ b/docs/model-deployment/sglang/deepseek-r1.md
@@ -8,9 +8,187 @@ DeepSeek-R1 是 DeepSeek 推出的推理强化模型系列，面向复杂推理�
 
 | 模型权重 | 量化方式 | SGLang 版本 | 推荐硬件 | 卡数 | 部署方式 | 启动命令 |
 | -------- | -------- | ----------- | -------- | ---- | -------- | -------- |
+| [deepseek-ai/DeepSeek-R1-Distill-Llama-70B](https://www.modelscope.cn/models/deepseek-ai/DeepSeek-R1-Distill-Llama-70B) | BF16 | 0.5.12 | BW1100 | 8 | IFB | [**`>_`**](#deepseek-r1-distill-llama-70b-ifb-bw1100-8x-sglang-0512) |
+|                                                                                                                     | BF16 | 0.5.12 | K100_AI | 4 | IFB | [**`>_`**](#deepseek-r1-distill-llama-70b-ifb-k100_ai-4x-sglang-0512) |
+| [hygon/DeepSeek-R1-Distill-Llama-70B-Channel-INT8-w8a8](https://www.modelscope.cn/models/hygon/DeepSeek-R1-Distill-Llama-70B-Channel-INT8-w8a8) | INT8 W8A8 | 0.5.12 | BW1100 | 2 | IFB | [**`>_`**](#deepseek-r1-distill-llama-70b-channel-int8-w8a8-ifb-bw1100-2x-sglang-0512) |
+|                                                                                                                                                     | INT8 W8A8 | 0.5.12 | K100_AI | 8 | IFB | [**`>_`**](#deepseek-r1-distill-llama-70b-channel-int8-w8a8-ifb-k100_ai-8x-sglang-0512) |
 | [hygon/DeepSeek-R1-Channel-FP8-w8a8](https://www.modelscope.cn/models/hygon/DeepSeek-R1-Channel-FP8-w8a8) | FP8 W8A8 | 0.5.10 | BW1100 | 8x | IFB | [**\`>_\`**](#deepseek-r1-channel-fp8-w8a8-ifb-bw1100-8x-sglang-0510) |
 
 ## 启动命令
+
+### DeepSeek-R1-Distill-Llama-70B IFB BW1100 8x SGLang 0.5.12
+
+```bash
+export SGLANG_ENABLE_SPEC_V2=1
+export HSA_ENABLE_COREDUMP=1
+export USE_DCU_CUSTOM_ALLREDUCE=1
+export ALLREDUCE_STREAM_WITH_COMPUTE=1
+export HIP_KERNEL_EVENT_SYSTENFENCE=1
+export SGLANG_CHUNKED_PREFIX_CACHE_THRESHOLD=0
+export GLIBC_TUNABLES=glibc.rtld.optional_static_tls=0x40000
+export HIP_KERNEL_BATCH_CEILING=100
+export GPU_FORCE_BLIT_COPY_SIZE=16
+export HSA_KERNARG_POOL_SIZE=8388608
+export ROC_AQL_QUEUE_SIZE=131072
+export SGLANG_USE_LIGHTOP=1
+export SGLANG_ROCM_USE_AITER_MOE=0
+export W8A8_SUPPORT_METHODS=1
+export SGLANG_KVALLOC_KERNEL=1
+export SGLANG_CREATE_EXTEND_AFTER_DECODE_SPEC_INFO=1
+export SGLANG_ASSIGN_EXTEND_CACHE_LOCS=1
+export SGLANG_ASSIGN_REQ_TO_TOKEN_POOL=1
+export SGLANG_GET_LAST_LOC=1
+export SGLANG_CREATE_FLASHMLA_KV_INDICES_TRITON=1
+export SGLANG_CREATE_CHUNKED_PREFIX_CACHE_KV_INDICES=1
+export HIP_GRAPH_ACCUMULATE_DISPATCH=1
+export HIP_GRAPH_USE_CMD_CACHE=0
+export SGLANG_DISAGGREGATION_BOOTSTRAP_TIMEOUT=1200
+export NCCL_IB_GID_INDEX=3
+
+sglang serve \
+  --model-path deepseek-ai/DeepSeek-R1-Distill-Llama-70B \
+  --trust-remote-code \
+  --tp-size 8 \
+  --attention-backend fa3 \
+  --dtype bfloat16 \
+  --dist-timeout 10000 \
+  --watchdog-timeout 3600 \
+  --page-size 64 \
+  --kv-cache-dtype fp8_e4m3 \
+  --mem-fraction-static 0.8 \
+  --chunked-prefill-size 8192
+```
+
+### DeepSeek-R1-Distill-Llama-70B IFB K100_AI 4x SGLang 0.5.12
+
+```bash
+export SGLANG_ENABLE_SPEC_V2=1
+export HSA_ENABLE_COREDUMP=1
+export USE_DCU_CUSTOM_ALLREDUCE=1
+export ALLREDUCE_STREAM_WITH_COMPUTE=1
+export HIP_KERNEL_EVENT_SYSTENFENCE=1
+export SGLANG_CHUNKED_PREFIX_CACHE_THRESHOLD=0
+export GLIBC_TUNABLES=glibc.rtld.optional_static_tls=0x40000
+export HIP_KERNEL_BATCH_CEILING=100
+export GPU_FORCE_BLIT_COPY_SIZE=16
+export HSA_KERNARG_POOL_SIZE=8388608
+export ROC_AQL_QUEUE_SIZE=131072
+export SGLANG_USE_LIGHTOP=1
+export SGLANG_ROCM_USE_AITER_MOE=0
+export W8A8_SUPPORT_METHODS=1
+export SGLANG_KVALLOC_KERNEL=1
+export SGLANG_CREATE_EXTEND_AFTER_DECODE_SPEC_INFO=1
+export SGLANG_ASSIGN_EXTEND_CACHE_LOCS=1
+export SGLANG_ASSIGN_REQ_TO_TOKEN_POOL=1
+export SGLANG_GET_LAST_LOC=1
+export SGLANG_CREATE_FLASHMLA_KV_INDICES_TRITON=1
+export SGLANG_CREATE_CHUNKED_PREFIX_CACHE_KV_INDICES=1
+export HIP_GRAPH_ACCUMULATE_DISPATCH=1
+export HIP_GRAPH_USE_CMD_CACHE=0
+export SGLANG_DISAGGREGATION_BOOTSTRAP_TIMEOUT=1200
+
+sglang serve \
+  --model-path deepseek-ai/DeepSeek-R1-Distill-Llama-70B \
+  --trust-remote-code \
+  --tp-size 4 \
+  --attention-backend fa3 \
+  --dtype bfloat16 \
+  --dist-timeout 10000 \
+  --watchdog-timeout 3600 \
+  --page-size 64 \
+  --kv-cache-dtype bf16 \
+  --mem-fraction-static 0.8 \
+  --chunked-prefill-size 8192 \
+  --disable-custom-all-reduce
+```
+
+### DeepSeek-R1-Distill-Llama-70B-Channel-INT8-w8a8 IFB BW1100 2x SGLang 0.5.12
+
+```bash
+export HSA_ENABLE_COREDUMP=1
+export USE_DCU_CUSTOM_ALLREDUCE=1
+export ALLREDUCE_STREAM_WITH_COMPUTE=1
+export HIP_KERNEL_EVENT_SYSTENFENCE=1
+export SGLANG_CHUNKED_PREFIX_CACHE_THRESHOLD=0
+export GLIBC_TUNABLES=glibc.rtld.optional_static_tls=0x40000
+export HIP_KERNEL_BATCH_CEILING=100
+export GPU_FORCE_BLIT_COPY_SIZE=16
+export HSA_KERNARG_POOL_SIZE=8388608
+export ROC_AQL_QUEUE_SIZE=131072
+export SGLANG_USE_LIGHTOP=1
+export SGLANG_ROCM_USE_AITER_MOE=0
+export W8A8_SUPPORT_METHODS=1
+export SGLANG_KVALLOC_KERNEL=1
+export SGLANG_CREATE_EXTEND_AFTER_DECODE_SPEC_INFO=1
+export SGLANG_ASSIGN_EXTEND_CACHE_LOCS=1
+export SGLANG_ASSIGN_REQ_TO_TOKEN_POOL=1
+export SGLANG_GET_LAST_LOC=1
+export SGLANG_CREATE_FLASHMLA_KV_INDICES_TRITON=1
+export SGLANG_CREATE_CHUNKED_PREFIX_CACHE_KV_INDICES=1
+export HIP_GRAPH_ACCUMULATE_DISPATCH=1
+export HIP_GRAPH_USE_CMD_CACHE=0
+export SGLANG_DISAGGREGATION_BOOTSTRAP_TIMEOUT=1200
+export NCCL_IB_GID_INDEX=3
+
+sglang serve \
+  --model-path hygon/DeepSeek-R1-Distill-Llama-70B-Channel-INT8-w8a8 \
+  --trust-remote-code \
+  --tp-size 2 \
+  --attention-backend fa3 \
+  --dtype bfloat16 \
+  --dist-timeout 10000 \
+  --watchdog-timeout 3600 \
+  --page-size 64 \
+  --kv-cache-dtype fp8_e4m3 \
+  --mem-fraction-static 0.8 \
+  --chunked-prefill-size 8192 \
+  --quantization slimquant_marlin
+```
+
+### DeepSeek-R1-Distill-Llama-70B-Channel-INT8-w8a8 IFB K100_AI 8x SGLang 0.5.12
+
+```bash
+export SGLANG_ENABLE_SPEC_V2=1
+export HSA_ENABLE_COREDUMP=1
+export USE_DCU_CUSTOM_ALLREDUCE=1
+export ALLREDUCE_STREAM_WITH_COMPUTE=1
+export HIP_KERNEL_EVENT_SYSTENFENCE=1
+export SGLANG_CHUNKED_PREFIX_CACHE_THRESHOLD=0
+export GLIBC_TUNABLES=glibc.rtld.optional_static_tls=0x40000
+export HIP_KERNEL_BATCH_CEILING=100
+export GPU_FORCE_BLIT_COPY_SIZE=16
+export HSA_KERNARG_POOL_SIZE=8388608
+export ROC_AQL_QUEUE_SIZE=131072
+export SGLANG_USE_LIGHTOP=1
+export SGLANG_ROCM_USE_AITER_MOE=0
+export W8A8_SUPPORT_METHODS=1
+export SGLANG_KVALLOC_KERNEL=1
+export SGLANG_CREATE_EXTEND_AFTER_DECODE_SPEC_INFO=1
+export SGLANG_ASSIGN_EXTEND_CACHE_LOCS=1
+export SGLANG_ASSIGN_REQ_TO_TOKEN_POOL=1
+export SGLANG_GET_LAST_LOC=1
+export SGLANG_CREATE_FLASHMLA_KV_INDICES_TRITON=1
+export SGLANG_CREATE_CHUNKED_PREFIX_CACHE_KV_INDICES=1
+export HIP_GRAPH_ACCUMULATE_DISPATCH=1
+export HIP_GRAPH_USE_CMD_CACHE=0
+export SGLANG_DISAGGREGATION_BOOTSTRAP_TIMEOUT=1200
+export NCCL_IB_GID_INDEX=3
+
+sglang serve \
+  --model-path hygon/DeepSeek-R1-Distill-Llama-70B-Channel-INT8-w8a8 \
+  --trust-remote-code \
+  --tp-size 8 \
+  --attention-backend fa3 \
+  --dtype bfloat16 \
+  --dist-timeout 10000 \
+  --watchdog-timeout 3600 \
+  --page-size 64 \
+  --kv-cache-dtype bf16 \
+  --mem-fraction-static 0.8 \
+  --chunked-prefill-size 8192 \
+  --disable-custom-all-reduce \
+  --quantization slimquant_marlin
+```
 
 ### DeepSeek-R1-Channel-FP8-w8a8 IFB BW1100 8x SGLang 0.5.10
 ```bash

--- a/docs/model-deployment/sglang/qwen3.5.md
+++ b/docs/model-deployment/sglang/qwen3.5.md
@@ -8,7 +8,9 @@ Qwen3.5 是 Qwen3 系列的增强版本，在推理能力、代码生成、多�
 
 | 模型权重 | 量化方式 | SGLang 版本 | 推荐硬件 | 卡数 | 部署方式 | 启动命令 |
 | -------- | -------- | ----------- | -------- | ---- | -------- | -------- |
-| [Qwen/Qwen3.5-27B](https://www.modelscope.cn/models/Qwen/Qwen3.5-27B) | BF16 | 0.5.10 | BW1100 | 2 | IFB | [**`>_`**](#qwen35-27b-ifb-bw1100-2x-sglang-0510) |
+| [Qwen/Qwen3.5-27B](https://www.modelscope.cn/models/Qwen/Qwen3.5-27B) | BF16 | 0.5.12 | BW1100 | 2 | IFB | [**`>_`**](#qwen35-27b-ifb-bw1100-2x-sglang-0512) |
+|                                                                       | BF16 | 0.5.12 | K100_AI | 2 | IFB | [**`>_`**](#qwen35-27b-ifb-k100_ai-2x-sglang-0512) |
+|                                                                       | BF16 | 0.5.10 | BW1100 | 2 | IFB | [**`>_`**](#qwen35-27b-ifb-bw1100-2x-sglang-0510) |
 |                                                                       | BF16 | 0.5.10 | K100_AI | 2 | IFB | [**`>_`**](#qwen35-27b-ifb-k100_ai-2x-sglang-0510) |
 | [Qwen/Qwen3.5-35B-A3B](https://www.modelscope.cn/models/Qwen/Qwen3.5-35B-A3B) | BF16 | 0.5.10 | BW1100 | 2 | IFB | [**`>_`**](#qwen35-35b-a3b-ifb-bw1100-2x-sglang-0510) |
 | [hygon/Qwen3.5-35B-A3B-Channel-FP8-w8a8](https://www.modelscope.cn/models/hygon/Qwen3.5-35B-A3B-Channel-FP8-w8a8) | FP8 W8A8 | 0.5.10 | BW1100 | 2 | IFB | [**`>_`**](#qwen35-35b-a3b-channel-fp8-w8a8-ifb-bw1100-2x-sglang-0510) |
@@ -24,6 +26,54 @@ Qwen3.5-397B-A17B 采用 MoE 架构（397B 总参数 / 17B 激活参数）。
 | [hygon/Qwen3.5-397B-A17B-W8A8](https://www.modelscope.cn/models/hygon/Qwen3.5-397B-A17B-W8A8)              | INT8 W8A8 | [0.5.10](../docker_images.md) | BW1000 |  8 | IFB  | [**`>_`**](#qwen35-397b-a17b-w8a8-ifb-bw1000-8x-sglang-0510)          |
 
 ## 启动命令
+
+### Qwen3.5-27B IFB BW1100 2x SGLang 0.5.12
+
+```bash
+export SGLANG_ENABLE_SPEC_V2=1
+export SGLANG_USE_FUSED_TOPK_SOFTMAX=1
+export SGLANG_USE_LIGHTOP=1
+export SGLANG_USE_CAUSAL_CONV1D=1
+export SGLANG_USE_AITER_LINEAR_ATTN=1
+
+sglang serve \
+  --model-path Qwen/Qwen3.5-27B \
+  --attention-backend fa3 \
+  --mm-attention-backend fa3 \
+  --speculative-algorithm NEXTN \
+  --speculative-num-steps 3 \
+  --speculative-eagle-topk 1 \
+  --speculative-num-draft-tokens 4 \
+  --tp-size 2 \
+  --pp-size 1 \
+  --page-size 64 \
+  --mamba-scheduler-strategy extra_buffer \
+  --kv-cache-dtype fp8_e4m3 \
+  --trust-remote-code \
+  --tool-call-parser qwen3_coder \
+  --reasoning-parser qwen3 \
+  --chunked-prefill-size -1
+```
+
+### Qwen3.5-27B IFB K100_AI 2x SGLang 0.5.12
+
+```bash
+export SGLANG_USE_LIGHTOP=1
+export SGLANG_USE_FUSED_TOPK_SOFTMAX=1
+export SGLANG_USE_CAUSAL_CONV1D=1
+export SGLANG_USE_AITER_LINEAR_ATTN=1
+
+sglang serve \
+  --model-path Qwen/Qwen3.5-27B \
+  --tp-size 2 \
+  --attention-backend fa3 \
+  --page-size 64 \
+  --pp-size 1 \
+  --mamba-scheduler-strategy extra_buffer \
+  --disable-custom-all-reduce \
+  --tool-call-parser qwen3_coder \
+  --reasoning-parser qwen3
+```
 
 ### Qwen3.5-27B IFB BW1100 2x SGLang 0.5.10
 

--- a/docs/model-deployment/sglang/qwen3.6.md
+++ b/docs/model-deployment/sglang/qwen3.6.md
@@ -9,11 +9,62 @@ Qwen3.6 模型相较于 Qwen3.5 模型，**在智能体编程能力、推理速�
 
 | 模型权重 | 量化方式 | SGLang 版本 | 推荐硬件 | 卡数 | 部署方式 | 启动命令 |
 | -------- | -------- | ----------- | -------- | ---- | -------- | -------- |
-| [Qwen/Qwen3.6-27B](https://www.modelscope.cn/models/Qwen/Qwen3.6-27B) | BF16 | 0.5.10 | BW1100 | 2 | IFB | [**`>_`**](#qwen36-27b-ifb-bw1100-2x-sglang-0510) |
+| [Qwen/Qwen3.6-27B](https://www.modelscope.cn/models/Qwen/Qwen3.6-27B) | BF16 | 0.5.12 | BW1100 | 2 | IFB | [**`>_`**](#qwen36-27b-ifb-bw1100-2x-sglang-0512) |
+|                                                                       | BF16 | 0.5.12 | K100_AI | 2 | IFB | [**`>_`**](#qwen36-27b-ifb-k100_ai-2x-sglang-0512) |
+|                                                                       | BF16 | 0.5.10 | BW1100 | 2 | IFB | [**`>_`**](#qwen36-27b-ifb-bw1100-2x-sglang-0510) |
+| [hygon/Qwen3.6-27B-Channel-INT8-w8a8](https://www.modelscope.cn/models/hygon/Qwen3.6-27B-Channel-INT8-w8a8) | INT8 W8A8 | 0.5.12 | BW1100 | 2 | IFB | [**`>_`**](#qwen36-27b-channel-int8-w8a8-ifb-bw1100-2x-sglang-0512) |
+|                                                                                                                   | INT8 W8A8 | 0.5.12 | K100_AI | 2 | IFB | [**`>_`**](#qwen36-27b-channel-int8-w8a8-ifb-k100_ai-2x-sglang-0512) |
 | [Qwen/Qwen3.6-35B-A3B](https://www.modelscope.cn/models/Qwen/Qwen3.6-35B-A3B) | BF16 | 0.5.10 | BW1100 | 2 | IFB | [**`>_`**](#qwen36-35b-a3b-ifb-bw1100-2x-sglang-0510) |
 
 
 ## 启动命令
+
+### Qwen3.6-27B IFB BW1100 2x SGLang 0.5.12
+
+```bash
+export SGLANG_ENABLE_SPEC_V2=1
+export SGLANG_USE_FUSED_TOPK_SOFTMAX=1
+export SGLANG_USE_LIGHTOP=1
+export SGLANG_USE_CAUSAL_CONV1D=1
+export SGLANG_USE_AITER_LINEAR_ATTN=1
+
+sglang serve \
+  --model-path Qwen/Qwen3.6-27B \
+  --attention-backend fa3 \
+  --mm-attention-backend fa3 \
+  --speculative-algorithm NEXTN \
+  --speculative-num-steps 3 \
+  --speculative-eagle-topk 1 \
+  --speculative-num-draft-tokens 4 \
+  --tp-size 2 \
+  --pp-size 1 \
+  --page-size 64 \
+  --mamba-scheduler-strategy extra_buffer \
+  --kv-cache-dtype fp8_e4m3 \
+  --tool-call-parser qwen3_coder \
+  --reasoning-parser qwen3 \
+  --trust-remote-code
+```
+
+### Qwen3.6-27B IFB K100_AI 2x SGLang 0.5.12
+
+```bash
+export SGLANG_USE_LIGHTOP=1
+export SGLANG_USE_FUSED_TOPK_SOFTMAX=1
+export SGLANG_USE_CAUSAL_CONV1D=1
+export SGLANG_USE_AITER_LINEAR_ATTN=1
+
+sglang serve \
+  --model-path Qwen/Qwen3.6-27B \
+  --tp-size 2 \
+  --attention-backend fa3 \
+  --page-size 64 \
+  --pp-size 1 \
+  --mamba-scheduler-strategy extra_buffer \
+  --disable-custom-all-reduce \
+  --tool-call-parser qwen3_coder \
+  --reasoning-parser qwen3
+```
 
 ### Qwen3.6-27B IFB BW1100 2x SGLang 0.5.10
 
@@ -37,6 +88,53 @@ sglang serve --model-path Qwen/Qwen3.6-27B \
     --kv-cache-dtype fp8_e4m3 \
     --reasoning-parser qwen3 \
     --trust-remote-code
+```
+
+### Qwen3.6-27B-Channel-INT8-w8a8 IFB BW1100 2x SGLang 0.5.12
+
+```bash
+export SGLANG_ENABLE_SPEC_V2=1
+export SGLANG_USE_FUSED_TOPK_SOFTMAX=1
+export SGLANG_USE_LIGHTOP=1
+export SGLANG_USE_CAUSAL_CONV1D=1
+export SGLANG_USE_AITER_LINEAR_ATTN=1
+
+sglang serve \
+  --model-path hygon/Qwen3.6-27B-Channel-INT8-w8a8 \
+  --attention-backend fa3 \
+  --mm-attention-backend fa3 \
+  --speculative-algorithm NEXTN \
+  --speculative-num-steps 3 \
+  --speculative-eagle-topk 1 \
+  --speculative-num-draft-tokens 4 \
+  --tp-size 2 \
+  --pp-size 1 \
+  --page-size 64 \
+  --mamba-scheduler-strategy extra_buffer \
+  --kv-cache-dtype fp8_e4m3 \
+  --tool-call-parser qwen3_coder \
+  --reasoning-parser qwen3 \
+  --trust-remote-code
+```
+
+### Qwen3.6-27B-Channel-INT8-w8a8 IFB K100_AI 2x SGLang 0.5.12
+
+```bash
+export SGLANG_USE_LIGHTOP=1
+export SGLANG_USE_FUSED_TOPK_SOFTMAX=1
+export SGLANG_USE_CAUSAL_CONV1D=1
+export SGLANG_USE_AITER_LINEAR_ATTN=1
+
+sglang serve \
+  --model-path hygon/Qwen3.6-27B-Channel-INT8-w8a8 \
+  --tp-size 2 \
+  --attention-backend fa3 \
+  --page-size 64 \
+  --pp-size 1 \
+  --mamba-scheduler-strategy extra_buffer \
+  --disable-custom-all-reduce \
+  --tool-call-parser qwen3_coder \
+  --reasoning-parser qwen3
 ```
 
 ### Qwen3.6-35B-A3B IFB BW1100 2x SGLang 0.5.10

--- a/docs/model-deployment/sglang/qwen3.md
+++ b/docs/model-deployment/sglang/qwen3.md
@@ -8,11 +8,26 @@ Qwen3 是阿里通义千问第三代大语言模型，支持 0.6B ~ 235B 多种�
 
 | 模型权重 | 量化方式 | SGLang 版本 | 推荐硬件 | 卡数 | 部署方式 | 启动命令 |
 | -------- | -------- | ----------- | -------- | ---- | -------- | -------- |
+| [Qwen/Qwen3-4B-Thinking-2507](https://www.modelscope.cn/models/Qwen/Qwen3-4B-Thinking-2507) | BF16 | 0.5.12 | BW1100 | 1 | IFB | [**`>_`**](#qwen3-4b-thinking-2507-ifb-bw1100-1x-sglang-0512) |
 | [Qwen/Qwen3-8B](https://www.modelscope.cn/models/Qwen/Qwen3-8B) | BF16 | 0.5.10 | BW1000 | 1x | IFB | [**\`>_\`**](#qwen3-8b-ifb-bw1000-1x-sglang-0510) |
 | [Qwen/Qwen3-32B](https://www.modelscope.cn/models/Qwen/Qwen3-32B) | BF16 | 0.5.10 | BW1100 | 2x | IFB | [**\`>_\`**](#qwen3-32b-ifb-bw1100-2x-sglang-0510) |
 | [Qwen/Qwen3-235B-A22B](https://www.modelscope.cn/models/Qwen/Qwen3-235B-A22B) | BF16 | 0.5.10 | BW1100 | 4x | IFB | [**\`>_\`**](#qwen3-235b-a22b-ifb-bw1100-4x-sglang-0510) |
+| [Qwen/Qwen3-235B-A22B-Instruct-2507](https://www.modelscope.cn/models/Qwen/Qwen3-235B-A22B-Instruct-2507) | BF16 | 0.5.12 | BW1100 | 8 | IFB | [**`>_`**](#qwen3-235b-a22b-instruct-2507-ifb-bw1100-8x-sglang-0512) |
+|                                                                                                                   | BF16 | 0.5.12 | K100_AI | 8 | IFB | [**`>_`**](#qwen3-235b-a22b-instruct-2507-ifb-k100_ai-8x-sglang-0512) |
 
 ## 启动命令
+
+### Qwen3-4B-Thinking-2507 IFB BW1100 1x SGLang 0.5.12
+
+```bash
+sglang serve \
+  --model-path Qwen/Qwen3-4B-Thinking-2507 \
+  --tp-size 1 \
+  --trust-remote-code \
+  --mem-fraction-static 0.85 \
+  --attention-backend fa3 \
+  --page-size 64
+```
 
 ### Qwen3-8B IFB BW1000 1x SGLang 0.5.10
 
@@ -48,6 +63,35 @@ python -m sglang.launch_server \
     --attention-backend fa3 \
     --page-size 64 \
     --mem-fraction-static 0.90
+```
+
+### Qwen3-235B-A22B-Instruct-2507 IFB BW1100 8x SGLang 0.5.12
+
+```bash
+sglang serve \
+  --model-path Qwen/Qwen3-235B-A22B-Instruct-2507 \
+  --tp-size 8 \
+  --trust-remote-code \
+  --mem-fraction-static 0.85 \
+  --attention-backend fa3 \
+  --page-size 64 \
+  --tool-call-parser qwen3_coder \
+  --reasoning-parser qwen3
+```
+
+### Qwen3-235B-A22B-Instruct-2507 IFB K100_AI 8x SGLang 0.5.12
+
+```bash
+sglang serve \
+  --model-path Qwen/Qwen3-235B-A22B-Instruct-2507 \
+  --tp-size 8 \
+  --trust-remote-code \
+  --mem-fraction-static 0.90 \
+  --attention-backend fa3 \
+  --page-size 64 \
+  --tool-call-parser qwen3_coder \
+  --reasoning-parser qwen3 \
+  --disable-custom-all-reduce
 ```
 
 ## API 调用


### PR DESCRIPTION
## Summary
- add SGLang 0.5.12 IFB deployment records for BW1100 and K100_AI
- add DeepSeek R1 Distill Llama 70B BF16 and INT8 W8A8 configurations
- add Qwen3, Qwen3.5, and Qwen3.6 deployment configurations
- update the README hardware support matrix

## Verification
- git diff --check
- verified model table anchors match command section headings