### PR TITLE
vllm/Qwen2-57B-A14B-Instruct: add 0.25 MoE align env

### DIFF
--- a/docs/model-deployment/vllm/qwen2.md
+++ b/docs/model-deployment/vllm/qwen2.md
@@ -35,7 +35,9 @@ Qwen2 是阿里通义千问开源大语言模型系列，支持多种参数规�
 |  | BF16 | [0.18-hotfix](../docker_images.md) | BW1100 | 1 | IFB | [**`>_`**](#qwen2-7b-instruct-ifb-bw1100-1x-vllm-018-hotfix) |
 |  | BF16 | [0.18-hotfix](../docker_images.md) | BW1000 | 1 | IFB | [**`>_`**](#qwen2-7b-instruct-ifb-bw1000-1x-vllm-018-hotfix) |
 |  | BF16 | [0.18-hotfix](../docker_images.md) | K100_AI | 1 | IFB | [**`>_`**](#qwen2-7b-instruct-ifb-k100_ai-1x-vllm-018-hotfix) |
-| [Qwen/Qwen2-57B-A14B-Instruct](https://www.modelscope.cn/models/Qwen/Qwen2-57B-A14B-Instruct) | BF16 | 0.21 | BW1100 | 2 | IFB | [**`>_`**](#qwen2-57b-a14b-instruct-ifb-bw1100-2x-vllm-021) |
+| [Qwen/Qwen2-57B-A14B-Instruct](https://www.modelscope.cn/models/Qwen/Qwen2-57B-A14B-Instruct) | BF16 | 0.25 | BW1100 | 2 | IFB | [**`>_`**](#qwen2-57b-a14b-instruct-ifb-bw1100-2x-vllm-025) |
+|  | BF16 | 0.25 | BW1000 | 4 | IFB | [**`>_`**](#qwen2-57b-a14b-instruct-ifb-bw1000-4x-vllm-025) |
+|  | BF16 | 0.21 | BW1100 | 2 | IFB | [**`>_`**](#qwen2-57b-a14b-instruct-ifb-bw1100-2x-vllm-021) |
 |  | BF16 | 0.21 | BW1000 | 4 | IFB | [**`>_`**](#qwen2-57b-a14b-instruct-ifb-bw1000-4x-vllm-021) |
 |  | BF16 | 0.21 | K100_AI | 4 | IFB | [**`>_`**](#qwen2-57b-a14b-instruct-ifb-k100_ai-4x-vllm-021) |
 |  | BF16 | 0.18 | BW1100 | 2 | IFB | [**`>_`**](#qwen2-57b-a14b-instruct-ifb-bw1100-2x-vllm-018) |
@@ -378,6 +380,33 @@ export VLLM_USE_MODELSCOPE=1
 vllm serve Qwen/Qwen2-7B-Instruct \
   -tp 1 \
   --trust-remote-code
+```
+
+### Qwen2-57B-A14B-Instruct IFB BW1100 2x vLLM 0.25
+
+```bash
+export VLLM_USE_MODELSCOPE=1
+export VLLM_HCU_USE_CUSTOM_OPS=0
+export VLLM_HCU_USE_LIGHTOP_MOE_ALIGN=0
+
+vllm serve Qwen/Qwen2-57B-A14B-Instruct \
+  -tp 2 \
+  --trust-remote-code \
+  --attention-backend FLASH_ATTN_CUSTOM \
+  --moe-backend triton
+```
+
+### Qwen2-57B-A14B-Instruct IFB BW1000 4x vLLM 0.25
+
+```bash
+export VLLM_USE_MODELSCOPE=1
+export VLLM_HCU_USE_LIGHTOP_MOE_ALIGN=0
+
+vllm serve Qwen/Qwen2-57B-A14B-Instruct \
+  -tp 4 \
+  --trust-remote-code \
+  --attention-backend FLASH_ATTN_CUSTOM \
+  --moe-backend triton
 ```
 
 ### Qwen2-57B-A14B-Instruct IFB BW1100 2x vLLM 0.21


### PR DESCRIPTION
## Summary
- Add vLLM 0.25 BW1100 and BW1000 entries for Qwen2-57B-A14B-Instruct.
- Add export VLLM_HCU_USE_LIGHTOP_MOE_ALIGN=0 to both vLLM 0.25 commands.
- Place the vLLM 0.25 entries ahead of the existing vLLM 0.21 entries in the model list and command sections.

## Verification
- Confirmed both vLLM 0.25 sections contain export VLLM_HCU_USE_LIGHTOP_MOE_ALIGN=0.
- Confirmed both vLLM 0.25 entries are present in the model list.
- Confirmed the vLLM 0.25 sections appear before the model's vLLM 0.21 sections.
- Ran git diff --check.