### PR TITLE
docs: mark Hy3 SGLang BW1000 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@
     </tr>
     <tr>
       <td>SGLang</td>
-      <td align="center">-</td><td align="center">-</td><td align="center"><a href="docs/model-deployment/sglang/hy3.md">✅</a></td>
+      <td align="center">-</td><td align="center"><a href="docs/model-deployment/sglang/hy3.md">✅</a></td><td align="center"><a href="docs/model-deployment/sglang/hy3.md">✅</a></td>
     </tr>
     <tr>
       <td rowspan="6" align="center"><img src="https://cdn-avatars.huggingface.co/v1/production/uploads/641c1e77c3983aa9490f8121/X1yT2rsaIbR9cdYGEVu0X.jpeg" height="40"/><br/>Moonshot AI</td>


### PR DESCRIPTION
## Summary

- Update the Hy3 SGLang support matrix in `README.md`.
- Mark BW1000 as verified and link it to the existing Hy3 SGLang deployment guide.
- Keep the existing BW1100 support entry unchanged.

## Documentation

- Deployment guide: `docs/model-deployment/sglang/hy3.md`
- The guide already contains Hy3 INT8 W8A8 deployment commands for BW1000.