### PR TITLE
vllm/Gemma-4-31B-it: remove language model only arg

### DIFF
--- a/docs/model-deployment/vllm/gemma-4.md
+++ b/docs/model-deployment/vllm/gemma-4.md
@@ -24,7 +24,6 @@ vllm serve \
   --max-model-len 32768 \
   --attention-backend TRITON_ATTN \
   --hf-overrides '{"text_config":{"allow_global_per_layer_attribute_access":true,"global_head_dim":512,"num_global_key_value_heads":4,"use_bidirectional_attention":null}}' \
-  --language-model-only \
   --enable-auto-tool-choice \
   --tool-call-parser gemma4 \
   --reasoning-parser gemma4


### PR DESCRIPTION
## Summary
- Remove `--language-model-only` from the Gemma-4-31B-it BW1000 vLLM 0.25 command.

## Verification
- Verified the target BW1000 vLLM 0.25 section no longer contains `--language-model-only`.
- Scanned the changed file for `???`.