### PR TITLE
vllm/Qwen2-57B-A14B-Instruct: update 0.21 env vars

### DIFF
--- a/docs/model-deployment/vllm/qwen2.md
+++ b/docs/model-deployment/vllm/qwen2.md
@@ -387,7 +387,6 @@ vllm serve Qwen/Qwen2-7B-Instruct \
 ```bash
 export VLLM_USE_MODELSCOPE=1
 export VLLM_HCU_USE_CUSTOM_OPS=0
-export VLLM_HCU_USE_LIGHTOP_MOE_ALIGN=0
 
 vllm serve Qwen/Qwen2-57B-A14B-Instruct \
   -tp 2 \
@@ -400,7 +399,6 @@ vllm serve Qwen/Qwen2-57B-A14B-Instruct \
 
 ```bash
 export VLLM_USE_MODELSCOPE=1
-export VLLM_HCU_USE_LIGHTOP_MOE_ALIGN=0
 
 vllm serve Qwen/Qwen2-57B-A14B-Instruct \
   -tp 4 \
@@ -413,7 +411,7 @@ vllm serve Qwen/Qwen2-57B-A14B-Instruct \
 
 ```bash
 export VLLM_USE_MODELSCOPE=1
-export VLLM_HCU_USE_CUSTOM_OPS=0
+export VLLM_HCU_USE_LIGHTOP_MOE_ALIGN=0
 
 vllm serve Qwen/Qwen2-57B-A14B-Instruct \
   -tp 2 \
@@ -426,6 +424,7 @@ vllm serve Qwen/Qwen2-57B-A14B-Instruct \
 
 ```bash
 export VLLM_USE_MODELSCOPE=1
+export VLLM_HCU_USE_LIGHTOP_MOE_ALIGN=0
 
 vllm serve Qwen/Qwen2-57B-A14B-Instruct \
   -tp 4 \


### PR DESCRIPTION
## Summary
- Move export VLLM_HCU_USE_LIGHTOP_MOE_ALIGN=0 from Qwen2-57B-A14B-Instruct vLLM 0.25 commands to the vLLM 0.21 BW1100 and BW1000 commands.
- Remove export VLLM_HCU_USE_CUSTOM_OPS=0 from the vLLM 0.21 BW1100 command.
- Leave the vLLM 0.21 K100_AI section unchanged for LIGHTOP_MOE_ALIGN.

## Verification
- Confirmed the vLLM 0.21 BW1100 and BW1000 sections contain export VLLM_HCU_USE_LIGHTOP_MOE_ALIGN=0.
- Confirmed the vLLM 0.21 BW1100 section no longer contains export VLLM_HCU_USE_CUSTOM_OPS=0.
- Confirmed the vLLM 0.25 BW1100 and BW1000 sections no longer contain export VLLM_HCU_USE_LIGHTOP_MOE_ALIGN=0.
- Ran git diff --check origin/main...HEAD.