### PR TITLE
vllm/K100_AI-MoE: add triton moe backend

### DIFF
--- a/docs/model-deployment/vllm/minimax-2.x.md
+++ b/docs/model-deployment/vllm/minimax-2.x.md
@@ -77,6 +77,7 @@ export VLLM_ROCM_USE_AITER=0
 vllm serve hygon/MiniMax-M2.5-Channel-INT8-w8a8 \
   -tp 8 \
   --trust-remote-code \
+  --moe-backend triton \
   --max-model-len 73216 \
   --max-num-batched-tokens 16384 \
   --enable-prefix-caching \

--- a/docs/model-deployment/vllm/qwen2.md
+++ b/docs/model-deployment/vllm/qwen2.md
@@ -413,7 +413,8 @@ export VLLM_ROCM_USE_AITER=0
 vllm serve Qwen/Qwen2-57B-A14B-Instruct \
   -tp 4 \
   --trust-remote-code \
-  --attention-backend TRITON_ATTN
+  --attention-backend TRITON_ATTN \
+  --moe-backend triton
 ```
 
 ### Qwen2-57B-A14B-Instruct IFB BW1100 2x vLLM 0.18

--- a/docs/model-deployment/vllm/qwen3-vl.md
+++ b/docs/model-deployment/vllm/qwen3-vl.md
@@ -688,7 +688,8 @@ export VLLM_ROCM_USE_AITER=0
 vllm serve Qwen/Qwen3-VL-30B-A3B-Instruct \
   -tp 2 \
   --trust-remote-code \
-  --attention-backend TRITON_ATTN
+  --attention-backend TRITON_ATTN \
+  --moe-backend triton
 ```
 ### Qwen3-VL-30B-A3B-Instruct IFB BW1100 1x vLLM 0.18
 ```bash
@@ -779,7 +780,8 @@ export VLLM_ROCM_USE_AITER=0
 vllm serve Qwen/Qwen3-VL-30B-A3B-Thinking \
   -tp 2 \
   --trust-remote-code \
-  --attention-backend TRITON_ATTN
+  --attention-backend TRITON_ATTN \
+  --moe-backend triton
 ```
 ### Qwen3-VL-30B-A3B-Thinking IFB BW1100 1x vLLM 0.18
 ```bash
@@ -984,7 +986,8 @@ vllm serve Qwen/Qwen3-VL-235B-A22B-Instruct \
   -tp 8 \
   -pp 2 \
   --trust-remote-code \
-  --attention-backend TRITON_ATTN
+  --attention-backend TRITON_ATTN \
+  --moe-backend triton
 ```
 ### Qwen3-VL-235B-A22B-Instruct IFB BW1100 8x vLLM 0.18
 
@@ -1106,7 +1109,8 @@ vllm serve Qwen/Qwen3-VL-235B-A22B-Thinking \
   -tp 8 \
   -pp 2 \
   --trust-remote-code \
-  --attention-backend TRITON_ATTN
+  --attention-backend TRITON_ATTN \
+  --moe-backend triton
 ```
 ### Qwen3-VL-235B-A22B-Thinking IFB BW1100 8x vLLM 0.18
 ```bash

--- a/docs/model-deployment/vllm/qwen3.5.md
+++ b/docs/model-deployment/vllm/qwen3.5.md
@@ -513,7 +513,8 @@ vllm serve Qwen/Qwen3.5-35B-A3B \
   --speculative-config.num_speculative_tokens 3 \
   --speculative-config.attention_backend TRITON_ATTN \
   --max-num-seqs 128 \
-  --attention-backend TRITON_ATTN
+  --attention-backend TRITON_ATTN \
+  --moe-backend triton
 ```
 
 ### Qwen3.5-35B-A3B IFB BW1100 1x vLLM 0.18
@@ -651,7 +652,8 @@ vllm serve hygon/Qwen3.5-35B-A3B-Channel-INT8-w8a8 \
   --speculative-config.num_speculative_tokens 3 \
   --speculative-config.attention_backend TRITON_ATTN \
   --max-num-seqs 128 \
-  --attention-backend TRITON_ATTN
+  --attention-backend TRITON_ATTN \
+  --moe-backend triton
 ```
 
 ### Qwen3.5-35B-A3B-Channel-INT8-w8a8 IFB BW1100 1x vLLM 0.18
@@ -834,7 +836,8 @@ vllm serve Qwen/Qwen3.5-122B-A10B \
   --speculative-config.num_speculative_tokens 3 \
   --speculative-config.attention_backend TRITON_ATTN \
   --max-num-seqs 128 \
-  --attention-backend TRITON_ATTN
+  --attention-backend TRITON_ATTN \
+  --moe-backend triton
 ```
 
 ### Qwen3.5-122B-A10B IFB BW1100 4x vLLM 0.18
@@ -971,7 +974,8 @@ vllm serve Qwen/Qwen3.5-122B-A10B-W8A8-INT8 \
   --speculative-config.num_speculative_tokens 3 \
   --speculative-config.attention_backend TRITON_ATTN \
   --max-num-seqs 128 \
-  --attention-backend TRITON_ATTN
+  --attention-backend TRITON_ATTN \
+  --moe-backend triton
 ```
 
 ### Qwen3.5-122B-A10B-W8A8-INT8 IFB BW1100 2x vLLM 0.18
@@ -1156,7 +1160,8 @@ vllm serve Qwen/Qwen3.5-397B-A17B-W8A8-INT8 \
   --speculative-config.num_speculative_tokens 3 \
   --speculative-config.attention_backend TRITON_ATTN \
   --max-num-seqs 128 \
-  --attention-backend TRITON_ATTN
+  --attention-backend TRITON_ATTN \
+  --moe-backend triton
 ```
 
 ### Qwen3.5-397B-A17B-W8A8-INT8 IFB BW1100 8x vLLM 0.18

--- a/docs/model-deployment/vllm/qwen3.6.md
+++ b/docs/model-deployment/vllm/qwen3.6.md
@@ -195,7 +195,8 @@ vllm serve Qwen/Qwen3.6-35B-A3B \
   --speculative-config.method mtp \
   --speculative-config.num_speculative_tokens 3 \
   --speculative-config.attention_backend TRITON_ATTN \
-  --attention-backend TRITON_ATTN
+  --attention-backend TRITON_ATTN \
+  --moe-backend triton
 ```
 
 ### Qwen3.6-35B-A3B IFB BW1100 1x vLLM 0.18

--- a/docs/model-deployment/vllm/qwen3.md
+++ b/docs/model-deployment/vllm/qwen3.md
@@ -1155,7 +1155,8 @@ vllm serve Qwen/Qwen3-30B-A3B-Instruct-2507 \
   -tp 2 \
   --trust-remote-code \
   --max-num-batched-tokens 10240 \
-  --attention-backend TRITON_ATTN
+  --attention-backend TRITON_ATTN \
+  --moe-backend triton
 ```
 
 ### Qwen3-30B-A3B-Instruct-2507 IFB BW1100 1x vLLM 0.18
@@ -1578,7 +1579,8 @@ vllm serve hygon/Qwen3-235B-A22B-Channel-INT8-w8a8 \
   --gpu-memory-utilization 0.9 \
   --trust-remote-code \
   --max-num-batched-tokens 10240 \
-  --attention-backend TRITON_ATTN
+  --attention-backend TRITON_ATTN \
+  --moe-backend triton
 ```
 
 ### Qwen3-235B-A22B-Channel-INT8-w8a8 IFB BW1100 2x vLLM 0.18


### PR DESCRIPTION
## Summary
- Add `--moe-backend triton` to K100_AI vLLM 0.21 MoE cookbook commands.
- Scope is limited to K100_AI vLLM 0.21 blocks whose model names indicate MoE (`AxxB`/`MoE`) plus MiniMax-M2.5 with existing MoE env config.

## Models
- docs/model-deployment/vllm/minimax-2.x.md :: MiniMax-M2.5-Channel-INT8-w8a8 IFB K100_AI 8x vLLM 0.21
- docs/model-deployment/vllm/qwen2.md :: Qwen2-57B-A14B-Instruct IFB K100_AI 4x vLLM 0.21
- docs/model-deployment/vllm/qwen3.5.md :: Qwen3.5-122B-A10B IFB K100_AI 8x vLLM 0.21
- docs/model-deployment/vllm/qwen3.5.md :: Qwen3.5-122B-A10B-W8A8-INT8 IFB K100_AI 4x vLLM 0.21
- docs/model-deployment/vllm/qwen3.5.md :: Qwen3.5-35B-A3B IFB K100_AI 2x vLLM 0.21
- docs/model-deployment/vllm/qwen3.5.md :: Qwen3.5-35B-A3B-Channel-INT8-w8a8 IFB K100_AI 1x vLLM 0.21
- docs/model-deployment/vllm/qwen3.5.md :: Qwen3.5-397B-A17B-W8A8-INT8 IFB K100_AI 8x vLLM 0.21
- docs/model-deployment/vllm/qwen3.6.md :: Qwen3.6-35B-A3B IFB K100_AI 2x vLLM 0.21
- docs/model-deployment/vllm/qwen3.md :: Qwen3-235B-A22B-Channel-INT8-w8a8 IFB K100_AI 4x vLLM 0.21
- docs/model-deployment/vllm/qwen3.md :: Qwen3-30B-A3B-Instruct-2507 IFB K100_AI 2x vLLM 0.21
- docs/model-deployment/vllm/qwen3-vl.md :: Qwen3-VL-235B-A22B-Instruct IFB K100_AI 16x vLLM 0.21
- docs/model-deployment/vllm/qwen3-vl.md :: Qwen3-VL-235B-A22B-Thinking IFB K100_AI 16x vLLM 0.21
- docs/model-deployment/vllm/qwen3-vl.md :: Qwen3-VL-30B-A3B-Instruct IFB K100_AI 2x vLLM 0.21
- docs/model-deployment/vllm/qwen3-vl.md :: Qwen3-VL-30B-A3B-Thinking IFB K100_AI 2x vLLM 0.21

## Verification
- Scanned updated K100_AI vLLM 0.21 MoE blocks for `--moe-backend triton`.
- Scanned changed files for `???`.