### PR TITLE
vllm/Qwen: update 0.25 attention backend

### DIFF
--- a/docs/model-deployment/vllm/qwen3-vl.md
+++ b/docs/model-deployment/vllm/qwen3-vl.md
@@ -497,7 +497,7 @@ export VLLM_KV_CACHE_LAYOUT=NHD
 
 vllm serve \
   --model Qwen/Qwen3-VL-8B-Instruct \
-  --attention-backend FLASH_ATTN_VARLEN \
+  --attention-backend FLASH_ATTN \
   --trust-remote-code \
   --tensor-parallel-size 1 \
   --max-model-len 32768

--- a/docs/model-deployment/vllm/qwen3.6.md
+++ b/docs/model-deployment/vllm/qwen3.6.md
@@ -38,7 +38,7 @@ export VLLM_KV_CACHE_LAYOUT=HND
 
 vllm serve \
   --model Qwen/Qwen3.6-27B \
-  --attention-backend FLASH_ATTN_VARLEN \
+  --attention-backend FLASH_ATTN \
   --trust-remote-code \
   --tensor-parallel-size 2 \
   --max-model-len 32768 \

--- a/docs/model-deployment/vllm/qwen3.8.md
+++ b/docs/model-deployment/vllm/qwen3.8.md
@@ -28,7 +28,7 @@ export VLLM_KV_CACHE_LAYOUT=HND
 
 vllm serve \
   --model Qwen/Qwen3.8-27B \
-  --attention-backend FLASH_ATTN_VARLEN \
+  --attention-backend FLASH_ATTN \
   --trust-remote-code \
   --tensor-parallel-size 2 \
   --max-model-len 32768 \


### PR DESCRIPTION
## Summary
- Change vLLM 0.25 Qwen attention backend from FLASH_ATTN_VARLEN to FLASH_ATTN.

## Verification
- git grep -n 'FLASH_ATTN_VARLEN' -- docs/model-deployment/vllm returned no matches
- git diff --check