### PR TITLE
vllm/Qwen3-VL-8B-Instruct: update vLLM 0.25 max model len

### DIFF
--- a/docs/model-deployment/vllm/qwen3-vl.md
+++ b/docs/model-deployment/vllm/qwen3-vl.md
@@ -509,7 +509,7 @@ vllm serve \
   --attention-backend FLASH_ATTN_VARLEN \
   --trust-remote-code \
   --tensor-parallel-size 1 \
-  --max-model-len 8192 \
+  --max-model-len 32768 \
   --reasoning-parser qwen3 \
   --enable-auto-tool-choice \
   --tool-call-parser qwen3_coder


### PR DESCRIPTION
## Summary
- Update Qwen3-VL-8B-Instruct BW1000 vLLM 0.25 `--max-model-len` from `8192` to `32768`.

## Verification
- Verified the target vLLM 0.25 section contains `--max-model-len 32768`.
- Scanned the changed file for `???`.