### PR TITLE
vllm/Qwen3-30B-A3B-Channel-INT8-w8a8: remove fp8 cache dtype

### DIFF
--- a/docs/model-deployment/vllm/qwen3.md
+++ b/docs/model-deployment/vllm/qwen3.md
@@ -1272,7 +1272,6 @@ vllm serve Qwen/Qwen3-30B-A3B-Instruct-2507-W8A8 \
   --trust-remote-code \
   --max-num-batched-tokens 10240 \
   --q slimquant_marlin \
-  --kv-cache-dtype fp8_e4m3 \
   --attention-backend FLASH_ATTN_CUSTOM
 ```
 


### PR DESCRIPTION
## Summary
- Remove `--kv-cache-dtype fp8_e4m3` from the Qwen3-30B-A3B-Channel-INT8-w8a8 vLLM 0.21 command.

## Verification
- Verified the target vLLM 0.21 section no longer contains `--kv-cache-dtype fp8_e4m3`.
- Scanned the changed file for `???`.