### PR TITLE
vllm/Qwen3-VL-32B-Instruct: add BW1000 max model len

### DIFF
--- a/docs/model-deployment/vllm/qwen3-vl.md
+++ b/docs/model-deployment/vllm/qwen3-vl.md
@@ -891,6 +891,7 @@ export VLLM_USE_MODELSCOPE=1
 vllm serve Qwen/Qwen3-VL-32B-Instruct \
   -tp 2 \
   --trust-remote-code \
+  --max-model-len 32768 \
   --attention-backend FLASH_ATTN_CUSTOM
 ```
 ### Qwen3-VL-32B-Instruct IFB K100_AI 2x vLLM 0.21


### PR DESCRIPTION
## Summary
- Add `--max-model-len 32768` to Qwen3-VL-32B-Instruct BW1000 vLLM 0.21 command.

## Verification
- Verified the target BW1000 vLLM 0.21 section contains `--max-model-len 32768`.
- Scanned the changed file for `???`.