### PR TITLE
docs: add and normalize SGLang deployment records

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@
     </tr>
     <tr>
       <td>SGLang</td>
-      <td align="center">🚧</td><td align="center">🚧</td><td align="center">🚧</td>
+      <td align="center"><a href="docs/model-deployment/sglang/qwen3-vl.md">✅</a></td><td align="center"><a href="docs/model-deployment/sglang/qwen3-vl.md">✅</a></td><td align="center"><a href="docs/model-deployment/sglang/qwen3-vl.md">✅</a></td>
     </tr>
     <tr>
       <td rowspan="2">Qwen3-Coder</td>
@@ -80,7 +80,7 @@
     </tr>
     <tr>
       <td>SGLang</td>
-      <td align="center">-</td><td align="center"><a href="docs/model-deployment/sglang/qwen3.md">✅</a></td><td align="center"><a href="docs/model-deployment/sglang/qwen3.md">✅</a></td>
+      <td align="center"><a href="docs/model-deployment/sglang/qwen3.md">✅</a></td><td align="center"><a href="docs/model-deployment/sglang/qwen3.md">✅</a></td><td align="center"><a href="docs/model-deployment/sglang/qwen3.md">✅</a></td>
     </tr>
     <tr>
       <td rowspan="2">Qwen2.5-VL</td>
@@ -294,7 +294,7 @@
     </tr>
     <tr>
       <td>SGLang</td>
-      <td align="center">-</td><td align="center"><a href="docs/model-deployment/sglang/mimo-v2-flash.md">✅</a></td><td align="center"><a href="docs/model-deployment/sglang/mimo-v2-flash.md">✅</a></td>
+      <td align="center"><a href="docs/model-deployment/sglang/mimo-v2-flash.md">✅</a></td><td align="center"><a href="docs/model-deployment/sglang/mimo-v2-flash.md">✅</a></td><td align="center"><a href="docs/model-deployment/sglang/mimo-v2-flash.md">✅</a></td>
     </tr>
     <tr>
       <td rowspan="12" align="center"><img src="https://cdn-avatars.huggingface.co/v1/production/uploads/67b610677ea7952def8b29c6/N6jQbbeaa_FcUY-wI1dgG.png" height="40"/><br/>Wan</td>

--- a/docs/model-deployment/sglang/mimo-v2-flash.md
+++ b/docs/model-deployment/sglang/mimo-v2-flash.md
@@ -9,9 +9,12 @@ MiMo-V2-Flash 是小米推出的大规模 MoE（混合专家）语言模型，�
 | 模型权重 | 量化方式 | SGLang 版本 | 推荐硬件 | 卡数 | 部署方式 | 启动命令 |
 | -------- | -------- | ----------- | -------- | ---- | -------- | -------- |
 | [XiaomiMiMo/MiMo-V2-Flash](https://www.modelscope.cn/models/XiaomiMiMo/MiMo-V2-Flash) | BF16 | 0.5.10 | BW1100 | 8 | IFB | [**`>_`**](#mimo-v2-flash-ifb-bw1100-8x-sglang-0510) |
-| [hygon/MiMo-V2-Flash-Channel-FP8-w8a8](https://www.modelscope.cn/models/hygon/MiMo-V2-Flash-Channel-FP8-w8a8) | FP8 W8A8 | [0.5.10](../docker_images.md) | BW1100 | 8 | IFB | [**`>_`**](#mimo-v2-flash-channel-fp8-w8a8-ifb-bw1100-8x-sglang-0510) |
-| [hygon/MiMo-V2-Flash-Channel-INT8-w8a8](https://www.modelscope.cn/models/hygon/MiMo-V2-Flash-Channel-INT8-w8a8) | INT8 W8A8 | [0.5.10](../docker_images.md) | BW1000 | 8 | IFB | [**`>_`**](#mimo-v2-flash-channel-int8-w8a8-ifb-bw1000-8x-sglang-0510) |
-| [hygon/MiMo-V2-Flash-Channel-FP8-w8a8](https://www.modelscope.cn/models/hygon/MiMo-V2-Flash-Channel-FP8-w8a8) | FP8 W8A8 | 0.5.12 | BW1100 | 20x | 2P0.5D | [**`>_`**](#mimo-v2-flash-channel-fp8-w8a8-2p05d-bw1100-20x-sglang-0512) |
+| [hygon/MiMo-V2-Flash-Channel-INT8-w8a8](https://www.modelscope.cn/models/hygon/MiMo-V2-Flash-Channel-INT8-w8a8) | INT8 W8A8 | [0.5.12](../docker_images.md) | BW1000 | 8 | IFB | [**`>_`**](#mimo-v2-flash-channel-int8-w8a8-ifb-bw1000-8x-sglang-0512) |
+|  | INT8 W8A8 | [0.5.12](../docker_images.md) | K100_AI | 8 | IFB | [**`>_`**](#mimo-v2-flash-channel-int8-w8a8-ifb-k100_ai-8x-sglang-0512) |
+| [hygon/MiMo-V2-Flash-Channel-FP8-w8a8](https://www.modelscope.cn/models/hygon/MiMo-V2-Flash-Channel-FP8-w8a8) | FP8 W8A8 | [0.5.12](../docker_images.md) | BW1100 | 8 | IFB | [**`>_`**](#mimo-v2-flash-channel-fp8-w8a8-ifb-bw1100-8x-sglang-0512) |
+| | FP8 W8A8 | 0.5.12 | BW1100 | 20x | 2P0.5D | [**`>_`**](#mimo-v2-flash-channel-fp8-w8a8-2p05d-bw1100-20x-sglang-0512) |
+|  | INT8 W8A8 | [0.5.10](../docker_images.md) | BW1000 | 8 | IFB | [**`>_`**](#mimo-v2-flash-channel-int8-w8a8-ifb-bw1000-8x-sglang-0510) |
+|  | FP8 W8A8 | [0.5.10](../docker_images.md) | BW1100 | 8 | IFB | [**`>_`**](#mimo-v2-flash-channel-fp8-w8a8-ifb-bw1100-8x-sglang-0510) |
 
 ## 启动命令
 
@@ -43,37 +46,7 @@ sglang serve \
     --speculative-eagle-topk 1 \
     --speculative-num-draft-tokens 4
 ```
-
-### MiMo-V2-Flash-Channel-FP8-w8a8 IFB BW1100 8x SGLang 0.5.10
-
-```bash
-export SGLANG_USE_LIGHTOP=1
-export SGLANG_KV_LAYOUT_DCU_FA=0
-export SGLANG_ENABLE_SPEC_V2=1
-export SGLANG_USE_FP8_W8A8_MOE=1
-export SGLANG_USE_MODELSCOPE=1
-
-sglang serve \
-    --model-path hygon/MiMo-V2-Flash-Channel-FP8-w8a8 \
-    --pp-size 1 \
-    --dp-size 2 \
-    --tp-size 4 \
-    --page-size 64 \
-    --trust-remote-code \
-    --mem-fraction-static 0.85 \
-    --max-running-requests 128 \
-    --tool-call-parser mimo \
-    --disable-radix-cache \
-    --context-length 262144 \
-    --attention-backend fa3 \
-    --chunked-prefill-size -1 \
-    --speculative-algorithm EAGLE \
-    --speculative-num-steps 3 \
-    --speculative-eagle-topk 1 \
-    --speculative-num-draft-tokens 4
-```
-
-### MiMo-V2-Flash-Channel-INT8-w8a8 IFB BW1000 8x SGLang 0.5.10
+### MiMo-V2-Flash-Channel-INT8-w8a8 IFB BW1000 8x SGLang 0.5.12
 
 ```bash
 export HSA_SCRATCH_SINGLE_LIMIT=1073741824
@@ -81,32 +54,95 @@ export HSA_NO_SCRATCH_RECLAIM=1
 export USE_DCU_CUSTOM_ALLREDUCE=1
 export ALLREDUCE_STREAM_WITH_COMPUTE=1
 export SGLANG_USE_LIGHTOP=1
-export SGLANG_KV_LAYOUT_DCU_FA=0
+export SGLANG_KV_LAYOUT_HCU_FA=0
 export SGLANG_ENABLE_SPEC_V2=1
 export SGLANG_USE_MODELSCOPE=1
 
 sglang serve \
-    --model-path hygon/MiMo-V2-Flash-Channel-INT8-w8a8 \
-    --pp-size 1 \
-    --dp-size 1 \
-    --tp-size 8 \
-    --page-size 64 \
-    --trust-remote-code \
-    --mem-fraction-static 0.75 \
-    --quantization slimquant_marlin \
-    --max-running-requests 128 \
-    --tool-call-parser mimo \
-    --context-length 262144 \
-    --chunked-prefill-size -1 \
-    --disable-radix-cache \
-    --port 11010 \
-    --attention-backend fa3 \
-    --speculative-algorithm EAGLE \
-    --speculative-num-steps 3 \
-    --speculative-eagle-topk 1 \
-    --speculative-num-draft-tokens 4
+  --model-path hygon/MiMo-V2-Flash-Channel-INT8-w8a8 \
+  --pp-size 1 \
+  --dp-size 1 \
+  --tp-size 8 \
+  --page-size 128 \
+  --trust-remote-code \
+  --mem-fraction-static 0.75 \
+  --quantization slimquant_marlin \
+  --max-running-requests 128 \
+  --tool-call-parser mimo \
+  --reasoning-parser mimo \
+  --context-length 262144 \
+  --chunked-prefill-size -1 \
+  --attention-backend fa3 \
+  --speculative-algorithm EAGLE \
+  --speculative-num-steps 3 \
+  --speculative-eagle-topk 1 \
+  --speculative-num-draft-tokens 4
 ```
+### MiMo-V2-Flash-Channel-INT8-w8a8 IFB K100_AI 8x SGLang 0.5.12
 
+```bash
+export HSA_SCRATCH_SINGLE_LIMIT=1073741824
+export HSA_NO_SCRATCH_RECLAIM=1
+export USE_DCU_CUSTOM_ALLREDUCE=1
+export ALLREDUCE_STREAM_WITH_COMPUTE=1
+export SGLANG_USE_LIGHTOP=1
+export SGLANG_KV_LAYOUT_HCU_FA=0
+export SGLANG_USE_TRITON_EXTEND_FROM_AITER=1
+export SGLANG_ROCM_USE_AITER_MOE=0
+export SGLANG_ENABLE_SPEC_V2=1
+export SGLANG_USE_MODELSCOPE=1
+export SGLANG_USE_AITER_AR=0
+
+sglang serve \
+  --model-path hygon/MiMo-V2-Flash-Channel-INT8-w8a8 \
+  --pp-size 1 \
+  --dp-size 1 \
+  --tp-size 8 \
+  --page-size 64 \
+  --trust-remote-code \
+  --mem-fraction-static 0.75 \
+  --quantization w8a8_int8 \
+  --max-running-requests 128 \
+  --tool-call-parser mimo \
+  --reasoning-parser mimo \
+  --context-length 262144 \
+  --chunked-prefill-size -1 \
+  --attention-backend triton \
+  --speculative-algorithm EAGLE \
+  --speculative-num-steps 3 \
+  --speculative-eagle-topk 1 \
+  --speculative-num-draft-tokens 4 \
+  --moe-runner-backend triton \
+  --custom-all-reduce-backend native
+```
+### MiMo-V2-Flash-Channel-FP8-w8a8 IFB BW1100 8x SGLang 0.5.12
+
+```bash
+export SGLANG_USE_LIGHTOP=1
+export SGLANG_KV_LAYOUT_HCU_FA=0
+export SGLANG_ENABLE_SPEC_V2=1
+export SGLANG_USE_FP8_W8A8_MOE=1
+export SGLANG_USE_MODELSCOPE=1
+
+sglang serve \
+  --model-path hygon/MiMo-V2-Flash-Channel-FP8-w8a8 \
+  --pp-size 1 \
+  --dp-size 2 \
+  --tp-size 4 \
+  --page-size 64 \
+  --trust-remote-code \
+  --mem-fraction-static 0.85 \
+  --max-running-requests 128 \
+  --tool-call-parser mimo \
+  --reasoning-parser mimo \
+  --context-length 262144 \
+  --attention-backend fa3 \
+  --chunked-prefill-size -1 \
+  --speculative-algorithm EAGLE \
+  --speculative-num-steps 3 \
+  --speculative-eagle-topk 1 \
+  --speculative-num-draft-tokens 4
+```
 ### MiMo-V2-Flash-Channel-FP8-w8a8 2P0.5D BW1100 20x SGLang 0.5.12
 
 网卡配置参考：[IB 网卡](../../troubleshooting/common-issues.md#ib网卡)。
@@ -268,6 +304,67 @@ python3 -m sglang_router.launch_router \
     --decode http://<D_node_ip>:30000 \
     --policy round_robin \
     --port $port
+```
+### MiMo-V2-Flash-Channel-INT8-w8a8 IFB BW1000 8x SGLang 0.5.10
+
+```bash
+export HSA_SCRATCH_SINGLE_LIMIT=1073741824
+export HSA_NO_SCRATCH_RECLAIM=1
+export USE_DCU_CUSTOM_ALLREDUCE=1
+export ALLREDUCE_STREAM_WITH_COMPUTE=1
+export SGLANG_USE_LIGHTOP=1
+export SGLANG_KV_LAYOUT_DCU_FA=0
+export SGLANG_ENABLE_SPEC_V2=1
+export SGLANG_USE_MODELSCOPE=1
+
+sglang serve \
+    --model-path hygon/MiMo-V2-Flash-Channel-INT8-w8a8 \
+    --pp-size 1 \
+    --dp-size 1 \
+    --tp-size 8 \
+    --page-size 64 \
+    --trust-remote-code \
+    --mem-fraction-static 0.75 \
+    --quantization slimquant_marlin \
+    --max-running-requests 128 \
+    --tool-call-parser mimo \
+    --context-length 262144 \
+    --chunked-prefill-size -1 \
+    --disable-radix-cache \
+    --port 11010 \
+    --attention-backend fa3 \
+    --speculative-algorithm EAGLE \
+    --speculative-num-steps 3 \
+    --speculative-eagle-topk 1 \
+    --speculative-num-draft-tokens 4
+```
+### MiMo-V2-Flash-Channel-FP8-w8a8 IFB BW1100 8x SGLang 0.5.10
+
+```bash
+export SGLANG_USE_LIGHTOP=1
+export SGLANG_KV_LAYOUT_DCU_FA=0
+export SGLANG_ENABLE_SPEC_V2=1
+export SGLANG_USE_FP8_W8A8_MOE=1
+export SGLANG_USE_MODELSCOPE=1
+
+sglang serve \
+    --model-path hygon/MiMo-V2-Flash-Channel-FP8-w8a8 \
+    --pp-size 1 \
+    --dp-size 2 \
+    --tp-size 4 \
+    --page-size 64 \
+    --trust-remote-code \
+    --mem-fraction-static 0.85 \
+    --max-running-requests 128 \
+    --tool-call-parser mimo \
+    --disable-radix-cache \
+    --context-length 262144 \
+    --attention-backend fa3 \
+    --chunked-prefill-size -1 \
+    --speculative-algorithm EAGLE \
+    --speculative-num-steps 3 \
+    --speculative-eagle-topk 1 \
+    --speculative-num-draft-tokens 4
 ```
 
 ## API 调用

--- a/docs/model-deployment/sglang/qwen3-vl.md
+++ b/docs/model-deployment/sglang/qwen3-vl.md
@@ -1,0 +1,194 @@
+# Qwen3-VL on SGLang
+
+## 模型简介
+
+Qwen3-VL 是阿里云推出的新一代多模态视觉语言模型，支持文本、图像和视频等多模态输入。
+
+## 模型列表
+
+| 模型权重 | 量化方式 | SGLang 版本 | 推荐硬件 | 卡数 | 部署方式 | 启动命令 |
+| -------- | -------- | ----------- | -------- | ---- | -------- | -------- |
+| [Qwen/Qwen3-VL-235B-A22B-Instruct](https://www.modelscope.cn/models/Qwen/Qwen3-VL-235B-A22B-Instruct) | BF16 | [0.5.12](../docker_images.md) | BW1100 | 4x | IFB | [**`>_`**](#qwen3-vl-235b-a22b-instruct-ifb-bw1100-4x-sglang-0512) |
+|  | BF16 | [0.5.12](../docker_images.md) | BW1000 | 8x | IFB | [**`>_`**](#qwen3-vl-235b-a22b-instruct-ifb-bw1000-8x-sglang-0512) |
+|  | BF16 | [0.5.12](../docker_images.md) | K100_AI | 8x | IFB | [**`>_`**](#qwen3-vl-235b-a22b-instruct-ifb-k100_ai-8x-sglang-0512) |
+
+## 启动命令
+
+### Qwen3-VL-235B-A22B-Instruct IFB BW1100 4x SGLang 0.5.12
+
+```bash
+export USE_DCU_CUSTOM_ALLREDUCE=1
+export SGL_CHUNKED_PREFIX_CACHE_THRESHOLD=0
+export SGLANG_DISAGGREGATION_BOOTSTRAP_TIMEOUT=1200
+export GLIBC_TUNABLES=glibc.rtld.optional_static_tls=0x40000
+export SGLANG_TORCH_PROFILER_DIR=/home/profile
+export SGLANG_SET_CPU_AFFINITY=1
+export HIP_KERNEL_BATCH_CEILING=100
+export GPU_MAX_HW_QUEUES=3
+sysctl -w kernel.numa_balancing=0
+export SGLANG_ENABLE_SPEC_V2=1
+export SGLANG_KVALLOC_KERNEL=1
+export SGLANG_CREATE_EXTEND_AFTER_DECODE_SPEC_INFO=1
+export SGLANG_ASSIGN_EXTEND_CACHE_LOCS=1
+export SGLANG_ASSIGN_REQ_TO_TOKEN_POOL=1
+export SGLANG_GET_LAST_LOC=1
+export SGLANG_CREATE_FLASHMLA_KV_INDICES_TRITON=1
+export SGLANG_CREATE_CHUNKED_PREFIX_CACHE_KV_INDICES=1
+export HIP_H2D_DISABLE_COPY_BUFFER=0
+export HIP_D2H_DISABLE_COPY_BUFFER=0
+export HIP_H2D_DIRECT_COPY_THRESHOLD=32768
+export HIP_H2D_HSAAPI_COPY_THRESHOLD=32768
+export HIP_D2H_DIRECT_COPY_THRESHOLD=512
+export HIP_D2H_HSAAPI_COPY_THRESHOLD=512
+export SGLANG_USE_FUSED_RMSNORM_ROPE=1
+export HSA_KERNARG_POOL_SIZE=8388608
+export ROC_AQL_QUEUE_SIZE=131072
+export ALLREDUCE_STREAM_WITH_COMPUTE=1
+export SGLANG_USE_LIGHTOP=1
+export SGLANG_USE_MARLIN_W16A16_MOE=1
+
+sglang serve \
+  --model-path Qwen/Qwen3-VL-235B-A22B-Instruct \
+  --trust-remote-code \
+  --numa-node 0 0 1 1 2 2 3 3 \
+  --mm-attention-backend fa3 \
+  --dtype float16 \
+  --tool-call-parser qwen \
+  --reasoning-parser qwen3 \
+  --kv-cache-dtype fp8_e4m3 \
+  --tensor-parallel-size 4 \
+  --page-size 64 \
+  --nnodes 1 \
+  --node-rank 0 \
+  --mem-fraction-static 0.85 \
+  --attention-backend fa3
+```
+
+### Qwen3-VL-235B-A22B-Instruct IFB BW1000 8x SGLang 0.5.12
+
+```bash
+export USE_DCU_CUSTOM_ALLREDUCE=1
+export SGL_CHUNKED_PREFIX_CACHE_THRESHOLD=0
+export SGLANG_DISAGGREGATION_BOOTSTRAP_TIMEOUT=1200
+export GLIBC_TUNABLES=glibc.rtld.optional_static_tls=0x40000
+export SGLANG_TORCH_PROFILER_DIR=/home/profile
+export SGLANG_SET_CPU_AFFINITY=1
+export HIP_KERNEL_BATCH_CEILING=100
+export GPU_MAX_HW_QUEUES=3
+sysctl -w kernel.numa_balancing=0
+export SGLANG_ENABLE_SPEC_V2=1
+export SGLANG_KVALLOC_KERNEL=1
+export SGLANG_CREATE_EXTEND_AFTER_DECODE_SPEC_INFO=1
+export SGLANG_ASSIGN_EXTEND_CACHE_LOCS=1
+export SGLANG_ASSIGN_REQ_TO_TOKEN_POOL=1
+export SGLANG_GET_LAST_LOC=1
+export SGLANG_CREATE_FLASHMLA_KV_INDICES_TRITON=1
+export SGLANG_CREATE_CHUNKED_PREFIX_CACHE_KV_INDICES=1
+export HIP_H2D_DISABLE_COPY_BUFFER=0
+export HIP_D2H_DISABLE_COPY_BUFFER=0
+export HIP_H2D_DIRECT_COPY_THRESHOLD=32768
+export HIP_H2D_HSAAPI_COPY_THRESHOLD=32768
+export HIP_D2H_DIRECT_COPY_THRESHOLD=512
+export HIP_D2H_HSAAPI_COPY_THRESHOLD=512
+export SGLANG_USE_FUSED_RMSNORM_ROPE=1
+export HSA_KERNARG_POOL_SIZE=8388608
+export ROC_AQL_QUEUE_SIZE=131072
+export NCCL_MAX_NCHANNELS=16
+export NCCL_MIN_NCHANNELS=16
+export NCCL_MIN_NCHANNELS=16
+export ALLREDUCE_STREAM_WITH_COMPUTE=1
+export SGLANG_USE_LIGHTOP=1
+export SGLANG_USE_MARLIN_W16A16_MOE=1
+
+sglang serve \
+  --model-path Qwen/Qwen3-VL-235B-A22B-Instruct \
+  --trust-remote-code \
+  --numa-node 0 0 0 0 1 1 1 1 \
+  --mm-attention-backend fa3 \
+  --dtype float16 \
+  --tool-call-parser qwen3_coder \
+  --reasoning-parser qwen3 \
+  --chunked-prefill-size 8192 \
+  --kv-cache-dtype fp8_e5m2 \
+  --tensor-parallel-size 8 \
+  --page-size 64 \
+  --nnodes 1 \
+  --node-rank 0 \
+  --mem-fraction-static 0.925 \
+  --attention-backend fa3
+```
+
+### Qwen3-VL-235B-A22B-Instruct IFB K100_AI 8x SGLang 0.5.12
+
+```bash
+export USE_DCU_CUSTOM_ALLREDUCE=1
+export SGL_CHUNKED_PREFIX_CACHE_THRESHOLD=0
+export SGLANG_DISAGGREGATION_BOOTSTRAP_TIMEOUT=1200
+export GLIBC_TUNABLES=glibc.rtld.optional_static_tls=0x40000
+export SGLANG_TORCH_PROFILER_DIR=/home/profile
+export SGLANG_SET_CPU_AFFINITY=1
+export HIP_KERNEL_BATCH_CEILING=100
+export GPU_MAX_HW_QUEUES=3
+sysctl -w kernel.numa_balancing=0
+export SGLANG_ENABLE_SPEC_V2=1
+export SGLANG_KVALLOC_KERNEL=1
+export SGLANG_CREATE_EXTEND_AFTER_DECODE_SPEC_INFO=1
+export SGLANG_ASSIGN_EXTEND_CACHE_LOCS=1
+export SGLANG_ASSIGN_REQ_TO_TOKEN_POOL=1
+export SGLANG_GET_LAST_LOC=1
+export SGLANG_CREATE_FLASHMLA_KV_INDICES_TRITON=1
+export SGLANG_CREATE_CHUNKED_PREFIX_CACHE_KV_INDICES=1
+export HIP_H2D_DISABLE_COPY_BUFFER=0
+export HIP_D2H_DISABLE_COPY_BUFFER=0
+export HIP_H2D_DIRECT_COPY_THRESHOLD=32768
+export HIP_H2D_HSAAPI_COPY_THRESHOLD=32768
+export HIP_D2H_DIRECT_COPY_THRESHOLD=512
+export HIP_D2H_HSAAPI_COPY_THRESHOLD=512
+export SGLANG_USE_FUSED_RMSNORM_ROPE=1
+export HSA_KERNARG_POOL_SIZE=8388608
+export ROC_AQL_QUEUE_SIZE=131072
+export NCCL_MAX_NCHANNELS=16
+export NCCL_MIN_NCHANNELS=16
+export NCCL_MIN_NCHANNELS=16
+export ALLREDUCE_STREAM_WITH_COMPUTE=1
+export SGLANG_USE_LIGHTOP=1
+
+sglang serve \
+  --model-path Qwen/Qwen3-VL-235B-A22B-Instruct \
+  --trust-remote-code \
+  --numa-node 0 0 0 0 1 1 1 1 \
+  --mm-attention-backend fa3 \
+  --dtype float16 \
+  --tool-call-parser qwen3_coder \
+  --reasoning-parser qwen3 \
+  --tensor-parallel-size 8 \
+  --page-size 64 \
+  --nnodes 1 \
+  --node-rank 0 \
+  --disable-custom-all-reduce \
+  --mem-fraction-static 0.91 \
+  --attention-backend fa3
+```
+
+## API 调用
+
+### IFB
+
+```python
+from openai import OpenAI
+
+client = OpenAI(base_url="http://localhost:30000/v1", api_key="not-needed")
+
+response = client.chat.completions.create(
+    model="Qwen/Qwen3-VL-235B-A22B-Instruct",
+    messages=[{"role": "user", "content": "请描述图片内容"}],
+    max_tokens=1024,
+)
+print(response.choices[0].message.content)
+```
+
+```bash
+curl http://localhost:30000/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{"model": "Qwen/Qwen3-VL-235B-A22B-Instruct", "messages": [{"role": "user", "content": "请描述图片内容"}], "max_tokens": 128}'
+```

--- a/docs/model-deployment/sglang/qwen3.md
+++ b/docs/model-deployment/sglang/qwen3.md
@@ -9,6 +9,12 @@ Qwen3 是阿里通义千问第三代大语言模型，支持 0.6B ~ 235B 多种�
 | 模型权重 | 量化方式 | SGLang 版本 | 推荐硬件 | 卡数 | 部署方式 | 启动命令 |
 | -------- | -------- | ----------- | -------- | ---- | -------- | -------- |
 | [Qwen/Qwen3-8B](https://www.modelscope.cn/models/Qwen/Qwen3-8B) | BF16 | 0.5.10 | BW1000 | 1x | IFB | [**\`>_\`**](#qwen3-8b-ifb-bw1000-1x-sglang-0510) |
+| [Qwen/Qwen3-30B-A3B](https://www.modelscope.cn/models/Qwen/Qwen3-30B-A3B) | BF16 | [0.5.12](../docker_images.md) | BW1100 | 1x | IFB | [**\`>_\`**](#qwen3-30b-a3b-ifb-bw1100-1x-sglang-0512) |
+|  | BF16 | [0.5.12](../docker_images.md) | BW1000 | 2x | IFB | [**\`>_\`**](#qwen3-30b-a3b-ifb-bw1000-2x-sglang-0512) |
+|  | BF16 | [0.5.12](../docker_images.md) | K100_AI | 2x | IFB | [**\`>_\`**](#qwen3-30b-a3b-ifb-k100_ai-2x-sglang-0512) |
+| [hygon/Qwen3-30B-A3B-Channel-INT8-w8a8](https://www.modelscope.cn/models/hygon/Qwen3-30B-A3B-Channel-INT8-w8a8) | INT8 W8A8 | [0.5.12](../docker_images.md) | BW1100 | 1x | IFB | [**\`>_\`**](#qwen3-30b-a3b-channel-int8-w8a8-ifb-bw1100-1x-sglang-0512) |
+|  | INT8 W8A8 | [0.5.12](../docker_images.md) | BW1000 | 1x | IFB | [**\`>_\`**](#qwen3-30b-a3b-channel-int8-w8a8-ifb-bw1000-1x-sglang-0512) |
+|  | INT8 W8A8 | [0.5.12](../docker_images.md) | K100_AI | 1x | IFB | [**\`>_\`**](#qwen3-30b-a3b-channel-int8-w8a8-ifb-k100_ai-1x-sglang-0512) |
 | [Qwen/Qwen3-32B](https://www.modelscope.cn/models/Qwen/Qwen3-32B) | BF16 | 0.5.10 | BW1100 | 2x | IFB | [**\`>_\`**](#qwen3-32b-ifb-bw1100-2x-sglang-0510) |
 | [Qwen/Qwen3-235B-A22B](https://www.modelscope.cn/models/Qwen/Qwen3-235B-A22B) | BF16 | 0.5.10 | BW1100 | 4x | IFB | [**\`>_\`**](#qwen3-235b-a22b-ifb-bw1100-4x-sglang-0510) |
 
@@ -24,6 +30,295 @@ python -m sglang.launch_server \
     --attention-backend fa3 \
     --page-size 64 \
     --mem-fraction-static 0.85
+```
+
+### Qwen3-30B-A3B IFB BW1100 1x SGLang 0.5.12
+
+```bash
+export USE_DCU_CUSTOM_ALLREDUCE=1
+export SGL_CHUNKED_PREFIX_CACHE_THRESHOLD=0
+export SGLANG_DISAGGREGATION_BOOTSTRAP_TIMEOUT=1200
+export GLIBC_TUNABLES=glibc.rtld.optional_static_tls=0x40000
+export SGLANG_TORCH_PROFILER_DIR=/home/profile
+export SGLANG_SET_CPU_AFFINITY=1
+export HIP_KERNEL_BATCH_CEILING=100
+export GPU_MAX_HW_QUEUES=3
+sysctl -w kernel.numa_balancing=0
+export SGLANG_ENABLE_SPEC_V2=1
+export SGLANG_KVALLOC_KERNEL=1
+export SGLANG_CREATE_EXTEND_AFTER_DECODE_SPEC_INFO=1
+export SGLANG_ASSIGN_EXTEND_CACHE_LOCS=1
+export SGLANG_ASSIGN_REQ_TO_TOKEN_POOL=1
+export SGLANG_GET_LAST_LOC=1
+export SGLANG_CREATE_FLASHMLA_KV_INDICES_TRITON=1
+export SGLANG_CREATE_CHUNKED_PREFIX_CACHE_KV_INDICES=1
+export HIP_H2D_DISABLE_COPY_BUFFER=0
+export HIP_D2H_DISABLE_COPY_BUFFER=0
+export HIP_H2D_DIRECT_COPY_THRESHOLD=32768
+export HIP_H2D_HSAAPI_COPY_THRESHOLD=32768
+export HIP_D2H_DIRECT_COPY_THRESHOLD=512
+export HIP_D2H_HSAAPI_COPY_THRESHOLD=512
+export SGLANG_USE_FUSED_RMSNORM_ROPE=1
+export HSA_KERNARG_POOL_SIZE=8388608
+export ROC_AQL_QUEUE_SIZE=131072
+export ALLREDUCE_STREAM_WITH_COMPUTE=1
+export SGLANG_USE_LIGHTOP=1
+export SGLANG_USE_MARLIN_W16A16_MOE=1
+
+sglang serve \
+  --model-path Qwen/Qwen3-30B-A3B \
+  --trust-remote-code \
+  --numa-node 0 0 0 0 1 1 1 1 \
+  --dtype float16 \
+  --kv-cache-dtype fp8_e4m3 \
+  --tensor-parallel-size 1 \
+  --page-size 64 \
+  --tool-call-parser qwen \
+  --reasoning-parser qwen3 \
+  --mem-fraction-static 0.9 \
+  --attention-backend fa3
+```
+
+### Qwen3-30B-A3B IFB BW1000 2x SGLang 0.5.12
+
+```bash
+export USE_DCU_CUSTOM_ALLREDUCE=1
+export SGL_CHUNKED_PREFIX_CACHE_THRESHOLD=0
+export SGLANG_DISAGGREGATION_BOOTSTRAP_TIMEOUT=1200
+export GLIBC_TUNABLES=glibc.rtld.optional_static_tls=0x40000
+export SGLANG_TORCH_PROFILER_DIR=/home/profile
+export SGLANG_SET_CPU_AFFINITY=1
+export HIP_KERNEL_BATCH_CEILING=100
+export GPU_MAX_HW_QUEUES=3
+sysctl -w kernel.numa_balancing=0
+export SGLANG_ENABLE_SPEC_V2=1
+export SGLANG_KVALLOC_KERNEL=1
+export SGLANG_CREATE_EXTEND_AFTER_DECODE_SPEC_INFO=1
+export SGLANG_ASSIGN_EXTEND_CACHE_LOCS=1
+export SGLANG_ASSIGN_REQ_TO_TOKEN_POOL=1
+export SGLANG_GET_LAST_LOC=1
+export SGLANG_CREATE_FLASHMLA_KV_INDICES_TRITON=1
+export SGLANG_CREATE_CHUNKED_PREFIX_CACHE_KV_INDICES=1
+export HIP_H2D_DISABLE_COPY_BUFFER=0
+export HIP_D2H_DISABLE_COPY_BUFFER=0
+export HIP_H2D_DIRECT_COPY_THRESHOLD=32768
+export HIP_H2D_HSAAPI_COPY_THRESHOLD=32768
+export HIP_D2H_DIRECT_COPY_THRESHOLD=512
+export HIP_D2H_HSAAPI_COPY_THRESHOLD=512
+export SGLANG_USE_FUSED_RMSNORM_ROPE=1
+export HSA_KERNARG_POOL_SIZE=8388608
+export ROC_AQL_QUEUE_SIZE=131072
+export ALLREDUCE_STREAM_WITH_COMPUTE=1
+export SGLANG_USE_LIGHTOP=1
+export SGLANG_USE_MARLIN_W16A16_MOE=1
+
+sglang serve \
+  --model-path Qwen/Qwen3-30B-A3B \
+  --trust-remote-code \
+  --numa-node 0 0 0 0 1 1 1 1 \
+  --dtype float16 \
+  --kv-cache-dtype fp8_e5m2 \
+  --tensor-parallel-size 2 \
+  --page-size 64 \
+  --tool-call-parser qwen \
+  --reasoning-parser qwen3 \
+  --mem-fraction-static 0.9 \
+  --attention-backend fa3
+```
+
+### Qwen3-30B-A3B IFB K100_AI 2x SGLang 0.5.12
+
+```bash
+export USE_DCU_CUSTOM_ALLREDUCE=1
+export SGL_CHUNKED_PREFIX_CACHE_THRESHOLD=0
+export SGLANG_DISAGGREGATION_BOOTSTRAP_TIMEOUT=1200
+export GLIBC_TUNABLES=glibc.rtld.optional_static_tls=0x40000
+export SGLANG_TORCH_PROFILER_DIR=/home/profile
+export SGLANG_SET_CPU_AFFINITY=1
+export HIP_KERNEL_BATCH_CEILING=100
+export GPU_MAX_HW_QUEUES=3
+sysctl -w kernel.numa_balancing=0
+export SGLANG_ENABLE_SPEC_V2=1
+export SGLANG_KVALLOC_KERNEL=1
+export SGLANG_CREATE_EXTEND_AFTER_DECODE_SPEC_INFO=1
+export SGLANG_ASSIGN_EXTEND_CACHE_LOCS=1
+export SGLANG_ASSIGN_REQ_TO_TOKEN_POOL=1
+export SGLANG_GET_LAST_LOC=1
+export SGLANG_CREATE_FLASHMLA_KV_INDICES_TRITON=1
+export SGLANG_CREATE_CHUNKED_PREFIX_CACHE_KV_INDICES=1
+export HIP_H2D_DISABLE_COPY_BUFFER=0
+export HIP_D2H_DISABLE_COPY_BUFFER=0
+export HIP_H2D_DIRECT_COPY_THRESHOLD=32768
+export HIP_H2D_HSAAPI_COPY_THRESHOLD=32768
+export HIP_D2H_DIRECT_COPY_THRESHOLD=512
+export HIP_D2H_HSAAPI_COPY_THRESHOLD=512
+export SGLANG_USE_FUSED_RMSNORM_ROPE=1
+export HSA_KERNARG_POOL_SIZE=8388608
+export ROC_AQL_QUEUE_SIZE=131072
+export ALLREDUCE_STREAM_WITH_COMPUTE=1
+export SGLANG_USE_LIGHTOP=1
+export SGLANG_ROCM_USE_AITER_MOE=0
+
+
+sglang serve \
+  --model-path Qwen/Qwen3-30B-A3B \
+  --trust-remote-code \
+  --numa-node 0 0 0 0 1 1 1 1 \
+  --dtype float16 \
+  --moe-runner-backend triton \
+  --tensor-parallel-size 2 \
+  --page-size 64 \
+  --tool-call-parser qwen \
+  --disable-custom-all-reduce \
+  --reasoning-parser qwen3 \
+  --mem-fraction-static 0.9 \
+  --attention-backend fa3
+```
+
+### Qwen3-30B-A3B-Channel-INT8-w8a8 IFB BW1100 1x SGLang 0.5.12
+
+```bash
+export USE_DCU_CUSTOM_ALLREDUCE=1
+export SGL_CHUNKED_PREFIX_CACHE_THRESHOLD=0
+export SGLANG_DISAGGREGATION_BOOTSTRAP_TIMEOUT=1200
+export GLIBC_TUNABLES=glibc.rtld.optional_static_tls=0x40000
+export SGLANG_TORCH_PROFILER_DIR=/home/profile
+export SGLANG_SET_CPU_AFFINITY=1
+export HIP_KERNEL_BATCH_CEILING=100
+export GPU_MAX_HW_QUEUES=3
+sysctl -w kernel.numa_balancing=0
+export SGLANG_ENABLE_SPEC_V2=1
+export SGLANG_KVALLOC_KERNEL=1
+export SGLANG_CREATE_EXTEND_AFTER_DECODE_SPEC_INFO=1
+export SGLANG_ASSIGN_EXTEND_CACHE_LOCS=1
+export SGLANG_ASSIGN_REQ_TO_TOKEN_POOL=1
+export SGLANG_GET_LAST_LOC=1
+export SGLANG_CREATE_FLASHMLA_KV_INDICES_TRITON=1
+export SGLANG_CREATE_CHUNKED_PREFIX_CACHE_KV_INDICES=1
+export HIP_H2D_DISABLE_COPY_BUFFER=0
+export HIP_D2H_DISABLE_COPY_BUFFER=0
+export HIP_H2D_DIRECT_COPY_THRESHOLD=32768
+export HIP_H2D_HSAAPI_COPY_THRESHOLD=32768
+export HIP_D2H_DIRECT_COPY_THRESHOLD=512
+export HIP_D2H_HSAAPI_COPY_THRESHOLD=512
+export SGLANG_USE_FUSED_RMSNORM_ROPE=1
+export HSA_KERNARG_POOL_SIZE=8388608
+export ROC_AQL_QUEUE_SIZE=131072
+export ALLREDUCE_STREAM_WITH_COMPUTE=1
+export SGLANG_USE_LIGHTOP=1
+export SGLANG_USE_MARLIN_W16A16_MOE=1
+
+sglang serve \
+  --model-path hygon/Qwen3-30B-A3B-Channel-INT8-w8a8 \
+  --trust-remote-code \
+  --numa-node 0 0 0 0 1 1 1 1 \
+  --dtype bfloat16 \
+  --quantization w8a8_int8 \
+  --moe-runner-backend lightop \
+  --tool-call-parser qwen \
+  --reasoning-parser qwen3 \
+  --tensor-parallel-size 1 \
+  --kv-cache-dtype fp8_e4m3 \
+  --page-size 64 \
+  --mem-fraction-static 0.9 \
+  --attention-backend fa3
+```
+
+### Qwen3-30B-A3B-Channel-INT8-w8a8 IFB BW1000 1x SGLang 0.5.12
+
+```bash
+export USE_DCU_CUSTOM_ALLREDUCE=1
+export SGL_CHUNKED_PREFIX_CACHE_THRESHOLD=0
+export SGLANG_DISAGGREGATION_BOOTSTRAP_TIMEOUT=1200
+export GLIBC_TUNABLES=glibc.rtld.optional_static_tls=0x40000
+export SGLANG_TORCH_PROFILER_DIR=/home/profile
+export SGLANG_SET_CPU_AFFINITY=1
+export HIP_KERNEL_BATCH_CEILING=100
+export GPU_MAX_HW_QUEUES=3
+sysctl -w kernel.numa_balancing=0
+export SGLANG_ENABLE_SPEC_V2=1
+export SGLANG_KVALLOC_KERNEL=1
+export SGLANG_CREATE_EXTEND_AFTER_DECODE_SPEC_INFO=1
+export SGLANG_ASSIGN_EXTEND_CACHE_LOCS=1
+export SGLANG_ASSIGN_REQ_TO_TOKEN_POOL=1
+export SGLANG_GET_LAST_LOC=1
+export SGLANG_CREATE_FLASHMLA_KV_INDICES_TRITON=1
+export SGLANG_CREATE_CHUNKED_PREFIX_CACHE_KV_INDICES=1
+export HIP_H2D_DISABLE_COPY_BUFFER=0
+export HIP_D2H_DISABLE_COPY_BUFFER=0
+export HIP_H2D_DIRECT_COPY_THRESHOLD=32768
+export HIP_H2D_HSAAPI_COPY_THRESHOLD=32768
+export HIP_D2H_DIRECT_COPY_THRESHOLD=512
+export HIP_D2H_HSAAPI_COPY_THRESHOLD=512
+export SGLANG_USE_FUSED_RMSNORM_ROPE=1
+export HSA_KERNARG_POOL_SIZE=8388608
+export ROC_AQL_QUEUE_SIZE=131072
+export ALLREDUCE_STREAM_WITH_COMPUTE=1
+export SGLANG_USE_LIGHTOP=1
+
+sglang serve \
+  --model-path hygon/Qwen3-30B-A3B-Channel-INT8-w8a8 \
+  --trust-remote-code \
+  --numa-node 0 0 0 0 1 1 1 1 \
+  --dtype bfloat16 \
+  --quantization w8a8_int8 \
+  --moe-runner-backend lightop \
+  --tool-call-parser qwen \
+  --reasoning-parser qwen3 \
+  --tensor-parallel-size 1 \
+  --kv-cache-dtype fp8_e5m2 \
+  --page-size 64 \
+  --mem-fraction-static 0.9 \
+  --attention-backend fa3
+```
+
+### Qwen3-30B-A3B-Channel-INT8-w8a8 IFB K100_AI 1x SGLang 0.5.12
+
+```bash
+export USE_DCU_CUSTOM_ALLREDUCE=1
+export SGL_CHUNKED_PREFIX_CACHE_THRESHOLD=0
+export SGLANG_DISAGGREGATION_BOOTSTRAP_TIMEOUT=1200
+export GLIBC_TUNABLES=glibc.rtld.optional_static_tls=0x40000
+export SGLANG_TORCH_PROFILER_DIR=/home/profile
+export SGLANG_SET_CPU_AFFINITY=1
+export HIP_KERNEL_BATCH_CEILING=100
+export GPU_MAX_HW_QUEUES=3
+sysctl -w kernel.numa_balancing=0
+export SGLANG_ENABLE_SPEC_V2=1
+export SGLANG_KVALLOC_KERNEL=1
+export SGLANG_CREATE_EXTEND_AFTER_DECODE_SPEC_INFO=1
+export SGLANG_ASSIGN_EXTEND_CACHE_LOCS=1
+export SGLANG_ASSIGN_REQ_TO_TOKEN_POOL=1
+export SGLANG_GET_LAST_LOC=1
+export SGLANG_CREATE_FLASHMLA_KV_INDICES_TRITON=1
+export SGLANG_CREATE_CHUNKED_PREFIX_CACHE_KV_INDICES=1
+export HIP_H2D_DISABLE_COPY_BUFFER=0
+export HIP_D2H_DISABLE_COPY_BUFFER=0
+export HIP_H2D_DIRECT_COPY_THRESHOLD=32768
+export HIP_H2D_HSAAPI_COPY_THRESHOLD=32768
+export HIP_D2H_DIRECT_COPY_THRESHOLD=512
+export HIP_D2H_HSAAPI_COPY_THRESHOLD=512
+export SGLANG_USE_FUSED_RMSNORM_ROPE=1
+export HSA_KERNARG_POOL_SIZE=8388608
+export ROC_AQL_QUEUE_SIZE=131072
+export ALLREDUCE_STREAM_WITH_COMPUTE=1
+export SGLANG_USE_LIGHTOP=1
+export SGLANG_USE_MARLIN_W16A16_MOE=1
+export SGLANG_ROCM_USE_AITER_MOE=0
+
+sglang serve \
+  --model-path hygon/Qwen3-30B-A3B-Channel-INT8-w8a8 \
+  --trust-remote-code \
+  --numa-node 0 0 0 0 1 1 1 1 \
+  --dtype bfloat16 \
+  --quantization w8a8_int8 \
+  --moe-runner-backend triton \
+  --tool-call-parser qwen \
+  --reasoning-parser qwen3 \
+  --tensor-parallel-size 1 \
+  --page-size 64 \
+  --mem-fraction-static 0.9 \
+  --attention-backend fa3
 ```
 
 ### Qwen3-32B IFB BW1100 2x SGLang 0.5.10


### PR DESCRIPTION
## Summary
- Add Qwen3-VL SGLang deployment documentation.
- Add Qwen3-30B-A3B deployment records for supported hardware.
- Normalize MiMo-V2-Flash model-table links and command-section ordering.
- Update the README support matrix.

## Verification
- Ran git diff --check.
- Checked model-table anchors against deployment section headings.
- Confirmed all current working-tree changes are committed.