### PR TITLE
vllm/MiniMax-M2.5-bf16: update max model len

### DIFF
--- a/docs/model-deployment/vllm/minimax-2.x.md
+++ b/docs/model-deployment/vllm/minimax-2.x.md
@@ -431,7 +431,7 @@ export VLLM_ROCM_USE_AITER_MOE=0
 vllm serve MiniMax-M2.5-bf16 \
   -tp 8 \
   --trust-remote-code \
-  --max-model-len 73216 \
+  --max-model-len 32768 \
   --max-num-batched-tokens 16384 \
   --enable-prefix-caching \
   --gpu-memory-utilization 0.92 \
@@ -451,7 +451,7 @@ export VLLM_ROCM_USE_AITER_MOE=0
 vllm serve MiniMax-M2.5-bf16 \
   -tp 8 \
   --trust-remote-code \
-  --max-model-len 73216 \
+  --max-model-len 32768 \
   --max-num-batched-tokens 16384 \
   --enable-prefix-caching \
   --gpu-memory-utilization 0.92 \


### PR DESCRIPTION
## Summary
- Update MiniMax-M2.5-bf16 vLLM 0.21 BW1100/BW1000 commands to use --max-model-len 32768.
- Leave other MiniMax sections unchanged.

## Verification
- Checked the scoped diff for docs/model-deployment/vllm/minimax-2.x.md.
- Verified both MiniMax-M2.5-bf16 vLLM 0.21 sections use --max-model-len 32768 and no longer use 73216.
- Ran git diff --check.