### PR TITLE
docs(qwen3.5): set K100 memory utilization

### DIFF
--- a/docs/model-deployment/vllm/qwen3.5.md
+++ b/docs/model-deployment/vllm/qwen3.5.md
@@ -1245,6 +1245,7 @@ export VLLM_ROCM_USE_AITER_MOE=0
 
 vllm serve Qwen/Qwen3.5-397B-A17B-W8A8-INT8 \
   -tp 8 \
+  --gpu-memory-utilization 0.92 \
   --trust-remote-code \
   --max-num-batched-tokens 16384 \
   --speculative-config.method mtp \


### PR DESCRIPTION
## Summary
- Set --gpu-memory-utilization 0.92 for the Qwen3.5-397B-A17B-W8A8-INT8 K100_AI vLLM 0.21 deployment command.

## Verification
- git diff --check`n- Confirmed the commit contains exactly one added line.