### PR TITLE
docs: 调整 Qwen3.6 部署配置顺序

### DIFF
--- a/docs/model-deployment/sglang/qwen3.6.md
+++ b/docs/model-deployment/sglang/qwen3.6.md
@@ -13,10 +13,10 @@ Qwen3.6 模型相较于 Qwen3.5 模型，**在智能体编程能力、推理速�
 |                                                                       | BF16 | [0.5.12](../docker_images.md) | BW1000 | 2 | IFB | [**`>_`**](#qwen36-27b-ifb-bw1000-2x-sglang-0512) |
 |                                                                       | BF16 | [0.5.12](../docker_images.md) | K100_AI | 2 | IFB | [**`>_`**](#qwen36-27b-ifb-k100_ai-2x-sglang-0512) |
 | [Qwen/Qwen3.6-27B](https://www.modelscope.cn/models/Qwen/Qwen3.6-27B) | BF16 | 0.5.10 | BW1100 | 2 | IFB | [**`>_`**](#qwen36-27b-ifb-bw1100-2x-sglang-0510) |
-| [Qwen/Qwen3.6-35B-A3B](https://www.modelscope.cn/models/Qwen/Qwen3.6-35B-A3B) | BF16 | [0.5.12](../docker_images.md) | BW1100 | 2 | IFB | [**`>_`**](#qwen36-35b-a3b-ifb-bw1100-2x-sglang-0512) |
 | [hygon/Qwen3.6-27B-Channel-INT8-w8a8](https://www.modelscope.cn/models/hygon/Qwen3.6-27B-Channel-INT8-w8a8) | INT8 W8A8 | [0.5.12](../docker_images.md) | BW1100 | 2 | IFB | [**`>_`**](#qwen36-27b-channel-int8-w8a8-ifb-bw1100-2x-sglang-0512) |
 |  | INT8 W8A8 | [0.5.12](../docker_images.md) | BW1000 | 2 | IFB | [**`>_`**](#qwen36-27b-channel-int8-w8a8-ifb-bw1000-2x-sglang-0512) |
 |  | INT8 W8A8 | [0.5.12](../docker_images.md) | K100_AI | 2 | IFB | [**`>_`**](#qwen36-27b-channel-int8-w8a8-ifb-k100_ai-2x-sglang-0512) |
+| [Qwen/Qwen3.6-35B-A3B](https://www.modelscope.cn/models/Qwen/Qwen3.6-35B-A3B) | BF16 | [0.5.12](../docker_images.md) | BW1100 | 2 | IFB | [**`>_`**](#qwen36-35b-a3b-ifb-bw1100-2x-sglang-0512) |
 |                                                                                             | BF16 | 0.5.12 | BW1000 | 2 | IFB | [**`>_`**](#qwen36-35b-a3b-ifb-bw1000-2x-sglang-0512) |
 |                                                                                             | BF16 | [0.5.12](../docker_images.md) | K100_AI | 2 | IFB | [**`>_`**](#qwen36-35b-a3b-ifb-k100_ai-2x-sglang-0512) |
 |                                                                       | BF16 | 0.5.10 | BW1100 | 2 | IFB | [**`>_`**](#qwen36-35b-a3b-ifb-bw1100-2x-sglang-0510) |
@@ -124,39 +124,6 @@ sglang serve --model-path Qwen/Qwen3.6-27B \
     --trust-remote-code
 ```
 
-### Qwen3.6-35B-A3B IFB BW1100 2x SGLang 0.5.12
-
-```bash
-export SGLANG_ENABLE_SPEC_V2=1
-export SGLANG_USE_FUSED_TOPK_SOFTMAX=1
-export SGLANG_USE_LIGHTOP=1
-export SGLANG_USE_CAUSAL_CONV1D=1
-export SGLANG_USE_AITER_LINEAR_ATTN=1
-export SGLANG_USE_CUDA_IPC_TRANSPORT=1
-export SGLANG_USE_MARLIN_W16A16_MOE=1
-
-sglang serve \
-  --model-path RedHatAI/Qwen3.6-35B-A3B \
-  --dtype bfloat16 \
-  --attention-backend fa3 \
-  --mm-attention-backend fa3 \
-  --mem-fraction-static 0.9 \
-  --page-size 64 \
-  --tp-size 2 \
-  --pp-size 1 \
-  --trust-remote-code \
-  --speculative-algorithm EAGLE \
-  --enable-piecewise-cuda-graph \
-  --speculative-num-steps 3 \
-  --speculative-eagle-topk 1 \
-  --speculative-num-draft-tokens 4 \
-  --mamba-scheduler-strategy extra_buffer \
-  --chunked-prefill-size -1 \
-  --kv-cache-dtype fp8_e4m3 \
-  --tool-call-parser qwen3_coder \
-  --reasoning-parser qwen3
-```
-
 ### Qwen3.6-27B-Channel-INT8-w8a8 IFB BW1100 2x SGLang 0.5.12
 
 ```bash
@@ -226,6 +193,39 @@ sglang serve \
   --pp-size 1 \
   --mamba-scheduler-strategy extra_buffer \
   --disable-custom-all-reduce \
+  --tool-call-parser qwen3_coder \
+  --reasoning-parser qwen3
+```
+
+### Qwen3.6-35B-A3B IFB BW1100 2x SGLang 0.5.12
+
+```bash
+export SGLANG_ENABLE_SPEC_V2=1
+export SGLANG_USE_FUSED_TOPK_SOFTMAX=1
+export SGLANG_USE_LIGHTOP=1
+export SGLANG_USE_CAUSAL_CONV1D=1
+export SGLANG_USE_AITER_LINEAR_ATTN=1
+export SGLANG_USE_CUDA_IPC_TRANSPORT=1
+export SGLANG_USE_MARLIN_W16A16_MOE=1
+
+sglang serve \
+  --model-path RedHatAI/Qwen3.6-35B-A3B \
+  --dtype bfloat16 \
+  --attention-backend fa3 \
+  --mm-attention-backend fa3 \
+  --mem-fraction-static 0.9 \
+  --page-size 64 \
+  --tp-size 2 \
+  --pp-size 1 \
+  --trust-remote-code \
+  --speculative-algorithm EAGLE \
+  --enable-piecewise-cuda-graph \
+  --speculative-num-steps 3 \
+  --speculative-eagle-topk 1 \
+  --speculative-num-draft-tokens 4 \
+  --mamba-scheduler-strategy extra_buffer \
+  --chunked-prefill-size -1 \
+  --kv-cache-dtype fp8_e4m3 \
   --tool-call-parser qwen3_coder \
   --reasoning-parser qwen3
 ```


### PR DESCRIPTION
## Summary
- 按模型系列整理 Qwen3.6 模型列表顺序
- 同步调整对应启动命令区块顺序
- 保持全部 Bash 启动脚本内容不变

## Verification
- git diff --check
- 校验 15 个 Bash 代码块哈希，变更数为 0