### PR TITLE
vllm/Qwen2-57B-A14B-Instruct: add BW1000 MoE backend

### DIFF
--- a/docs/model-deployment/vllm/qwen2.md
+++ b/docs/model-deployment/vllm/qwen2.md
@@ -401,7 +401,8 @@ export VLLM_USE_MODELSCOPE=1
 vllm serve Qwen/Qwen2-57B-A14B-Instruct \
   -tp 4 \
   --trust-remote-code \
-  --attention-backend FLASH_ATTN_CUSTOM
+  --attention-backend FLASH_ATTN_CUSTOM \
+  --moe-backend triton
 ```
 
 ### Qwen2-57B-A14B-Instruct IFB K100_AI 4x vLLM 0.21


### PR DESCRIPTION
## Summary
- Add --moe-backend triton to the Qwen2-57B-A14B-Instruct IFB BW1000 4x vLLM 0.21 command.
- Leave the existing BW1100, K100_AI, and older vLLM sections unchanged.

## Verification
- Checked the scoped diff for docs/model-deployment/vllm/qwen2.md.
- Confirmed the BW1000 vLLM 0.21 section contains --moe-backend triton.
- Ran git diff --check origin/main...HEAD.