### PR TITLE
docs(vllm): 新增 Qwen3.8-Flash-Next-FP8-Channelwise 部署条目

### DIFF
--- a/docs/model-deployment/vllm/qwen3.8.md
+++ b/docs/model-deployment/vllm/qwen3.8.md
@@ -17,6 +17,7 @@ Qwen3.8 系列模型面向长上下文推理与工具调用场景，支持 vLLM 
 |  | W8A8 | 0.21 | BW1000 | 2 | IFB | [**`>_`**](#qwen38-27b-channel-int8-w8a8-ifb-bw1000-2x-vllm-021) |
 |  | W8A8 | [0.18-hotfix](../docker_images.md) | BW1000 | 1 | IFB | [**`>_`**](#qwen38-27b-channel-int8-w8a8-ifb-bw1000-1x-vllm-018-hotfix) |
 |  | W8A8 | [0.18-hotfix](../docker_images.md) | BW1000 | 2 | IFB | [**`>_`**](#qwen38-27b-channel-int8-w8a8-ifb-bw1000-2x-vllm-018-hotfix) |
+| Qwen3.8-Flash-Next-FP8-Channelwise | FP8 | 0.28 | BW1100 | 4 | IFB | [**`>_`**](#qwen38-flash-next-fp8-channelwise-ifb-bw1100-4x-vllm-028) |
 
 ## 启动命令
 
@@ -143,7 +144,6 @@ vllm serve hygon/Qwen3.8-27B-Channel-INT8-w8a8 \
 ```bash
 vllm serve hygon/Qwen3.8-27B-Channel-INT8-w8a8 \
   -tp 1 \
-  --served-model-name "$SERVED_MODEL_NAME" \
   --trust-remote-code \
   --attention-backend FLASH_ATTN_CUSTOM \
   --max-num-batched-tokens 10240 \
@@ -159,7 +159,6 @@ vllm serve hygon/Qwen3.8-27B-Channel-INT8-w8a8 \
 ```bash
 vllm serve hygon/Qwen3.8-27B-Channel-INT8-w8a8 \
   -tp 2 \
-  --served-model-name "$SERVED_MODEL_NAME" \
   --trust-remote-code \
   --attention-backend FLASH_ATTN_CUSTOM \
   --max-num-batched-tokens 10240 \
@@ -168,6 +167,19 @@ vllm serve hygon/Qwen3.8-27B-Channel-INT8-w8a8 \
   --speculative-config.num_speculative_tokens 3 \
   --speculative-config.quantization "slimquant_marlin" \
   -q slimquant_marlin
+```
+
+### Qwen3.8-Flash-Next-FP8-Channelwise IFB BW1100 4x vLLM 0.28
+
+```bash
+vllm serve hygon/Qwen3.8-Flash-Next-FP8-Channelwise \
+  -tp 4 \
+  --moe-backend aiter \
+  --trust-remote-code \
+  --attention-backend FLASH_ATTN  \
+  --max-num-batched-tokens 10240 \
+  --speculative-config.method mtp \
+  --speculative-config.num_speculative_tokens 3 
 ```
 
 ## API 调用


### PR DESCRIPTION
新增 Qwen3.8-Flash-Next-FP8-Channelwise 模型（FP8 / vLLM 0.28 / BW1100 / 4 卡 / IFB）的模型列表行与启动命令小节；移除 Channel-INT8-w8a8 0.18-hotfix 小节中冗余的 --served-model-name 参数

修改文件：
- docs/model-deployment/vllm/qwen3.8.md: 模型列表新增 FP8 0.28 条目