### PR TITLE
vllm/Qwen2: remove BW1100 kv cache dtype

### DIFF
--- a/docs/model-deployment/vllm/qwen2-vl.md
+++ b/docs/model-deployment/vllm/qwen2-vl.md
@@ -28,7 +28,6 @@ vllm serve Qwen/Qwen2-VL-2B-Instruct \
     --trust-remote-code \
     --gpu-memory-utilization 0.95 \
     --chat-template-content-format openai \
-    --kv-cache-dtype fp8_e4m3 \
     --attention-backend FLASH_ATTN_CUSTOM
 ```
 

--- a/docs/model-deployment/vllm/qwen2.md
+++ b/docs/model-deployment/vllm/qwen2.md
@@ -172,7 +172,6 @@ export VLLM_USE_MODELSCOPE=1
 vllm serve Qwen/Qwen2-1.5B-Instruct \
   -tp 1 \
   --trust-remote-code \
-  --kv-cache-dtype fp8_e4m3 \
   --attention-backend FLASH_ATTN_CUSTOM
 ```
 


### PR DESCRIPTION
## Summary
- Remove `--kv-cache-dtype fp8_e4m3` from Qwen2-1.5B-Instruct BW1100 vLLM 0.21 command.
- Remove `--kv-cache-dtype fp8_e4m3` from Qwen2-VL-2B-Instruct BW1100 vLLM 0.21 command.

## Verification
- Verified both target BW1100 vLLM 0.21 sections no longer contain `--kv-cache-dtype fp8_e4m3`.
- Scanned changed files for `???`.