### PR TITLE
vllm/Gemma-4-31B-it: update 0.21 attention backend

### DIFF
--- a/docs/model-deployment/vllm/gemma-4.md
+++ b/docs/model-deployment/vllm/gemma-4.md
@@ -40,7 +40,7 @@ vllm serve hygon/gemma-4-31B-it \
     --tool-call-parser gemma4 \
     --reasoning-parser gemma4 \
     --chat-template tool_chat_template_gemma4.jinja \
-    --attention-backend FLASH_ATTN_CUTLASS
+    --attention-backend TRITON_ATTN
 ```
 
 ## API 调用


### PR DESCRIPTION
## Summary
- Update Gemma-4-31B-it IFB BW1000 1x vLLM 0.21 attention backend to TRITON_ATTN.

## Verification
- Checked the target section in docs/model-deployment/vllm/gemma-4.md
- git diff --check