### PR TITLE
docs(fd): add DeepSeek-R1 and Qwen3-VL SGLang deployments

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@
     </tr>
     <tr>
       <td>SGLang</td>
-      <td align="center">🚧</td><td align="center">🚧</td><td align="center">🚧</td>
+      <td align="center">🚧</td><td align="center"><a href="docs/model-deployment/sglang/qwen3-vl.md">✅</a></td><td align="center"><a href="docs/model-deployment/sglang/qwen3-vl.md">✅</a></td>
     </tr>
     <tr>
       <td rowspan="2">Qwen3-Coder</td>

--- a/docs/model-deployment/sglang/deepseek-r1.md
+++ b/docs/model-deployment/sglang/deepseek-r1.md
@@ -8,9 +8,72 @@ DeepSeek-R1 是 DeepSeek 推出的推理强化模型系列，面向复杂推理�
 
 | 模型权重 | 量化方式 | SGLang 版本 | 推荐硬件 | 卡数 | 部署方式 | 启动命令 |
 | -------- | -------- | ----------- | -------- | ---- | -------- | -------- |
-| [hygon/DeepSeek-R1-Channel-FP8-w8a8](https://www.modelscope.cn/models/hygon/DeepSeek-R1-Channel-FP8-w8a8) | FP8 W8A8 | 0.5.10 | BW1100 | 8x | IFB | [**\`>_\`**](#deepseek-r1-channel-fp8-w8a8-ifb-bw1100-8x-sglang-0510) |
+| [hygon/DeepSeek-R1-Channel-FP8-w8a8](https://www.modelscope.cn/models/hygon/DeepSeek-R1-Channel-FP8-w8a8) | FP8 W8A8 | [0.5.12](../docker_images.md) | BW1100 | 8x | IFB | [**\`>_\`**](#deepseek-r1-channel-fp8-w8a8-ifb-bw1100-8x-sglang-0512) |
+|  | FP8 W8A8 | 0.5.10 | BW1100 | 8x | IFB | [**\`>_\`**](#deepseek-r1-channel-fp8-w8a8-ifb-bw1100-8x-sglang-0510) |
 
 ## 启动命令
+
+### DeepSeek-R1-Channel-FP8-w8a8 IFB BW1100 8x SGLang 0.5.12
+
+```bash
+export USE_HCU_CUSTOM_ALLREDUCE=1
+export SGLANG_CHUNKED_PREFIX_CACHE_THRESHOLD=0
+export SGLANG_DISAGGREGATION_BOOTSTRAP_TIMEOUT=1200
+export GLIBC_TUNABLES=glibc.rtld.optional_static_tls=0x40000
+export SGLANG_KVALLOC_KERNEL=1
+export SGLANG_USE_LIGHTOP=0
+export SGLANG_USE_FUSED_RMS_QUANT=0
+export SGLANG_USE_OPT_CAT=1
+export SGLANG_USE_FP8_W8A8_MOE=1
+export SGLANG_USE_RMS_QUANT_PATH=1
+export USE_FUSED_RMS_QUANT_PATH=1
+export SGLANG_USE_FUSED_RMSNORM_ROPE=0
+export SGLANG_TORCH_PROFILER_DIR=/workspace/prof
+export SGLANG_SET_CPU_AFFINITY=1
+export HIP_KERNEL_BATCH_CEILING=100
+export GPU_MAX_HW_QUEUES=4
+export SGLANG_ENABLE_SPEC_V2=1
+export SGLANG_CREATE_EXTEND_AFTER_DECODE_SPEC_INFO=1
+export SGLANG_ASSIGN_EXTEND_CACHE_LOCS=1
+export SGLANG_ASSIGN_REQ_TO_TOKEN_POOL=1
+export SGLANG_GET_LAST_LOC=1
+export SGLANG_CREATE_FLASHMLA_KV_INDICES_TRITON=1
+export SGLANG_CREATE_CHUNKED_PREFIX_CACHE_KV_INDICES=1
+export HIP_H2D_DISABLE_COPY_BUFFER=0
+export HIP_D2H_DISABLE_COPY_BUFFER=0
+export HIP_H2D_DIRECT_COPY_THRESHOLD=32768
+export HIP_H2D_HSAAPI_COPY_THRESHOLD=32768
+export HIP_D2H_DIRECT_COPY_THRESHOLD=512
+export HIP_D2H_HSAAPI_COPY_THRESHOLD=512
+export HSA_KERNARG_POOL_SIZE=8388608
+export ROC_AQL_QUEUE_SIZE=131072
+export ALLREDUCE_STREAM_WITH_COMPUTE=1
+export USE_SPE_MQP=1
+export MC_ALLOWED_IBV_DEVICES=mlx5_6,mlx5_7,mlx5_2,mlx5_3,mlx5_4,mlx5_5,mlx5_8,mlx5_9
+
+sglang serve \
+  --model-path hygon/DeepSeek-R1-Channel-FP8-w8a8 \
+  --numa-node 0 0 0 0 1 1 1 1 \
+  --chunked-prefill-size -1 \
+  --max-running-requests 256 \
+  --speculative-algorithm EAGLE \
+  --speculative-num-steps 2 \
+  --speculative-eagle-topk 1 \
+  --speculative-num-draft-tokens 1 \
+  --context-length 65536 \
+  --quantization w8a8_fp8 \
+  --kv-cache-dtype fp8_e4m3 \
+  --trust-remote-code \
+  --nnodes 1 \
+  --node-rank 0 \
+  --dtype bfloat16 \
+  --tp-size 8 \
+  --pp-size 1 \
+  --mem-fraction-static 0.9 \
+  --reasoning-parser deepseek-r1 \
+  --tool-call-parser deepseekv31 \
+  --attention-backend hcu_mla
+```
 
 ### DeepSeek-R1-Channel-FP8-w8a8 IFB BW1100 8x SGLang 0.5.10
 ```bash

--- a/docs/model-deployment/sglang/qwen3-vl.md
+++ b/docs/model-deployment/sglang/qwen3-vl.md
@@ -1,0 +1,136 @@
+# Qwen3-VL on SGLang
+
+## 模型简介
+
+Qwen3-VL 是 Qwen 系列的视觉语言模型，支持图像理解、文本生成和推理任务。
+
+## 模型列表
+
+| 模型权重 | 量化方式 | SGLang 版本 | 推荐硬件 | 卡数 | 部署方式 | 启动命令 |
+| -------- | -------- | ----------- | -------- | ---- | -------- | -------- |
+| [Qwen/Qwen3-VL-30B-A3B-Thinking](https://www.modelscope.cn/models/Qwen/Qwen3-VL-30B-A3B-Thinking) | BF16 | [0.5.12](../docker_images.md) | BW1100 | 1x | IFB | [**`>_`**](#qwen3-vl-30b-a3b-thinking-ifb-bw1100-1x-sglang-0512) |
+|  | BF16 | [0.5.12](../docker_images.md) | BW1000 | 2x | IFB | [**`>_`**](#qwen3-vl-30b-a3b-thinking-ifb-bw1000-2x-sglang-0512) |
+
+## 启动命令
+
+### Qwen3-VL-30B-A3B-Thinking IFB BW1100 1x SGLang 0.5.12
+
+```bash
+export USE_DCU_CUSTOM_ALLREDUCE=1
+export SGL_CHUNKED_PREFIX_CACHE_THRESHOLD=0
+export SGLANG_DISAGGREGATION_BOOTSTRAP_TIMEOUT=1200
+export GLIBC_TUNABLES=glibc.rtld.optional_static_tls=0x40000
+export SGLANG_TORCH_PROFILER_DIR=/home/profile
+export SGLANG_SET_CPU_AFFINITY=1
+export HIP_KERNEL_BATCH_CEILING=100
+export GPU_MAX_HW_QUEUES=3
+sysctl -w kernel.numa_balancing=0
+export SGLANG_ENABLE_SPEC_V2=1
+export SGLANG_KVALLOC_KERNEL=1
+export SGLANG_CREATE_EXTEND_AFTER_DECODE_SPEC_INFO=1
+export SGLANG_ASSIGN_EXTEND_CACHE_LOCS=1
+export SGLANG_ASSIGN_REQ_TO_TOKEN_POOL=1
+export SGLANG_GET_LAST_LOC=1
+export SGLANG_CREATE_FLASHMLA_KV_INDICES_TRITON=1
+export SGLANG_CREATE_CHUNKED_PREFIX_CACHE_KV_INDICES=1
+export HIP_H2D_DISABLE_COPY_BUFFER=0
+export HIP_D2H_DISABLE_COPY_BUFFER=0
+export HIP_H2D_DIRECT_COPY_THRESHOLD=32768
+export HIP_H2D_HSAAPI_COPY_THRESHOLD=32768
+export HIP_D2H_DIRECT_COPY_THRESHOLD=512
+export HIP_D2H_HSAAPI_COPY_THRESHOLD=512
+export SGLANG_USE_FUSED_RMSNORM_ROPE=1
+export HSA_KERNARG_POOL_SIZE=8388608
+export ROC_AQL_QUEUE_SIZE=131072
+export ALLREDUCE_STREAM_WITH_COMPUTE=1
+export SGLANG_USE_LIGHTOP=1
+export SGLANG_USE_MARLIN_W16A16_MOE=1
+
+sglang serve \
+  --model-path Qwen/Qwen3-VL-30B-A3B-Thinking \
+  --trust-remote-code \
+  --numa-node 0 0 0 0 1 1 1 1 \
+  --mm-attention-backend fa3 \
+  --dtype bfloat16 \
+  --kv-cache-dtype fp8_e4m3 \
+  --tensor-parallel-size 1 \
+  --page-size 64 \
+  --nnodes 1 \
+  --node-rank 0 \
+  --reasoning-parser qwen3-thinking \
+  --tool-call-parser qwen \
+  --mem-fraction-static 0.9 \
+  --attention-backend fa3
+```
+
+### Qwen3-VL-30B-A3B-Thinking IFB BW1000 2x SGLang 0.5.12
+
+```bash
+export USE_DCU_CUSTOM_ALLREDUCE=1
+export SGL_CHUNKED_PREFIX_CACHE_THRESHOLD=0
+export SGLANG_DISAGGREGATION_BOOTSTRAP_TIMEOUT=1200
+export GLIBC_TUNABLES=glibc.rtld.optional_static_tls=0x40000
+export SGLANG_TORCH_PROFILER_DIR=/home/profile
+export SGLANG_SET_CPU_AFFINITY=1
+export HIP_KERNEL_BATCH_CEILING=100
+export GPU_MAX_HW_QUEUES=3
+sysctl -w kernel.numa_balancing=0
+export SGLANG_ENABLE_SPEC_V2=1
+export SGLANG_KVALLOC_KERNEL=1
+export SGLANG_CREATE_EXTEND_AFTER_DECODE_SPEC_INFO=1
+export SGLANG_ASSIGN_EXTEND_CACHE_LOCS=1
+export SGLANG_ASSIGN_REQ_TO_TOKEN_POOL=1
+export SGLANG_GET_LAST_LOC=1
+export SGLANG_CREATE_FLASHMLA_KV_INDICES_TRITON=1
+export SGLANG_CREATE_CHUNKED_PREFIX_CACHE_KV_INDICES=1
+export HIP_H2D_DISABLE_COPY_BUFFER=0
+export HIP_D2H_DISABLE_COPY_BUFFER=0
+export HIP_H2D_DIRECT_COPY_THRESHOLD=32768
+export HIP_H2D_HSAAPI_COPY_THRESHOLD=32768
+export HIP_D2H_DIRECT_COPY_THRESHOLD=512
+export HIP_D2H_HSAAPI_COPY_THRESHOLD=512
+export SGLANG_USE_FUSED_RMSNORM_ROPE=1
+export HSA_KERNARG_POOL_SIZE=8388608
+export ROC_AQL_QUEUE_SIZE=131072
+export ALLREDUCE_STREAM_WITH_COMPUTE=1
+export SGLANG_USE_LIGHTOP=1
+export SGLANG_USE_MARLIN_W16A16_MOE=1
+
+sglang serve \
+  --model-path Qwen/Qwen3-VL-30B-A3B-Thinking \
+  --trust-remote-code \
+  --numa-node 0 0 0 0 1 1 1 1 \
+  --mm-attention-backend fa3 \
+  --dtype bfloat16 \
+  --kv-cache-dtype fp8_e5m2 \
+  --tensor-parallel-size 2 \
+  --page-size 64 \
+  --nnodes 1 \
+  --node-rank 0 \
+  --reasoning-parser qwen3-thinking \
+  --tool-call-parser qwen \
+  --mem-fraction-static 0.9 \
+  --attention-backend fa3
+```
+
+## API 调用
+
+### IFB
+
+```python
+from openai import OpenAI
+
+client = OpenAI(base_url="http://localhost:30000/v1", api_key="not-needed")
+
+response = client.chat.completions.create(
+    model="Qwen/Qwen3-VL-30B-A3B-Thinking",
+    messages=[...],
+    max_tokens=2048,
+)
+```
+
+```bash
+curl http://localhost:30000/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{"model": "Qwen/Qwen3-VL-30B-A3B-Thinking", "messages": [...], "max_tokens": 128}'
+```

--- a/docs/model-deployment/sglang/qwen3-vl.md
+++ b/docs/model-deployment/sglang/qwen3-vl.md
@@ -8,11 +8,11 @@ Qwen3-VL 是阿里云推出的新一代多模态视觉语言模型，支持文�
 
 | 模型权重 | 量化方式 | SGLang 版本 | 推荐硬件 | 卡数 | 部署方式 | 启动命令 |
 | -------- | -------- | ----------- | -------- | ---- | -------- | -------- |
+| [Qwen/Qwen3-VL-30B-A3B-Thinking](https://www.modelscope.cn/models/Qwen/Qwen3-VL-30B-A3B-Thinking) | BF16 | [0.5.12](../docker_images.md) | BW1100 | 1x | IFB | [**`>_`**](#qwen3-vl-30b-a3b-thinking-ifb-bw1100-1x-sglang-0512) |
+|  | BF16 | [0.5.12](../docker_images.md) | BW1000 | 2x | IFB | [**`>_`**](#qwen3-vl-30b-a3b-thinking-ifb-bw1000-2x-sglang-0512) |
 | [Qwen/Qwen3-VL-235B-A22B-Instruct](https://www.modelscope.cn/models/Qwen/Qwen3-VL-235B-A22B-Instruct) | BF16 | [0.5.12](../docker_images.md) | BW1100 | 4x | IFB | [**`>_`**](#qwen3-vl-235b-a22b-instruct-ifb-bw1100-4x-sglang-0512) |
 |  | BF16 | [0.5.12](../docker_images.md) | BW1000 | 8x | IFB | [**`>_`**](#qwen3-vl-235b-a22b-instruct-ifb-bw1000-8x-sglang-0512) |
 |  | BF16 | [0.5.12](../docker_images.md) | K100_AI | 8x | IFB | [**`>_`**](#qwen3-vl-235b-a22b-instruct-ifb-k100_ai-8x-sglang-0512) |
-| [Qwen/Qwen3-VL-30B-A3B-Thinking](https://www.modelscope.cn/models/Qwen/Qwen3-VL-30B-A3B-Thinking) | BF16 | [0.5.12](../docker_images.md) | BW1100 | 1x | IFB | [**`>_`**](#qwen3-vl-30b-a3b-thinking-ifb-bw1100-1x-sglang-0512) |
-|  | BF16 | [0.5.12](../docker_images.md) | BW1000 | 2x | IFB | [**`>_`**](#qwen3-vl-30b-a3b-thinking-ifb-bw1000-2x-sglang-0512) |
 
 ## 启动命令
 


### PR DESCRIPTION
## Summary
- Add the SGLang 0.5.12 BW1100 record for DeepSeek-R1 Channel FP8.
- Add Qwen3-VL-30B-A3B-Thinking SGLang records for BW1100 and BW1000.
- Update the README support matrix.
- Leave the DeepSeek-R1-0528 INT8 model out of scope.

## Verification
- Ran git diff --check.
- Checked model IDs, table anchors, section headings, and command model paths for consistency.
- Preserved the existing DeepSeek-R1 SGLang 0.5.10 command.