### PR TITLE
SGLang/MiniMax-M2.5: 新增 ScaleX40 PD 部署实践

### DIFF
--- a/docs/model-deployment/sglang/minimax-m2.5.md
+++ b/docs/model-deployment/sglang/minimax-m2.5.md
@@ -2,7 +2,7 @@
 
 ## 模型简介
 
-MiniMax-M2.5-Channel-FP8-w8a8 是 MiniMax 推出的大规模 MoE（混合专家）语言模型系列，总参数量 230B，激活参数约 10B，在长文本理解和生成方面表现突出。
+MiniMax-M2.5 是 MiniMax 推出的大规模 MoE（混合专家）语言模型系列，在长文本理解和生成方面表现较好。本文档提供 INT8 W8A8 和 FP8 W8A8 量化模型的部署参考。
 
 
 
@@ -16,6 +16,7 @@ MiniMax-M2.5-Channel-FP8-w8a8 是 MiniMax 推出的大规模 MoE（混合专家�
 |                                                                                                 | INT8 W8A8 | 0.5.10 | BW1000 | 16 | 1P1D| [**`>_`**](#minimax-m2-5-channel-int8-w8a8-1p1d-bw1000-16x) |
 | [MiniMax-M2-5-Channel-FP8-w8a8](https://www.modelscope.cn/models/hygon/MiniMax-M2.5-Channel-FP8-w8a8) | FP8 W8A8 | 0.5.10 | BW1100 | 8 | IFB | [**`>_`**](#minimax-m2-5-channel-fp8-w8a8-ifb-bw1100-8x) |
 |                                                                                                 | FP8 W8A8 | 0.5.10 | BW1100 | 16 | 1P1D| [**`>_`**](#minimax-m2-5-channel-fp8-w8a8-1p1d-bw1100-16x) |
+|                                                                                                 | FP8 W8A8 | [0.5.12](../docker_images.md) | ScaleX40 | 8 | PD | [**`>_`**](#minimax-m25-channel-fp8-w8a8-pd-scalex40-8x-sglang-0512) |
 
 
 ## 启动命令
@@ -413,6 +414,151 @@ sglang serve \
   --disaggregation-mode decode \
   --prefill-round-robin-balance \ 
   --host 10.63.60.113 --port 30001 
+```
+
+### MiniMax-M2.5-Channel-FP8-w8a8 PD ScaleX40 8x SGLang 0.5.12
+
+#### P 
+
+```bash
+export USE_DCU_CUSTOM_ALLREDUCE=0
+export SGLANG_USE_AITER_AR=0
+export SGLANG_CHUNKED_PREFIX_CACHE_THRESHOLD=0
+export SGLANG_DISAGGREGATION_BOOTSTRAP_TIMEOUT=1200
+export GLIBC_TUNABLES=glibc.rtld.optional_static_tls=0x40000
+export SGLANG_TORCH_PROFILER_DIR=/workspace/prof
+export VLLM_USE_LIGHTOP_MOE_ALIGN=1
+export LMSLIM_USE_LIGHTOP=1
+export SGLANG_KVALLOC_KERNEL=1
+export SGLANG_CREATE_EXTEND_AFTER_DECODE_SPEC_INFO=1
+export SGLANG_ASSIGN_EXTEND_CACHE_LOCS=1
+export SGLANG_ASSIGN_REQ_TO_TOKEN_POOL=1
+export SGLANG_GET_LAST_LOC=1
+export SGLANG_CREATE_FLASHMLA_KV_INDICES_TRITON=1
+export SGLANG_CREATE_CHUNKED_PREFIX_CACHE_KV_INDICES=1
+export NCCL_SIMPLE_CHANNELS=20
+export RCCL_P2P_XHCL_CHANNEL_NUM=16
+export RCCL_COLL_XHCL_CHANNEL_NUM=16
+export HIP_H2D_DISABLE_COPY_BUFFER=0
+export HIP_D2H_DISABLE_COPY_BUFFER=0
+export HIP_H2D_DIRECT_COPY_THRESHOLD=32768
+export HIP_H2D_HSAAPI_COPY_THRESHOLD=32768
+export HIP_D2H_DIRECT_COPY_THRESHOLD=512
+export HIP_D2H_HSAAPI_COPY_THRESHOLD=512
+export HSA_KERNARG_POOL_SIZE=8388608
+export HSA_FORCE_FINE_GRAIN_PCIE=1
+export ROC_AQL_QUEUE_SIZE=131072
+export NCCL_PLUGIN_P2P=ib
+export NCCL_IB_DISABLE=0
+unset NCCL_IB_GID_INDEX
+export NCCL_NET_PLUGIN=shca
+export NCCL_IB_HCA=shca_0:1,shca_1:1,shca_2:1,shca_4:1
+export MC_ENABLE_DEST_DEVICE_AFFINITY=1
+unset MC_GID_INDEX
+export ALLREDUCE_STREAM_WITH_COMPUTE=1
+export SGLANG_USE_LIGHTOP=1
+export SGLANG_ROCM_USE_AITER_MOE=0
+export W8A8_SUPPORT_METHODS=1
+export HIP_GRAPH_ACCUMULATE_DISPATCH=1
+export HIP_GRAPH_USE_CMD_CACHE=0
+export MC_ALLOWED_IBV_DEVICES=shca_0,shca_1,shca_2,shca_4
+export ROCSHMEM_ALLOWED_IBV_DEVICES=shca_0,shca_1,shca_2,shca_4
+export SGLANG_USE_FUSED_RMS_QUANT=0
+
+sglang serve \
+  --model-path hygon/MiniMax-M2.5-Channel-FP8-w8a8 \
+  --chunked-prefill-size 61568 \
+  --max-prefill-tokens 61568 \
+  --max-running-requests 256 \
+  --context-length 131072 \
+  --disaggregation-ib-device shca_0,shca_1,shca_2,shca_4 \
+  --disaggregation-mode prefill \
+  --load-balance-method round_robin \
+  --host <P_node_ip> \
+  --port <port> \
+  --model-loader-extra-config '{"enable_multithread_load": "true","num_threads": 8}' \
+  --quantization w8a8_fp8 \
+  --kv-cache-dtype fp8_e4m3 \
+  --trust-remote-code \
+  --page-size 64 \
+  --dtype bfloat16 \
+  --tp-size 4 \
+  --pp-size 1 \
+  --dp-size 1 \
+  --tool-call-parser minimax-m2 \
+  --reasoning-parser minimax-append-think \
+  --skip-server-warmup \
+  --mem-fraction-static 0.9 \
+  --attention-backend fa3
+```
+
+#### D 
+
+```bash
+export NCCL_NET_PLUGIN=shca
+export NCCL_IB_HCA=shca_0:1,shca_1:1,shca_2:1,shca_4:1
+export USE_DCU_CUSTOM_ALLREDUCE=0
+export SGLANG_USE_AITER_AR=0
+export SGL_CHUNKED_PREFIX_CACHE_THRESHOLD=0
+export SGLANG_DISAGGREGATION_BOOTSTRAP_TIMEOUT=1200
+export GLIBC_TUNABLES=glibc.rtld.optional_static_tls=0x40000
+export SGLANG_USE_LIGHTOP=1
+export SGLANG_TORCH_PROFILER_DIR=/workspace/prof
+export VLLM_USE_LIGHTOP_MOE_ALIGN=1
+export LMSLIM_USE_LIGHTOP=1
+export SGLANG_KVALLOC_KERNEL=1
+export SGLANG_CREATE_EXTEND_AFTER_DECODE_SPEC_INFO=1
+export SGLANG_ASSIGN_EXTEND_CACHE_LOCS=1
+export SGLANG_ASSIGN_REQ_TO_TOKEN_POOL=1
+export SGLANG_GET_LAST_LOC=1
+export SGLANG_CREATE_FLASHMLA_KV_INDICES_TRITON=1
+export SGLANG_CREATE_CHUNKED_PREFIX_CACHE_KV_INDICES=1
+export ALLREDUCE_STREAM_WITH_COMPUTE=1
+export NCCL_SIMPLE_CHANNELS=20
+export RCCL_P2P_XHCL_CHANNEL_NUM=16
+export RCCL_COLL_XHCL_CHANNEL_NUM=16
+export SGLANG_USE_FP32GEMM_GATE_CUSTOM=1
+export SGLANG_ROCM_USE_AITER_MOE=0
+export MC_ALLOWED_IBV_DEVICES=shca_0,shca_1,shca_2,shca_4
+export ROCSHMEM_ALLOWED_IBV_DEVICES=shca_0,shca_1,shca_2,shca_4
+
+sglang serve \
+  --model-path hygon/MiniMax-M2.5-Channel-FP8-w8a8 \
+  --chunked-prefill-size 61568 \
+  --max-prefill-tokens 61568 \
+  --max-running-requests 512 \
+  --context-length 131072 \
+  --disaggregation-mode decode \
+  --prefill-round-robin-balance \
+  --host <D_node_ip> \
+  --port <port> \
+  --disaggregation-ib-device shca_0,shca_1,shca_2,shca_4 \
+  --disable-radix-cache \
+  --model-loader-extra-config '{"enable_multithread_load": "true","num_threads": 2}' \
+  --quantization w8a8_fp8 \
+  --kv-cache-dtype fp8_e4m3 \
+  --trust-remote-code \
+  --page-size 64 \
+  --dtype bfloat16 \
+  --tp-size 4 \
+  --pp-size 1 \
+  --dp-size 1 \
+  --tool-call-parser minimax-m2 \
+  --reasoning-parser minimax-append-think \
+  --mem-fraction-static 0.90 \
+  --attention-backend fa3 \
+  --cuda-graph-max-bs 512
+```
+
+#### Router
+
+```bash
+python3 -m sglang_router.launch_router \
+  --pd-disaggregation \
+  --prefill http://<P_node_ip>:<port> \
+  --decode http://<D_node_ip>:<port> \
+  --policy cache_aware \
+  --port 30001
 ```
 
 ## Router

--- a/docs/model-deployment/sglang/minimax-m2.5.md
+++ b/docs/model-deployment/sglang/minimax-m2.5.md
@@ -14,9 +14,9 @@ MiniMax-M2.5 是 MiniMax 推出的大规模 MoE（混合专家）语言模型系
 |                                                                                                 | INT8 W8A8 | 0.5.10 | BW1100 | 16 | 1P1D| [**`>_`**](#minimax-m2-5-channel-int8-w8a8-1p1d-bw1100-16x) |
 |                                                                                                 | INT8 W8A8 | 0.5.10 | BW1000 | 8 | IFB | [**`>_`**](#minimax-m2-5-channel-int8-w8a8-ifb-bw1000-8x) |
 |                                                                                                 | INT8 W8A8 | 0.5.10 | BW1000 | 16 | 1P1D| [**`>_`**](#minimax-m2-5-channel-int8-w8a8-1p1d-bw1000-16x) |
-| [MiniMax-M2-5-Channel-FP8-w8a8](https://www.modelscope.cn/models/hygon/MiniMax-M2.5-Channel-FP8-w8a8) | FP8 W8A8 | 0.5.10 | BW1100 | 8 | IFB | [**`>_`**](#minimax-m2-5-channel-fp8-w8a8-ifb-bw1100-8x) |
+| [MiniMax-M2-5-Channel-FP8-w8a8](https://www.modelscope.cn/models/hygon/MiniMax-M2.5-Channel-FP8-w8a8) | FP8 W8A8 | [0.5.12](../docker_images.md) | ScaleX40 | 8 | PD | [**`>_`**](#minimax-m25-channel-fp8-w8a8-pd-scalex40-8x-sglang-0512) |
+|                                                                                                 | FP8 W8A8 | 0.5.10 | BW1100 | 8 | IFB | [**`>_`**](#minimax-m2-5-channel-fp8-w8a8-ifb-bw1100-8x) |
 |                                                                                                 | FP8 W8A8 | 0.5.10 | BW1100 | 16 | 1P1D| [**`>_`**](#minimax-m2-5-channel-fp8-w8a8-1p1d-bw1100-16x) |
-|                                                                                                 | FP8 W8A8 | [0.5.12](../docker_images.md) | ScaleX40 | 8 | PD | [**`>_`**](#minimax-m25-channel-fp8-w8a8-pd-scalex40-8x-sglang-0512) |
 
 
 ## 启动命令
@@ -57,88 +57,6 @@ sglang serve \
   --attention-backend fa3 \
   --numa-node 0 0 0 0 1 1 1 1 \
   --chunked-prefill-size 16384 \
-  --max-running-requests 512 \
-  --context-length 131072 \
-  --port 30000
-```
-
-### MiniMax-M2-5-Channel-INT8-w8a8 IFB BW1000 8x
-
-网卡配置参考：[mlx]
-
-```bash
-export SGLANG_USE_MODELSCOPE=1
-export USE_DCU_CUSTOM_ALLREDUCE=1
-export SGL_CHUNKED_PREFIX_CACHE_THRESHOLD=0
-export SGLANG_DISAGGREGATION_BOOTSTRAP_TIMEOUT=1200
-export GLIBC_TUNABLES=glibc.rtld.optional_static_tls=0x40000
-export SGLANG_USE_LIGHTOP=1 
-export SGLANG_KVALLOC_KERNEL=1
-export SGLANG_CREATE_EXTEND_AFTER_DECODE_SPEC_INFO=1
-export SGLANG_ASSIGN_EXTEND_CACHE_LOCS=1
-export SGLANG_ASSIGN_REQ_TO_TOKEN_POOL=1
-export SGLANG_GET_LAST_LOC=1
-export SGLANG_CREATE_FLASHMLA_KV_INDICES_TRITON=1
-export SGLANG_CREATE_CHUNKED_PREFIX_CACHE_KV_INDICES=1
-export ALLREDUCE_STREAM_WITH_COMPUTE=1
-export LMSLIM_USE_LIGHTOP=1
-export VLLM_USE_LIGHTOP_MOE_ALIGN=1
-
-sglang serve \
-  --model-path hygon/MiniMax-M2.5-Channel-INT8-w8a8 \
-  --quantization slimquant_marlin \
-  --kv-cache-dtype bfloat16 \
-  --trust-remote-code \
-  --page-size 64 \
-  --dtype bfloat16 \
-  --tp-size 8 --pp-size 1 --dp-size 1 \
-  --tool-call-parser minimax-m2 \
-  --reasoning-parser minimax-append-think \
-  --mem-fraction-static 0.95  \
-  --attention-backend fa3 \
-  --numa-node 0 0 0 0 1 1 1 1 \
-  --chunked-prefill-size 8192 \
-  --max-running-requests 512 \
-  --context-length 131072 \
-  --port 30000
-```
-
-### MiniMax-M2-5-Channel-FP8-w8a8 IFB BW1100 8x
-
-网卡配置参考：[mlx]
-
-```bash
-export SGLANG_USE_MODELSCOPE=1
-export USE_DCU_CUSTOM_ALLREDUCE=1
-export SGL_CHUNKED_PREFIX_CACHE_THRESHOLD=0
-export SGLANG_DISAGGREGATION_BOOTSTRAP_TIMEOUT=1200
-export GLIBC_TUNABLES=glibc.rtld.optional_static_tls=0x40000
-export SGLANG_USE_LIGHTOP=1
-export VLLM_USE_LIGHTOP_MOE_ALIGN=1
-export LMSLIM_USE_LIGHTOP=1
-export SGLANG_KVALLOC_KERNEL=1
-export SGLANG_CREATE_EXTEND_AFTER_DECODE_SPEC_INFO=1
-export SGLANG_ASSIGN_EXTEND_CACHE_LOCS=1
-export SGLANG_ASSIGN_REQ_TO_TOKEN_POOL=1
-export SGLANG_GET_LAST_LOC=1
-export SGLANG_CREATE_FLASHMLA_KV_INDICES_TRITON=1
-export SGLANG_CREATE_CHUNKED_PREFIX_CACHE_KV_INDICES=1
-export ALLREDUCE_STREAM_WITH_COMPUTE=1
-
-sglang serve \
-  --model-path hygon/MiniMax-M2.5-Channel-FP8-w8a8/ \
-  --kv-cache-dtype fp8_e4m3 \
-  --trust-remote-code \
-  --quantization w8a8_fp8 \
-  --page-size 64 \
-  --dtype bfloat16 \
-  --tp-size 4 --pp-size 1 --dp-size 2 \
-  --tool-call-parser minimax-m2 \
-  --reasoning-parser minimax-append-think \
-  --mem-fraction-static 0.92 \
-  --attention-backend fa3 \
-  --numa-node 0 0 0 0 1 1 1 1 \
-  --chunked-prefill-size 8192 \
   --max-running-requests 512 \
   --context-length 131072 \
   --port 30000
@@ -226,6 +144,47 @@ sglang serve \
   --disaggregation-mode decode \
   --prefill-round-robin-balance \ 
   --host 10.63.60.113 --port 30001 
+```
+
+### MiniMax-M2-5-Channel-INT8-w8a8 IFB BW1000 8x
+
+网卡配置参考：[mlx]
+
+```bash
+export SGLANG_USE_MODELSCOPE=1
+export USE_DCU_CUSTOM_ALLREDUCE=1
+export SGL_CHUNKED_PREFIX_CACHE_THRESHOLD=0
+export SGLANG_DISAGGREGATION_BOOTSTRAP_TIMEOUT=1200
+export GLIBC_TUNABLES=glibc.rtld.optional_static_tls=0x40000
+export SGLANG_USE_LIGHTOP=1 
+export SGLANG_KVALLOC_KERNEL=1
+export SGLANG_CREATE_EXTEND_AFTER_DECODE_SPEC_INFO=1
+export SGLANG_ASSIGN_EXTEND_CACHE_LOCS=1
+export SGLANG_ASSIGN_REQ_TO_TOKEN_POOL=1
+export SGLANG_GET_LAST_LOC=1
+export SGLANG_CREATE_FLASHMLA_KV_INDICES_TRITON=1
+export SGLANG_CREATE_CHUNKED_PREFIX_CACHE_KV_INDICES=1
+export ALLREDUCE_STREAM_WITH_COMPUTE=1
+export LMSLIM_USE_LIGHTOP=1
+export VLLM_USE_LIGHTOP_MOE_ALIGN=1
+
+sglang serve \
+  --model-path hygon/MiniMax-M2.5-Channel-INT8-w8a8 \
+  --quantization slimquant_marlin \
+  --kv-cache-dtype bfloat16 \
+  --trust-remote-code \
+  --page-size 64 \
+  --dtype bfloat16 \
+  --tp-size 8 --pp-size 1 --dp-size 1 \
+  --tool-call-parser minimax-m2 \
+  --reasoning-parser minimax-append-think \
+  --mem-fraction-static 0.95  \
+  --attention-backend fa3 \
+  --numa-node 0 0 0 0 1 1 1 1 \
+  --chunked-prefill-size 8192 \
+  --max-running-requests 512 \
+  --context-length 131072 \
+  --port 30000
 ```
 
 ### MiniMax-M2-5-Channel-INT8-w8a8 1P1D BW1000 16x
@@ -330,90 +289,6 @@ sglang serve \
   --prefill-round-robin-balance \ 
   --host 10.212.16.172 --port 30001 \
   --disaggregation-ib-device shca_0,shca_1,shca_2,shca_3
-```
-
-### MiniMax-M2-5-Channel-FP8-w8a8 1P1D BW1100 16x
-
-网卡配置参考：[mlx]
-
-#### P节点 
-```bash
-export SGLANG_USE_MODELSCOPE=1
-export USE_DCU_CUSTOM_ALLREDUCE=1
-export SGL_CHUNKED_PREFIX_CACHE_THRESHOLD=0
-export SGLANG_DISAGGREGATION_BOOTSTRAP_TIMEOUT=1200
-export GLIBC_TUNABLES=glibc.rtld.optional_static_tls=0x40000
-export SGLANG_USE_LIGHTOP=1 
-export VLLM_USE_LIGHTOP_MOE_ALIGN=1
-export LMSLIM_USE_LIGHTOP=1
-export SGLANG_KVALLOC_KERNEL=1
-export SGLANG_CREATE_EXTEND_AFTER_DECODE_SPEC_INFO=1
-export SGLANG_ASSIGN_EXTEND_CACHE_LOCS=1
-export SGLANG_ASSIGN_REQ_TO_TOKEN_POOL=1
-export SGLANG_GET_LAST_LOC=1
-export SGLANG_CREATE_FLASHMLA_KV_INDICES_TRITON=1
-export SGLANG_CREATE_CHUNKED_PREFIX_CACHE_KV_INDICES=1
-export MC_GID_INDEX=0
-export ALLREDUCE_STREAM_WITH_COMPUTE=1
-
-sglang serve \
-  --model-path hygon/MiniMax-M2.5-Channel-FP8-w8a8/ \
-  --quantization w8a8_fp8 \
-  --kv-cache-dtype fp8_e4m3 \
-  --trust-remote-code \ 
-  --page-size 64 \ 
-  --dtype bfloat16 \ 
-  --tp-size 2 --pp-size 4 --dp-size 1 \
-  --tool-call-parser minimax-m2 \
-  --reasoning-parser minimax-append-think \
-  --mem-fraction-static 0.9 \ 
-  --attention-backend fa3 \
-  --numa-node 0 0 0 0 1 1 1 1 \ 
-  --chunked-prefill-size 4096 \
-  --max-running-requests 512 \ 
-  --context-length 131072 \
-  --disaggregation-mode prefill \
-  --load-balance-method round_robin \
-  --host 10.63.60.114 --port 30000 
-```
-
-#### D节点
-```bash
-export SGLANG_USE_MODELSCOPE=1
-export USE_DCU_CUSTOM_ALLREDUCE=1
-export SGL_CHUNKED_PREFIX_CACHE_THRESHOLD=0
-export SGLANG_DISAGGREGATION_BOOTSTRAP_TIMEOUT=1200
-export GLIBC_TUNABLES=glibc.rtld.optional_static_tls=0x40000
-export SGLANG_USE_LIGHTOP=1 
-export VLLM_USE_LIGHTOP_MOE_ALIGN=1
-export LMSLIM_USE_LIGHTOP=1
-export SGLANG_KVALLOC_KERNEL=1
-export SGLANG_CREATE_EXTEND_AFTER_DECODE_SPEC_INFO=1
-export SGLANG_ASSIGN_EXTEND_CACHE_LOCS=1
-export SGLANG_ASSIGN_REQ_TO_TOKEN_POOL=1
-export SGLANG_GET_LAST_LOC=1
-export SGLANG_CREATE_FLASHMLA_KV_INDICES_TRITON=1
-export SGLANG_CREATE_CHUNKED_PREFIX_CACHE_KV_INDICES=1
-export MC_GID_INDEX=0
-export ALLREDUCE_STREAM_WITH_COMPUTE=1
- 
-sglang serve \
-  --model-path hygon/MiniMax-M2.5-Channel-FP8-w8a8/ \
-  --quantization w8a8_fp8 \
-  --kv-cache-dtype fp8_e4m3 \
-  --trust-remote-code \ 
-  --page-size 64 \
-  --dtype bfloat16 \ 
-  --tp-size 8 --pp-size 1 --dp-size 1 \
-  --tool-call-parser minimax-m2 \
-  --reasoning-parser minimax-append-think\
-  --mem-fraction-static 0.9 --attention-backend fa3 \ 
-  --numa-node 0 0 0 0 1 1 1 1 \ 
-  --max-running-requests 512 \
-  --context-length 131072 \
-  --disaggregation-mode decode \
-  --prefill-round-robin-balance \ 
-  --host 10.63.60.113 --port 30001 
 ```
 
 ### MiniMax-M2.5-Channel-FP8-w8a8 PD ScaleX40 8x SGLang 0.5.12
@@ -559,6 +434,131 @@ python3 -m sglang_router.launch_router \
   --decode http://<D_node_ip>:<port> \
   --policy cache_aware \
   --port 30001
+```
+
+### MiniMax-M2-5-Channel-FP8-w8a8 IFB BW1100 8x
+
+网卡配置参考：[mlx]
+
+```bash
+export SGLANG_USE_MODELSCOPE=1
+export USE_DCU_CUSTOM_ALLREDUCE=1
+export SGL_CHUNKED_PREFIX_CACHE_THRESHOLD=0
+export SGLANG_DISAGGREGATION_BOOTSTRAP_TIMEOUT=1200
+export GLIBC_TUNABLES=glibc.rtld.optional_static_tls=0x40000
+export SGLANG_USE_LIGHTOP=1
+export VLLM_USE_LIGHTOP_MOE_ALIGN=1
+export LMSLIM_USE_LIGHTOP=1
+export SGLANG_KVALLOC_KERNEL=1
+export SGLANG_CREATE_EXTEND_AFTER_DECODE_SPEC_INFO=1
+export SGLANG_ASSIGN_EXTEND_CACHE_LOCS=1
+export SGLANG_ASSIGN_REQ_TO_TOKEN_POOL=1
+export SGLANG_GET_LAST_LOC=1
+export SGLANG_CREATE_FLASHMLA_KV_INDICES_TRITON=1
+export SGLANG_CREATE_CHUNKED_PREFIX_CACHE_KV_INDICES=1
+export ALLREDUCE_STREAM_WITH_COMPUTE=1
+
+sglang serve \
+  --model-path hygon/MiniMax-M2.5-Channel-FP8-w8a8/ \
+  --kv-cache-dtype fp8_e4m3 \
+  --trust-remote-code \
+  --quantization w8a8_fp8 \
+  --page-size 64 \
+  --dtype bfloat16 \
+  --tp-size 4 --pp-size 1 --dp-size 2 \
+  --tool-call-parser minimax-m2 \
+  --reasoning-parser minimax-append-think \
+  --mem-fraction-static 0.92 \
+  --attention-backend fa3 \
+  --numa-node 0 0 0 0 1 1 1 1 \
+  --chunked-prefill-size 8192 \
+  --max-running-requests 512 \
+  --context-length 131072 \
+  --port 30000
+```
+
+### MiniMax-M2-5-Channel-FP8-w8a8 1P1D BW1100 16x
+
+网卡配置参考：[mlx]
+
+#### P节点 
+```bash
+export SGLANG_USE_MODELSCOPE=1
+export USE_DCU_CUSTOM_ALLREDUCE=1
+export SGL_CHUNKED_PREFIX_CACHE_THRESHOLD=0
+export SGLANG_DISAGGREGATION_BOOTSTRAP_TIMEOUT=1200
+export GLIBC_TUNABLES=glibc.rtld.optional_static_tls=0x40000
+export SGLANG_USE_LIGHTOP=1 
+export VLLM_USE_LIGHTOP_MOE_ALIGN=1
+export LMSLIM_USE_LIGHTOP=1
+export SGLANG_KVALLOC_KERNEL=1
+export SGLANG_CREATE_EXTEND_AFTER_DECODE_SPEC_INFO=1
+export SGLANG_ASSIGN_EXTEND_CACHE_LOCS=1
+export SGLANG_ASSIGN_REQ_TO_TOKEN_POOL=1
+export SGLANG_GET_LAST_LOC=1
+export SGLANG_CREATE_FLASHMLA_KV_INDICES_TRITON=1
+export SGLANG_CREATE_CHUNKED_PREFIX_CACHE_KV_INDICES=1
+export MC_GID_INDEX=0
+export ALLREDUCE_STREAM_WITH_COMPUTE=1
+
+sglang serve \
+  --model-path hygon/MiniMax-M2.5-Channel-FP8-w8a8/ \
+  --quantization w8a8_fp8 \
+  --kv-cache-dtype fp8_e4m3 \
+  --trust-remote-code \ 
+  --page-size 64 \ 
+  --dtype bfloat16 \ 
+  --tp-size 2 --pp-size 4 --dp-size 1 \
+  --tool-call-parser minimax-m2 \
+  --reasoning-parser minimax-append-think \
+  --mem-fraction-static 0.9 \ 
+  --attention-backend fa3 \
+  --numa-node 0 0 0 0 1 1 1 1 \ 
+  --chunked-prefill-size 4096 \
+  --max-running-requests 512 \ 
+  --context-length 131072 \
+  --disaggregation-mode prefill \
+  --load-balance-method round_robin \
+  --host 10.63.60.114 --port 30000 
+```
+
+#### D节点
+```bash
+export SGLANG_USE_MODELSCOPE=1
+export USE_DCU_CUSTOM_ALLREDUCE=1
+export SGL_CHUNKED_PREFIX_CACHE_THRESHOLD=0
+export SGLANG_DISAGGREGATION_BOOTSTRAP_TIMEOUT=1200
+export GLIBC_TUNABLES=glibc.rtld.optional_static_tls=0x40000
+export SGLANG_USE_LIGHTOP=1 
+export VLLM_USE_LIGHTOP_MOE_ALIGN=1
+export LMSLIM_USE_LIGHTOP=1
+export SGLANG_KVALLOC_KERNEL=1
+export SGLANG_CREATE_EXTEND_AFTER_DECODE_SPEC_INFO=1
+export SGLANG_ASSIGN_EXTEND_CACHE_LOCS=1
+export SGLANG_ASSIGN_REQ_TO_TOKEN_POOL=1
+export SGLANG_GET_LAST_LOC=1
+export SGLANG_CREATE_FLASHMLA_KV_INDICES_TRITON=1
+export SGLANG_CREATE_CHUNKED_PREFIX_CACHE_KV_INDICES=1
+export MC_GID_INDEX=0
+export ALLREDUCE_STREAM_WITH_COMPUTE=1
+ 
+sglang serve \
+  --model-path hygon/MiniMax-M2.5-Channel-FP8-w8a8/ \
+  --quantization w8a8_fp8 \
+  --kv-cache-dtype fp8_e4m3 \
+  --trust-remote-code \ 
+  --page-size 64 \
+  --dtype bfloat16 \ 
+  --tp-size 8 --pp-size 1 --dp-size 1 \
+  --tool-call-parser minimax-m2 \
+  --reasoning-parser minimax-append-think\
+  --mem-fraction-static 0.9 --attention-backend fa3 \ 
+  --numa-node 0 0 0 0 1 1 1 1 \ 
+  --max-running-requests 512 \
+  --context-length 131072 \
+  --disaggregation-mode decode \
+  --prefill-round-robin-balance \ 
+  --host 10.63.60.113 --port 30001 
 ```
 
 ## Router


### PR DESCRIPTION
## Summary
- 新增 MiniMax-M2.5-Channel-FP8-w8a8 的 ScaleX40 PD 部署记录
- 补充 P 节点、D 节点和 SGLang Router 启动命令
- 按节点去除重复环境变量，并保留最后一次生效值

## Verification
- git diff --check
- 已检查 P/D 节点内无重复 export 环境变量
- 确认提交仅包含 docs/model-deployment/sglang/minimax-m2.5.md