### PR TITLE
vllm/Gemma-Qwen3: add BW1000 vLLM 0.25 commands

### DIFF
--- a/docs/model-deployment/vllm/gemma-4.md
+++ b/docs/model-deployment/vllm/gemma-4.md
@@ -12,6 +12,24 @@ Gemma-4-31B-it 是 Gemma 系列指令模型，本文档提供其在 vLLM 上的�
 
 ## 启动命令
 
+### Gemma-4-31B-it IFB BW1000 2x vLLM 0.25
+
+```bash
+export VLLM_USE_V2_MODEL_RUNNER=1
+export VLLM_KV_CACHE_LAYOUT=NHD
+
+vllm serve \
+  --model google/gemma-4-31B-it \
+  --tensor-parallel-size 2 \
+  --max-model-len 32768 \
+  --attention-backend TRITON_ATTN \
+  --hf-overrides '{"text_config":{"allow_global_per_layer_attribute_access":true,"global_head_dim":512,"num_global_key_value_heads":4,"use_bidirectional_attention":null}}' \
+  --language-model-only \
+  --enable-auto-tool-choice \
+  --tool-call-parser gemma4 \
+  --reasoning-parser gemma4
+```
+
 ### Gemma-4-31B-it IFB BW1000 1x vLLM 0.21
 
 ```bash

--- a/docs/model-deployment/vllm/gemma-4.md
+++ b/docs/model-deployment/vllm/gemma-4.md
@@ -16,7 +16,7 @@ Gemma-4-31B-it 是 Gemma 系列指令模型，本文档提供其在 vLLM 上的�
 
 ```bash
 export VLLM_USE_V2_MODEL_RUNNER=1
-export VLLM_KV_CACHE_LAYOUT=NHD
+export VLLM_KV_CACHE_LAYOUT=HND
 
 vllm serve \
   --model google/gemma-4-31B-it \

--- a/docs/model-deployment/vllm/qwen3-vl.md
+++ b/docs/model-deployment/vllm/qwen3-vl.md
@@ -498,6 +498,24 @@ vllm serve Qwen/Qwen3-VL-8B-Instruct \
   --kv-cache-dtype fp8_e4m3 \
   --attention-backend FLASH_ATTN_CUSTOM
 ```
+### Qwen3-VL-8B-Instruct IFB BW1000 1x vLLM 0.25
+
+```bash
+export VLLM_USE_V2_MODEL_RUNNER=1
+export VLLM_KV_CACHE_LAYOUT=NHD
+
+vllm serve \
+  --model Qwen/Qwen3-VL-8B-Instruct \
+  --attention-backend FLASH_ATTN_VARLEN \
+  --trust-remote-code \
+  --tensor-parallel-size 1 \
+  --max-model-len 8192 \
+  --default-chat-template-kwargs '{"enable_thinking":false}' \
+  --reasoning-parser qwen3 \
+  --enable-auto-tool-choice \
+  --tool-call-parser qwen3_coder
+```
+
 ### Qwen3-VL-8B-Instruct IFB BW1000 1x vLLM 0.21
 
 ```bash

--- a/docs/model-deployment/vllm/qwen3-vl.md
+++ b/docs/model-deployment/vllm/qwen3-vl.md
@@ -502,7 +502,7 @@ vllm serve Qwen/Qwen3-VL-8B-Instruct \
 
 ```bash
 export VLLM_USE_V2_MODEL_RUNNER=1
-export VLLM_KV_CACHE_LAYOUT=NHD
+export VLLM_KV_CACHE_LAYOUT=HND
 
 vllm serve \
   --model Qwen/Qwen3-VL-8B-Instruct \

--- a/docs/model-deployment/vllm/qwen3-vl.md
+++ b/docs/model-deployment/vllm/qwen3-vl.md
@@ -510,7 +510,6 @@ vllm serve \
   --trust-remote-code \
   --tensor-parallel-size 1 \
   --max-model-len 8192 \
-  --default-chat-template-kwargs '{"enable_thinking":false}' \
   --reasoning-parser qwen3 \
   --enable-auto-tool-choice \
   --tool-call-parser qwen3_coder

--- a/docs/model-deployment/vllm/qwen3.6.md
+++ b/docs/model-deployment/vllm/qwen3.6.md
@@ -55,7 +55,6 @@ vllm serve \
   --trust-remote-code \
   --tensor-parallel-size 2 \
   --max-model-len 32768 \
-  --default-chat-template-kwargs '{"enable_thinking":false}' \
   --reasoning-parser qwen3 \
   --enable-auto-tool-choice \
   --tool-call-parser qwen3_coder

--- a/docs/model-deployment/vllm/qwen3.6.md
+++ b/docs/model-deployment/vllm/qwen3.6.md
@@ -43,6 +43,24 @@ vllm serve Qwen/Qwen3.6-27B \
   --attention-backend FLASH_ATTN_CUSTOM
 ```
 
+### Qwen3.6-27B IFB BW1000 2x vLLM 0.25
+
+```bash
+export VLLM_USE_V2_MODEL_RUNNER=1
+export VLLM_KV_CACHE_LAYOUT=NHD
+
+vllm serve \
+  --model Qwen/Qwen3.6-27B \
+  --attention-backend FLASH_ATTN_VARLEN \
+  --trust-remote-code \
+  --tensor-parallel-size 2 \
+  --max-model-len 32768 \
+  --default-chat-template-kwargs '{"enable_thinking":false}' \
+  --reasoning-parser qwen3 \
+  --enable-auto-tool-choice \
+  --tool-call-parser qwen3_coder
+```
+
 ### Qwen3.6-27B IFB BW1000 2x vLLM 0.21
 
 ```bash

--- a/docs/model-deployment/vllm/qwen3.6.md
+++ b/docs/model-deployment/vllm/qwen3.6.md
@@ -47,7 +47,7 @@ vllm serve Qwen/Qwen3.6-27B \
 
 ```bash
 export VLLM_USE_V2_MODEL_RUNNER=1
-export VLLM_KV_CACHE_LAYOUT=NHD
+export VLLM_KV_CACHE_LAYOUT=HND
 
 vllm serve \
   --model Qwen/Qwen3.6-27B \

--- a/docs/model-deployment/vllm/qwen3.8.md
+++ b/docs/model-deployment/vllm/qwen3.8.md
@@ -36,7 +36,7 @@ vllm serve Qwen/Qwen3.8-27B \
 
 ```bash
 export VLLM_USE_V2_MODEL_RUNNER=1
-export VLLM_KV_CACHE_LAYOUT=NHD
+export VLLM_KV_CACHE_LAYOUT=HND
 
 vllm serve \
   --model Qwen/Qwen3.8-27B \

--- a/docs/model-deployment/vllm/qwen3.8.md
+++ b/docs/model-deployment/vllm/qwen3.8.md
@@ -32,6 +32,24 @@ vllm serve Qwen/Qwen3.8-27B \
   --compilation-config '{"cudagraph_mode":"FULL","max_cudagraph_capture_size":2048}' 
 ```
 
+### Qwen3.8-27B IFB BW1000 2x vLLM 0.25
+
+```bash
+export VLLM_USE_V2_MODEL_RUNNER=1
+export VLLM_KV_CACHE_LAYOUT=NHD
+
+vllm serve \
+  --model Qwen/Qwen3.8-27B \
+  --attention-backend FLASH_ATTN_VARLEN \
+  --trust-remote-code \
+  --tensor-parallel-size 2 \
+  --max-model-len 32768 \
+  --default-chat-template-kwargs '{"enable_thinking":false}' \
+  --reasoning-parser qwen3 \
+  --enable-auto-tool-choice \
+  --tool-call-parser qwen3_coder
+```
+
 ### Qwen3.8-27B IFB BW1000 2x vLLM 0.21
 
 ```bash

--- a/docs/model-deployment/vllm/qwen3.8.md
+++ b/docs/model-deployment/vllm/qwen3.8.md
@@ -44,7 +44,6 @@ vllm serve \
   --trust-remote-code \
   --tensor-parallel-size 2 \
   --max-model-len 32768 \
-  --default-chat-template-kwargs '{"enable_thinking":false}' \
   --reasoning-parser qwen3 \
   --enable-auto-tool-choice \
   --tool-call-parser qwen3_coder


### PR DESCRIPTION
## Summary
- Add BW1000 vLLM 0.25 commands for Gemma-4-31B-it, Qwen3-VL-8B-Instruct, Qwen3.6-27B, and Qwen3.8-27B.
- Keep the vLLM argument order aligned with the requested command format.

## Verification
- Verified all four new vLLM 0.25 BW1000 sections and command parameters.
- Scanned changed files for `???`.