### PR TITLE
docs: fix GLM custom all-reduce option

### DIFF
--- a/docs/model-deployment/sglang/glm-5.1.md
+++ b/docs/model-deployment/sglang/glm-5.1.md
@@ -59,7 +59,7 @@ sglang serve \
   --speculative-num-steps 3 \
   --speculative-eagle-topk 1 \
   --speculative-num-draft-tokens 4 \
-  --custom-all-reduce-backen aiter
+  --custom-all-reduce-backend aiter
 ~~~
 
 ### GLM-5.1-Channel-FP8-w8a8 IFB BW1100 8x SGLang 0.5.12 (tp8)
@@ -109,7 +109,7 @@ sglang serve \
   --speculative-num-steps 3 \
   --speculative-eagle-topk 1 \
   --speculative-num-draft-tokens 4 \
-  --custom-all-reduce-backen aiter
+  --custom-all-reduce-backend aiter
 ~~~
 
 ### GLM-5.1-Channel-FP8-w8a8 IFB BW1100 8x SGLang 0.5.12 (tp8ep8cp8)
@@ -235,7 +235,7 @@ sglang serve \
   --speculative-num-steps 3 \
   --speculative-eagle-topk 1 \
   --speculative-num-draft-tokens 4 \
-  --custom-all-reduce-backen aiter
+  --custom-all-reduce-backend aiter
 ~~~
 
 ### GLM-5.1-Channel-INT4-w4a8 IFB BW1000 8x SGLang 0.5.12

--- a/docs/model-deployment/sglang/glm-5.md
+++ b/docs/model-deployment/sglang/glm-5.md
@@ -71,7 +71,7 @@ sglang serve \
   --speculative-num-steps 3 \
   --speculative-eagle-topk 1 \
   --speculative-num-draft-tokens 4 \
-  --custom-all-reduce-backen aiter
+  --custom-all-reduce-backend aiter
 ```
 
 ### GLM-5-Channel-INT4-w4a8 IFB BW1000 8x SGLang 0.5.12
@@ -554,7 +554,7 @@ sglang serve \
   --speculative-num-steps 3 \
   --speculative-eagle-topk 1 \
   --speculative-num-draft-tokens 4 \
-  --custom-all-reduce-backen aiter
+  --custom-all-reduce-backend aiter
 ```
 
 ### GLM-5-Channel-INT8-w8a8 IFB BW1100 8x SGLang 0.5.10
@@ -877,7 +877,7 @@ sglang serve \
   --speculative-num-steps 3 \
   --speculative-eagle-topk 1 \
   --speculative-num-draft-tokens 4 \
-  --custom-all-reduce-backen aiter
+  --custom-all-reduce-backend aiter
 ~~~
 
 ### GLM-5-Channel-FP8-w8a8 IFB BW1100 8x SGLang 0.5.12 (tp8ep8cp8)


### PR DESCRIPTION
## Summary
- Fix the SGLang custom all-reduce backend option in GLM-5 deployment examples.
- Apply the same option correction to GLM-5.1 deployment examples.

## Verification
- Ran git diff --check successfully.
- Confirmed only glm-5.md and glm-5.1.md are included.