### PR TITLE
vllm/Gemma-4-31B-it: add vLLM 0.25 model list entry

### DIFF
--- a/docs/model-deployment/vllm/gemma-4.md
+++ b/docs/model-deployment/vllm/gemma-4.md
@@ -8,6 +8,7 @@ Gemma-4-31B-it 是 Gemma 系列指令模型，本文档提供其在 vLLM 上的�
 
 | 模型权重 | 量化方式 | vLLM 版本 | 推荐硬件 | 卡数 | 部署方式 | 启动命令 |
 | -------- | -------- | --------- | -------- | ---- | -------- | -------- |
+| [hygon/gemma-4-31B-it](https://www.modelscope.cn/models/hygon/gemma-4-31B-it) | BF16 | 0.25 | BW1000 | 2 | IFB | [**`>_`**](#gemma-4-31b-it-ifb-bw1000-2x-vllm-025) |
 | [hygon/gemma-4-31B-it](https://www.modelscope.cn/models/hygon/gemma-4-31B-it) | BF16 | 0.21 | BW1000 | 1 | IFB | [**`>_`**](#gemma-4-31b-it-ifb-bw1000-1x-vllm-021) |
 
 ## 启动命令


### PR DESCRIPTION
## Summary
- Add the Gemma-4-31B-it BW1000 vLLM 0.25 entry to the model list.
- The vLLM 0.25 command already has `--language-model-only` removed on current main.

## Verification
- Verified the model list contains the vLLM 0.25 BW1000 entry.
- Verified the Gemma-4-31B-it BW1000 vLLM 0.25 command does not contain `--language-model-only`.
- Scanned the changed file for `???`.