### PR TITLE
docs(vllm): qwen3.5/3.6/3.8 启动命令补充 tool_call 参数

### DIFF
--- a/docs/model-deployment/vllm/qwen3.5.md
+++ b/docs/model-deployment/vllm/qwen3.5.md
@@ -102,7 +102,10 @@ vllm serve Qwen/Qwen3.5-4B \
   --speculative-config.num_speculative_tokens 3 \
   --kv-cache-dtype fp8_e4m3 \
   --attention-backend FLASH_ATTN_CUSTOM \
-  --max-num-seqs 128
+  --max-num-seqs 128 \
+  --enable-auto-tool-choice \
+  --tool-call-parser qwen3_coder \
+  --reasoning-parser qwen3
 ```
 
 ### Qwen3.5-4B IFB BW1000 1x vLLM 0.21
@@ -115,7 +118,10 @@ vllm serve Qwen/Qwen3.5-4B \
   --speculative-config.method mtp \
   --speculative-config.num_speculative_tokens 3 \
   --attention-backend FLASH_ATTN_CUSTOM \
-  --max-num-seqs 128
+  --max-num-seqs 128 \
+  --enable-auto-tool-choice \
+  --tool-call-parser qwen3_coder \
+  --reasoning-parser qwen3
 ```
 
 ### Qwen3.5-4B IFB K100_AI 1x vLLM 0.21
@@ -135,7 +141,10 @@ vllm serve Qwen/Qwen3.5-4B \
   --speculative-config.num_speculative_tokens 3 \
   --speculative-config.attention_backend TRITON_ATTN \
   --max-num-seqs 128 \
-  --attention-backend TRITON_ATTN
+  --attention-backend TRITON_ATTN \
+  --enable-auto-tool-choice \
+  --tool-call-parser qwen3_coder \
+  --reasoning-parser qwen3
 ```
 
 ### Qwen3.5-4B IFB BW1100 1x vLLM 0.18
@@ -230,7 +239,10 @@ vllm serve Qwen/Qwen3.5-9B \
   --speculative-config.num_speculative_tokens 3 \
   --kv-cache-dtype fp8_e4m3 \
   --attention-backend FLASH_ATTN_CUSTOM \
-  --max-num-seqs 128
+  --max-num-seqs 128 \
+  --enable-auto-tool-choice \
+  --tool-call-parser qwen3_coder \
+  --reasoning-parser qwen3
 ```
 
 ### Qwen3.5-9B IFB BW1000 1x vLLM 0.21
@@ -243,7 +255,10 @@ vllm serve Qwen/Qwen3.5-9B \
   --speculative-config.method mtp \
   --speculative-config.num_speculative_tokens 3 \
   --attention-backend FLASH_ATTN_CUSTOM \
-  --max-num-seqs 128
+  --max-num-seqs 128 \
+  --enable-auto-tool-choice \
+  --tool-call-parser qwen3_coder \
+  --reasoning-parser qwen3
 ```
 
 ### Qwen3.5-9B IFB K100_AI 1x vLLM 0.21
@@ -263,7 +278,10 @@ vllm serve Qwen/Qwen3.5-9B \
   --speculative-config.num_speculative_tokens 3 \
   --speculative-config.attention_backend TRITON_ATTN \
   --max-num-seqs 128 \
-  --attention-backend TRITON_ATTN
+  --attention-backend TRITON_ATTN \
+  --enable-auto-tool-choice \
+  --tool-call-parser qwen3_coder \
+  --reasoning-parser qwen3
 ```
 
 ### Qwen3.5-9B IFB BW1100 1x vLLM 0.18
@@ -358,7 +376,10 @@ vllm serve Qwen/Qwen3.5-27B \
   --speculative-config.num_speculative_tokens 3 \
   --kv-cache-dtype fp8_e4m3 \
   --attention-backend FLASH_ATTN_CUSTOM \
-  --max-num-seqs 128
+  --max-num-seqs 128 \
+  --enable-auto-tool-choice \
+  --tool-call-parser qwen3_coder \
+  --reasoning-parser qwen3
 ```
 
 ### Qwen3.5-27B IFB BW1000 2x vLLM 0.21
@@ -371,7 +392,10 @@ vllm serve Qwen/Qwen3.5-27B \
   --speculative-config.method mtp \
   --speculative-config.num_speculative_tokens 3 \
   --attention-backend FLASH_ATTN_CUSTOM \
-  --max-num-seqs 128
+  --max-num-seqs 128 \
+  --enable-auto-tool-choice \
+  --tool-call-parser qwen3_coder \
+  --reasoning-parser qwen3
 ```
 
 ### Qwen3.5-27B IFB K100_AI 2x vLLM 0.21
@@ -391,7 +415,10 @@ vllm serve Qwen/Qwen3.5-27B \
   --speculative-config.num_speculative_tokens 3 \
   --speculative-config.attention_backend TRITON_ATTN \
   --max-num-seqs 128 \
-  --attention-backend TRITON_ATTN
+  --attention-backend TRITON_ATTN \
+  --enable-auto-tool-choice \
+  --tool-call-parser qwen3_coder \
+  --reasoning-parser qwen3
 ```
 
 ### Qwen3.5-27B IFB BW1100 1x vLLM 0.18
@@ -487,7 +514,10 @@ vllm serve Qwen/Qwen3.5-35B-A3B \
   --kv-cache-dtype fp8_e4m3 \
   --attention-backend FLASH_ATTN_CUSTOM \
   --moe-backend aiter \
-  --max-num-seqs 128
+  --max-num-seqs 128 \
+  --enable-auto-tool-choice \
+  --tool-call-parser qwen3_coder \
+  --reasoning-parser qwen3
 ```
 
 ### Qwen3.5-35B-A3B IFB BW1000 2x vLLM 0.21
@@ -501,7 +531,10 @@ vllm serve Qwen/Qwen3.5-35B-A3B \
   --speculative-config.num_speculative_tokens 3 \
   --attention-backend FLASH_ATTN_CUSTOM \
   --moe-backend aiter \
-  --max-num-seqs 128
+  --max-num-seqs 128 \
+  --enable-auto-tool-choice \
+  --tool-call-parser qwen3_coder \
+  --reasoning-parser qwen3
 ```
 
 ### Qwen3.5-35B-A3B IFB K100_AI 2x vLLM 0.21
@@ -522,7 +555,10 @@ vllm serve Qwen/Qwen3.5-35B-A3B \
   --speculative-config.attention_backend TRITON_ATTN \
   --max-num-seqs 128 \
   --attention-backend TRITON_ATTN \
-  --moe-backend triton
+  --moe-backend triton \
+  --enable-auto-tool-choice \
+  --tool-call-parser qwen3_coder \
+  --reasoning-parser qwen3
 ```
 
 ### Qwen3.5-35B-A3B IFB BW1100 1x vLLM 0.18
@@ -627,7 +663,10 @@ vllm serve hygon/Qwen3.5-35B-A3B-Channel-INT8-w8a8 \
   --speculative-config.quantization "slimquant_marlin" \
   --kv-cache-dtype fp8_e4m3 \
   --attention-backend FLASH_ATTN_CUSTOM \
-  --max-num-seqs 128
+  --max-num-seqs 128 \
+  --enable-auto-tool-choice \
+  --tool-call-parser qwen3_coder \
+  --reasoning-parser qwen3
 ```
 
 ### Qwen3.5-35B-A3B-Channel-INT8-w8a8 IFB BW1000 1x vLLM 0.21
@@ -642,7 +681,10 @@ vllm serve hygon/Qwen3.5-35B-A3B-Channel-INT8-w8a8 \
   --speculative-config.num_speculative_tokens 3 \
   --speculative-config.quantization "slimquant_marlin" \
   --attention-backend FLASH_ATTN_CUSTOM \
-  --max-num-seqs 128
+  --max-num-seqs 128 \
+  --enable-auto-tool-choice \
+  --tool-call-parser qwen3_coder \
+  --reasoning-parser qwen3
 ```
 
 ### Qwen3.5-35B-A3B-Channel-INT8-w8a8 IFB K100_AI 1x vLLM 0.21
@@ -663,7 +705,10 @@ vllm serve hygon/Qwen3.5-35B-A3B-Channel-INT8-w8a8 \
   --speculative-config.attention_backend TRITON_ATTN \
   --max-num-seqs 128 \
   --attention-backend TRITON_ATTN \
-  --moe-backend triton
+  --moe-backend triton \
+  --enable-auto-tool-choice \
+  --tool-call-parser qwen3_coder \
+  --reasoning-parser qwen3
 ```
 
 ### Qwen3.5-35B-A3B-Channel-INT8-w8a8 IFB BW1100 1x vLLM 0.18
@@ -768,7 +813,10 @@ vllm serve hygon/Qwen3.5-35B-A3B-Channel-FP8-w8a8 \
   --speculative-config.quantization "slimquant_marlin" \
   --kv-cache-dtype fp8_e4m3 \
   --attention-backend FLASH_ATTN_CUSTOM \
-  --max-num-seqs 128
+  --max-num-seqs 128 \
+  --enable-auto-tool-choice \
+  --tool-call-parser qwen3_coder \
+  --reasoning-parser qwen3
 ```
 
 ### Qwen3.5-35B-A3B-Channel-FP8-w8a8 IFB BW1100 1x vLLM 0.18
@@ -814,7 +862,10 @@ vllm serve Qwen/Qwen3.5-122B-A10B \
   --kv-cache-dtype fp8_e4m3 \
   --attention-backend FLASH_ATTN_CUSTOM \
   --moe-backend aiter \
-  --max-num-seqs 128
+  --max-num-seqs 128 \
+  --enable-auto-tool-choice \
+  --tool-call-parser qwen3_coder \
+  --reasoning-parser qwen3
 ```
 
 ### Qwen3.5-122B-A10B IFB BW1000 8x vLLM 0.21
@@ -828,7 +879,10 @@ vllm serve Qwen/Qwen3.5-122B-A10B \
   --speculative-config.num_speculative_tokens 3 \
   --attention-backend FLASH_ATTN_CUSTOM \
   --moe-backend aiter \
-  --max-num-seqs 128
+  --max-num-seqs 128 \
+  --enable-auto-tool-choice \
+  --tool-call-parser qwen3_coder \
+  --reasoning-parser qwen3
 ```
 
 ### Qwen3.5-122B-A10B IFB K100_AI 8x vLLM 0.21
@@ -849,7 +903,10 @@ vllm serve Qwen/Qwen3.5-122B-A10B \
   --speculative-config.attention_backend TRITON_ATTN \
   --max-num-seqs 128 \
   --attention-backend TRITON_ATTN \
-  --moe-backend triton
+  --moe-backend triton \
+  --enable-auto-tool-choice \
+  --tool-call-parser qwen3_coder \
+  --reasoning-parser qwen3
 ```
 
 ### Qwen3.5-122B-A10B IFB BW1100 4x vLLM 0.18
@@ -953,7 +1010,10 @@ vllm serve Qwen/Qwen3.5-122B-A10B-W8A8-INT8 \
   --kv-cache-dtype fp8_e4m3 \
   --attention-backend FLASH_ATTN_CUSTOM \
   --max-num-seqs 128 \
-  --moe-backend triton
+  --moe-backend triton \
+  --enable-auto-tool-choice \
+  --tool-call-parser qwen3_coder \
+  --reasoning-parser qwen3
 ```
 
 ### Qwen3.5-122B-A10B-W8A8-INT8 IFB BW1000 4x vLLM 0.21
@@ -968,7 +1028,10 @@ vllm serve Qwen/Qwen3.5-122B-A10B-W8A8-INT8 \
   --speculative-config.num_speculative_tokens 3 \
   --speculative-config.quantization "slimquant_marlin" \
   --attention-backend FLASH_ATTN_CUSTOM \
-  --max-num-seqs 128
+  --max-num-seqs 128 \
+  --enable-auto-tool-choice \
+  --tool-call-parser qwen3_coder \
+  --reasoning-parser qwen3
 ```
 
 ### Qwen3.5-122B-A10B-W8A8-INT8 IFB K100_AI 4x vLLM 0.21
@@ -989,7 +1052,10 @@ vllm serve Qwen/Qwen3.5-122B-A10B-W8A8-INT8 \
   --speculative-config.attention_backend TRITON_ATTN \
   --max-num-seqs 128 \
   --attention-backend TRITON_ATTN \
-  --moe-backend triton
+  --moe-backend triton \
+  --enable-auto-tool-choice \
+  --tool-call-parser qwen3_coder \
+  --reasoning-parser qwen3
 ```
 
 ### Qwen3.5-122B-A10B-W8A8-INT8 IFB BW1100 2x vLLM 0.18
@@ -1094,7 +1160,10 @@ vllm serve hygon/Qwen3.5-122B-A10B-Channel-FP8-w8a8 \
   --speculative-config.quantization "slimquant_marlin" \
   --kv-cache-dtype fp8_e4m3 \
   --attention-backend FLASH_ATTN_CUSTOM \
-  --max-num-seqs 128
+  --max-num-seqs 128 \
+  --enable-auto-tool-choice \
+  --tool-call-parser qwen3_coder \
+  --reasoning-parser qwen3
 ```
 
 ### Qwen3.5-122B-A10B-Channel-FP8-w8a8 IFB BW1100 2x vLLM 0.18
@@ -1141,7 +1210,10 @@ vllm serve Qwen/Qwen3.5-397B-A17B-W8A8-INT8 \
   --speculative-config.quantization "slimquant_marlin" \
   --kv-cache-dtype fp8_e4m3 \
   --attention-backend FLASH_ATTN_CUSTOM \
-  --max-num-seqs 128
+  --max-num-seqs 128 \
+  --enable-auto-tool-choice \
+  --tool-call-parser qwen3_coder \
+  --reasoning-parser qwen3
 ```
 
 ### Qwen3.5-397B-A17B-W8A8-INT8 IFB BW1000 8x vLLM 0.21
@@ -1156,7 +1228,10 @@ vllm serve Qwen/Qwen3.5-397B-A17B-W8A8-INT8 \
   --speculative-config.num_speculative_tokens 3 \
   --speculative-config.quantization "slimquant_marlin" \
   --attention-backend FLASH_ATTN_CUSTOM \
-  --max-num-seqs 128
+  --max-num-seqs 128 \
+  --enable-auto-tool-choice \
+  --tool-call-parser qwen3_coder \
+  --reasoning-parser qwen3
 ```
 
 ### Qwen3.5-397B-A17B-W8A8-INT8 IFB K100_AI 8x vLLM 0.21
@@ -1177,7 +1252,10 @@ vllm serve Qwen/Qwen3.5-397B-A17B-W8A8-INT8 \
   --speculative-config.attention_backend TRITON_ATTN \
   --max-num-seqs 128 \
   --attention-backend TRITON_ATTN \
-  --moe-backend triton
+  --moe-backend triton \
+  --enable-auto-tool-choice \
+  --tool-call-parser qwen3_coder \
+  --reasoning-parser qwen3
 ```
 
 ### Qwen3.5-397B-A17B-W8A8-INT8 IFB BW1100 8x vLLM 0.18
@@ -1282,7 +1360,10 @@ vllm serve hygon/Qwen3.5-397B-A17B-Channel-FP8 \
   --speculative-config.quantization "slimquant_marlin" \
   --kv-cache-dtype fp8_e4m3 \
   --attention-backend FLASH_ATTN_CUSTOM \
-  --max-num-seqs 128
+  --max-num-seqs 128 \
+  --enable-auto-tool-choice \
+  --tool-call-parser qwen3_coder \
+  --reasoning-parser qwen3
 ```
 
 ### Qwen3.5-397B-A17B-Channel-FP8 IFB BW1100 4x vLLM 0.18

--- a/docs/model-deployment/vllm/qwen3.6.md
+++ b/docs/model-deployment/vllm/qwen3.6.md
@@ -40,7 +40,10 @@ vllm serve Qwen/Qwen3.6-27B \
   --speculative-config.method mtp \
   --speculative-config.num_speculative_tokens 3 \
   --kv-cache-dtype fp8_e4m3 \
-  --attention-backend FLASH_ATTN_CUSTOM
+  --attention-backend FLASH_ATTN_CUSTOM \
+  --enable-auto-tool-choice \
+  --tool-call-parser qwen3_coder \
+  --reasoning-parser qwen3
 ```
 
 ### Qwen3.6-27B IFB BW1000 2x vLLM 0.21
@@ -53,7 +56,10 @@ vllm serve Qwen/Qwen3.6-27B \
   --max-num-batched-tokens 10240 \
   --speculative-config.method mtp \
   --speculative-config.num_speculative_tokens 3 \
-  --attention-backend FLASH_ATTN_CUSTOM
+  --attention-backend FLASH_ATTN_CUSTOM \
+  --enable-auto-tool-choice \
+  --tool-call-parser qwen3_coder \
+  --reasoning-parser qwen3
 ```
 
 ### Qwen3.6-27B IFB K100_AI 2x vLLM 0.21
@@ -72,7 +78,10 @@ vllm serve Qwen/Qwen3.6-27B \
   --speculative-config.method mtp \
   --speculative-config.num_speculative_tokens 3 \
   --speculative-config.attention_backend TRITON_ATTN \
-  --attention-backend TRITON_ATTN
+  --attention-backend TRITON_ATTN \
+  --enable-auto-tool-choice \
+  --tool-call-parser qwen3_coder \
+  --reasoning-parser qwen3
 ```
 
 ### Qwen3.6-27B IFB BW1100 1x vLLM 0.18
@@ -167,7 +176,10 @@ vllm serve Qwen/Qwen3.6-35B-A3B \
   --speculative-config.num_speculative_tokens 3 \
   --kv-cache-dtype fp8_e4m3 \
   --attention-backend FLASH_ATTN_CUSTOM \
-  --moe-backend aiter
+  --moe-backend aiter \
+  --enable-auto-tool-choice \
+  --tool-call-parser qwen3_coder \
+  --reasoning-parser qwen3
 ```
 
 ### Qwen3.6-35B-A3B IFB BW1000 2x vLLM 0.21
@@ -180,7 +192,10 @@ vllm serve Qwen/Qwen3.6-35B-A3B \
   --speculative-config.method mtp \
   --speculative-config.num_speculative_tokens 3 \
   --attention-backend FLASH_ATTN_CUSTOM \
-  --moe-backend aiter
+  --moe-backend aiter \
+  --enable-auto-tool-choice \
+  --tool-call-parser qwen3_coder \
+  --reasoning-parser qwen3
 ```
 
 ### Qwen3.6-35B-A3B IFB K100_AI 2x vLLM 0.21
@@ -200,7 +215,10 @@ vllm serve Qwen/Qwen3.6-35B-A3B \
   --speculative-config.num_speculative_tokens 3 \
   --speculative-config.attention_backend TRITON_ATTN \
   --attention-backend TRITON_ATTN \
-  --moe-backend triton
+  --moe-backend triton \
+  --enable-auto-tool-choice \
+  --tool-call-parser qwen3_coder \
+  --reasoning-parser qwen3
 ```
 
 ### Qwen3.6-35B-A3B IFB BW1100 1x vLLM 0.18

--- a/docs/model-deployment/vllm/qwen3.8.md
+++ b/docs/model-deployment/vllm/qwen3.8.md
@@ -29,7 +29,10 @@ vllm serve Qwen/Qwen3.8-27B \
   --max-num-batched-tokens 10240 \
   --speculative-config.method mtp \
   --speculative-config.num_speculative_tokens 3 \
-  --compilation-config '{"cudagraph_mode":"FULL","max_cudagraph_capture_size":2048}' 
+  --compilation-config '{"cudagraph_mode":"FULL","max_cudagraph_capture_size":2048}' \
+  --enable-auto-tool-choice \
+  --tool-call-parser qwen3_coder \
+  --reasoning-parser qwen3
 ```
 
 ### Qwen3.8-27B IFB BW1000 2x vLLM 0.21
@@ -42,7 +45,10 @@ vllm serve Qwen/Qwen3.8-27B \
   --max-num-batched-tokens 10240 \
   --speculative-config.method mtp \
   --speculative-config.num_speculative_tokens 3 \
-  --compilation-config '{"cudagraph_mode":"FULL","max_cudagraph_capture_size":2048}'
+  --compilation-config '{"cudagraph_mode":"FULL","max_cudagraph_capture_size":2048}' \
+  --enable-auto-tool-choice \
+  --tool-call-parser qwen3_coder \
+  --reasoning-parser qwen3
 ```
 
 ### Qwen3.8-27B IFB BW1000 2x vLLM 0.18-hotfix
@@ -72,7 +78,10 @@ vllm serve hygon/Qwen3.8-27B-Channel-INT8-w8a8 \
   --speculative-config.num_speculative_tokens 3 \
   -q slimquant_marlin \
   --compilation-config '{"cudagraph_mode":"FULL","max_cudagraph_capture_size":2048}' \
-  --speculative-config.quantization "slimquant_marlin"
+  --speculative-config.quantization "slimquant_marlin" \
+  --enable-auto-tool-choice \
+  --tool-call-parser qwen3_coder \
+  --reasoning-parser qwen3
 ```
 
 ### Qwen3.8-27B-Channel-INT8-w8a8 IFB BW1000 1x vLLM 0.21
@@ -87,7 +96,10 @@ vllm serve hygon/Qwen3.8-27B-Channel-INT8-w8a8 \
   --speculative-config.num_speculative_tokens 3 \
   -q slimquant_marlin \
   --compilation-config '{"cudagraph_mode":"FULL","max_cudagraph_capture_size":2048}' \
-  --speculative-config.quantization "slimquant_marlin"
+  --speculative-config.quantization "slimquant_marlin" \
+  --enable-auto-tool-choice \
+  --tool-call-parser qwen3_coder \
+  --reasoning-parser qwen3
 ```
 
 ### Qwen3.8-27B-Channel-INT8-w8a8 IFB BW1000 2x vLLM 0.21
@@ -102,7 +114,10 @@ vllm serve hygon/Qwen3.8-27B-Channel-INT8-w8a8 \
   --speculative-config.num_speculative_tokens 3 \
   -q slimquant_marlin \
   --compilation-config '{"cudagraph_mode":"FULL","max_cudagraph_capture_size":2048}' \
-  --speculative-config.quantization "slimquant_marlin"
+  --speculative-config.quantization "slimquant_marlin" \
+  --enable-auto-tool-choice \
+  --tool-call-parser qwen3_coder \
+  --reasoning-parser qwen3
 ```
 
 ### Qwen3.8-27B-Channel-INT8-w8a8 IFB BW1000 1x vLLM 0.18-hotfix


### PR DESCRIPTION
为 Qwen3.5 / Qwen3.6 / Qwen3.8 的 vLLM 0.21 启动命令
补充工具调用相关参数：
  --enable-auto-tool-choice
  --tool-call-parser qwen3_coder
  --reasoning-parser qwen3

已在 Qwen3.5-4B / Qwen3.6-27B / Qwen3.5-35B-A3B 实测验证通过。