### PR TITLE
docs: normalize MiMo V2 Flash SGLang ordering

### DIFF
--- a/docs/model-deployment/sglang/mimo-v2-flash.md
+++ b/docs/model-deployment/sglang/mimo-v2-flash.md
@@ -9,9 +9,12 @@ MiMo-V2-Flash 是小米推出的大规模 MoE（混合专家）语言模型，�
 | 模型权重 | 量化方式 | SGLang 版本 | 推荐硬件 | 卡数 | 部署方式 | 启动命令 |
 | -------- | -------- | ----------- | -------- | ---- | -------- | -------- |
 | [XiaomiMiMo/MiMo-V2-Flash](https://www.modelscope.cn/models/XiaomiMiMo/MiMo-V2-Flash) | BF16 | 0.5.10 | BW1100 | 8 | IFB | [**`>_`**](#mimo-v2-flash-ifb-bw1100-8x-sglang-0510) |
-| [hygon/MiMo-V2-Flash-Channel-FP8-w8a8](https://www.modelscope.cn/models/hygon/MiMo-V2-Flash-Channel-FP8-w8a8) | FP8 W8A8 | [0.5.10](../docker_images.md) | BW1100 | 8 | IFB | [**`>_`**](#mimo-v2-flash-channel-fp8-w8a8-ifb-bw1100-8x-sglang-0510) |
-| [hygon/MiMo-V2-Flash-Channel-INT8-w8a8](https://www.modelscope.cn/models/hygon/MiMo-V2-Flash-Channel-INT8-w8a8) | INT8 W8A8 | [0.5.10](../docker_images.md) | BW1000 | 8 | IFB | [**`>_`**](#mimo-v2-flash-channel-int8-w8a8-ifb-bw1000-8x-sglang-0510) |
-| [hygon/MiMo-V2-Flash-Channel-FP8-w8a8](https://www.modelscope.cn/models/hygon/MiMo-V2-Flash-Channel-FP8-w8a8) | FP8 W8A8 | 0.5.12 | BW1100 | 20x | 2P0.5D | [**`>_`**](#mimo-v2-flash-channel-fp8-w8a8-2p05d-bw1100-20x-sglang-0512) |
+| [hygon/MiMo-V2-Flash-Channel-INT8-w8a8](https://www.modelscope.cn/models/hygon/MiMo-V2-Flash-Channel-INT8-w8a8) | INT8 W8A8 | [0.5.12](../docker_images.md) | BW1000 | 8 | IFB | [**`>_`**](#mimo-v2-flash-channel-int8-w8a8-ifb-bw1000-8x-sglang-0512) |
+|  | INT8 W8A8 | [0.5.12](../docker_images.md) | K100_AI | 8 | IFB | [**`>_`**](#mimo-v2-flash-channel-int8-w8a8-ifb-k100_ai-8x-sglang-0512) |
+| [hygon/MiMo-V2-Flash-Channel-FP8-w8a8](https://www.modelscope.cn/models/hygon/MiMo-V2-Flash-Channel-FP8-w8a8) | FP8 W8A8 | [0.5.12](../docker_images.md) | BW1100 | 8 | IFB | [**`>_`**](#mimo-v2-flash-channel-fp8-w8a8-ifb-bw1100-8x-sglang-0512) |
+| | FP8 W8A8 | 0.5.12 | BW1100 | 20x | 2P0.5D | [**`>_`**](#mimo-v2-flash-channel-fp8-w8a8-2p05d-bw1100-20x-sglang-0512) |
+|  | INT8 W8A8 | [0.5.10](../docker_images.md) | BW1000 | 8 | IFB | [**`>_`**](#mimo-v2-flash-channel-int8-w8a8-ifb-bw1000-8x-sglang-0510) |
+|  | FP8 W8A8 | [0.5.10](../docker_images.md) | BW1100 | 8 | IFB | [**`>_`**](#mimo-v2-flash-channel-fp8-w8a8-ifb-bw1100-8x-sglang-0510) |
 
 ## 启动命令
 
@@ -43,37 +46,7 @@ sglang serve \
     --speculative-eagle-topk 1 \
     --speculative-num-draft-tokens 4
 ```
-
-### MiMo-V2-Flash-Channel-FP8-w8a8 IFB BW1100 8x SGLang 0.5.10
-
-```bash
-export SGLANG_USE_LIGHTOP=1
-export SGLANG_KV_LAYOUT_DCU_FA=0
-export SGLANG_ENABLE_SPEC_V2=1
-export SGLANG_USE_FP8_W8A8_MOE=1
-export SGLANG_USE_MODELSCOPE=1
-
-sglang serve \
-    --model-path hygon/MiMo-V2-Flash-Channel-FP8-w8a8 \
-    --pp-size 1 \
-    --dp-size 2 \
-    --tp-size 4 \
-    --page-size 64 \
-    --trust-remote-code \
-    --mem-fraction-static 0.85 \
-    --max-running-requests 128 \
-    --tool-call-parser mimo \
-    --disable-radix-cache \
-    --context-length 262144 \
-    --attention-backend fa3 \
-    --chunked-prefill-size -1 \
-    --speculative-algorithm EAGLE \
-    --speculative-num-steps 3 \
-    --speculative-eagle-topk 1 \
-    --speculative-num-draft-tokens 4
-```
-
-### MiMo-V2-Flash-Channel-INT8-w8a8 IFB BW1000 8x SGLang 0.5.10
+### MiMo-V2-Flash-Channel-INT8-w8a8 IFB BW1000 8x SGLang 0.5.12
 
 ```bash
 export HSA_SCRATCH_SINGLE_LIMIT=1073741824
@@ -81,32 +54,95 @@ export HSA_NO_SCRATCH_RECLAIM=1
 export USE_DCU_CUSTOM_ALLREDUCE=1
 export ALLREDUCE_STREAM_WITH_COMPUTE=1
 export SGLANG_USE_LIGHTOP=1
-export SGLANG_KV_LAYOUT_DCU_FA=0
+export SGLANG_KV_LAYOUT_HCU_FA=0
 export SGLANG_ENABLE_SPEC_V2=1
 export SGLANG_USE_MODELSCOPE=1
 
 sglang serve \
-    --model-path hygon/MiMo-V2-Flash-Channel-INT8-w8a8 \
-    --pp-size 1 \
-    --dp-size 1 \
-    --tp-size 8 \
-    --page-size 64 \
-    --trust-remote-code \
-    --mem-fraction-static 0.75 \
-    --quantization slimquant_marlin \
-    --max-running-requests 128 \
-    --tool-call-parser mimo \
-    --context-length 262144 \
-    --chunked-prefill-size -1 \
-    --disable-radix-cache \
-    --port 11010 \
-    --attention-backend fa3 \
-    --speculative-algorithm EAGLE \
-    --speculative-num-steps 3 \
-    --speculative-eagle-topk 1 \
-    --speculative-num-draft-tokens 4
+  --model-path hygon/MiMo-V2-Flash-Channel-INT8-w8a8 \
+  --pp-size 1 \
+  --dp-size 1 \
+  --tp-size 8 \
+  --page-size 128 \
+  --trust-remote-code \
+  --mem-fraction-static 0.75 \
+  --quantization slimquant_marlin \
+  --max-running-requests 128 \
+  --tool-call-parser mimo \
+  --reasoning-parser mimo \
+  --context-length 262144 \
+  --chunked-prefill-size -1 \
+  --attention-backend fa3 \
+  --speculative-algorithm EAGLE \
+  --speculative-num-steps 3 \
+  --speculative-eagle-topk 1 \
+  --speculative-num-draft-tokens 4
 ```
+### MiMo-V2-Flash-Channel-INT8-w8a8 IFB K100_AI 8x SGLang 0.5.12
 
+```bash
+export HSA_SCRATCH_SINGLE_LIMIT=1073741824
+export HSA_NO_SCRATCH_RECLAIM=1
+export USE_DCU_CUSTOM_ALLREDUCE=1
+export ALLREDUCE_STREAM_WITH_COMPUTE=1
+export SGLANG_USE_LIGHTOP=1
+export SGLANG_KV_LAYOUT_HCU_FA=0
+export SGLANG_USE_TRITON_EXTEND_FROM_AITER=1
+export SGLANG_ROCM_USE_AITER_MOE=0
+export SGLANG_ENABLE_SPEC_V2=1
+export SGLANG_USE_MODELSCOPE=1
+export SGLANG_USE_AITER_AR=0
+
+sglang serve \
+  --model-path hygon/MiMo-V2-Flash-Channel-INT8-w8a8 \
+  --pp-size 1 \
+  --dp-size 1 \
+  --tp-size 8 \
+  --page-size 64 \
+  --trust-remote-code \
+  --mem-fraction-static 0.75 \
+  --quantization w8a8_int8 \
+  --max-running-requests 128 \
+  --tool-call-parser mimo \
+  --reasoning-parser mimo \
+  --context-length 262144 \
+  --chunked-prefill-size -1 \
+  --attention-backend triton \
+  --speculative-algorithm EAGLE \
+  --speculative-num-steps 3 \
+  --speculative-eagle-topk 1 \
+  --speculative-num-draft-tokens 4 \
+  --moe-runner-backend triton \
+  --custom-all-reduce-backend native
+```
+### MiMo-V2-Flash-Channel-FP8-w8a8 IFB BW1100 8x SGLang 0.5.12
+
+```bash
+export SGLANG_USE_LIGHTOP=1
+export SGLANG_KV_LAYOUT_HCU_FA=0
+export SGLANG_ENABLE_SPEC_V2=1
+export SGLANG_USE_FP8_W8A8_MOE=1
+export SGLANG_USE_MODELSCOPE=1
+
+sglang serve \
+  --model-path hygon/MiMo-V2-Flash-Channel-FP8-w8a8 \
+  --pp-size 1 \
+  --dp-size 2 \
+  --tp-size 4 \
+  --page-size 64 \
+  --trust-remote-code \
+  --mem-fraction-static 0.85 \
+  --max-running-requests 128 \
+  --tool-call-parser mimo \
+  --reasoning-parser mimo \
+  --context-length 262144 \
+  --attention-backend fa3 \
+  --chunked-prefill-size -1 \
+  --speculative-algorithm EAGLE \
+  --speculative-num-steps 3 \
+  --speculative-eagle-topk 1 \
+  --speculative-num-draft-tokens 4
+```
 ### MiMo-V2-Flash-Channel-FP8-w8a8 2P0.5D BW1100 20x SGLang 0.5.12
 
 网卡配置参考：[IB 网卡](../../troubleshooting/common-issues.md#ib网卡)。
@@ -268,6 +304,67 @@ python3 -m sglang_router.launch_router \
     --decode http://<D_node_ip>:30000 \
     --policy round_robin \
     --port $port
+```
+### MiMo-V2-Flash-Channel-INT8-w8a8 IFB BW1000 8x SGLang 0.5.10
+
+```bash
+export HSA_SCRATCH_SINGLE_LIMIT=1073741824
+export HSA_NO_SCRATCH_RECLAIM=1
+export USE_DCU_CUSTOM_ALLREDUCE=1
+export ALLREDUCE_STREAM_WITH_COMPUTE=1
+export SGLANG_USE_LIGHTOP=1
+export SGLANG_KV_LAYOUT_DCU_FA=0
+export SGLANG_ENABLE_SPEC_V2=1
+export SGLANG_USE_MODELSCOPE=1
+
+sglang serve \
+    --model-path hygon/MiMo-V2-Flash-Channel-INT8-w8a8 \
+    --pp-size 1 \
+    --dp-size 1 \
+    --tp-size 8 \
+    --page-size 64 \
+    --trust-remote-code \
+    --mem-fraction-static 0.75 \
+    --quantization slimquant_marlin \
+    --max-running-requests 128 \
+    --tool-call-parser mimo \
+    --context-length 262144 \
+    --chunked-prefill-size -1 \
+    --disable-radix-cache \
+    --port 11010 \
+    --attention-backend fa3 \
+    --speculative-algorithm EAGLE \
+    --speculative-num-steps 3 \
+    --speculative-eagle-topk 1 \
+    --speculative-num-draft-tokens 4
+```
+### MiMo-V2-Flash-Channel-FP8-w8a8 IFB BW1100 8x SGLang 0.5.10
+
+```bash
+export SGLANG_USE_LIGHTOP=1
+export SGLANG_KV_LAYOUT_DCU_FA=0
+export SGLANG_ENABLE_SPEC_V2=1
+export SGLANG_USE_FP8_W8A8_MOE=1
+export SGLANG_USE_MODELSCOPE=1
+
+sglang serve \
+    --model-path hygon/MiMo-V2-Flash-Channel-FP8-w8a8 \
+    --pp-size 1 \
+    --dp-size 2 \
+    --tp-size 4 \
+    --page-size 64 \
+    --trust-remote-code \
+    --mem-fraction-static 0.85 \
+    --max-running-requests 128 \
+    --tool-call-parser mimo \
+    --disable-radix-cache \
+    --context-length 262144 \
+    --attention-backend fa3 \
+    --chunked-prefill-size -1 \
+    --speculative-algorithm EAGLE \
+    --speculative-num-steps 3 \
+    --speculative-eagle-topk 1 \
+    --speculative-num-draft-tokens 4
 ```
 
 ## API 调用


### PR DESCRIPTION
## Summary
- Normalize the MiMo-V2-Flash SGLang model table and command-section ordering.
- Fix malformed Markdown table syntax and broken command anchors.
- Keep unrelated working-tree changes out of the PR.

## Verification
- Manually checked the model table links and heading order.
- Only docs/model-deployment/sglang/mimo-v2-flash.md was staged and committed.