### PR TITLE
vllm/Qwen3-VL-32B-Instruct: add K100_AI max model len

### DIFF
--- a/docs/model-deployment/vllm/qwen3-vl.md
+++ b/docs/model-deployment/vllm/qwen3-vl.md
@@ -906,6 +906,7 @@ export VLLM_ROCM_USE_AITER_MOE=0
 vllm serve Qwen/Qwen3-VL-32B-Instruct \
   -tp 2 \
   --trust-remote-code \
+  --max-model-len 32768 \
   --attention-backend TRITON_ATTN
 ```
 ### Qwen3-VL-32B-Instruct IFB BW1100 1x vLLM 0.18


### PR DESCRIPTION
## Summary
- Add `--max-model-len 32768` to Qwen3-VL-32B-Instruct K100_AI vLLM 0.21 command.

## Verification
- Verified the target K100_AI vLLM 0.21 section contains `--max-model-len 32768`.
- Scanned the changed file for `???`.