### PR TITLE
docs: add DeepSeek V4 Pro scaleX40-3G PD deployment

### DIFF
--- a/docs/model-deployment/sglang/deepseek-v4.md
+++ b/docs/model-deployment/sglang/deepseek-v4.md
@@ -16,6 +16,7 @@ DeepSeek-V4 是 DeepSeek 系列的混合专家模型。本页汇总 DeepSeek-V4 
 | [hygon/DeepSeek-V4-Pro-Channel-FP8-w8a8](https://www.modelscope.cn/models/hygon/DeepSeek-V4-Pro-Channel-FP8-w8a8) | FP8 W8A8 | 0.5.12 | BW1100 | 16 | IFB(CP8EP8PP2) | [**`>_`**](#deepseek-v4-pro-channel-fp8-w8a8-ifb-p-bw1100-16x-sglang-0512) |
 |  | FP8 W8A8 | 0.5.12 | BW1100 | 16 | IFB(EP16DP16) | [**`>_`**](#deepseek-v4-pro-channel-fp8-w8a8-ifb-d-bw1100-16x-sglang-0512) |
 |  | FP8 W8A8 | 0.5.12 | BW1100 | 32 | PD | [**`>_`**](#deepseek-v4-pro-channel-fp8-w8a8-pd-bw1100-32x-sglang-0512) |
+|  | FP8 W8A8 | [0.5.12](../docker_images.md) | scaleX40-3G | 32 | PD | [**`>_`**](#deepseek-v4-pro-channel-fp8-w8a8-pd-scalex40-3g-32x-sglang-0512) |
 
 ## DeepEP 配置
 
@@ -1293,6 +1294,801 @@ python3 -m sglang_router.launch_router \
   --decode "http://<D_node0_ip>:<D_service_port>" \
   --policy cache_aware \
   --port 30001
+```
+
+### DeepSeek-V4-Pro-Channel-FP8-w8a8 PD scaleX40-3G 32x SGLang 0.5.12
+
+#### P node 0
+
+```bash
+export SGLANG_DSV4_REQUEST_SCOPED_C128_STATE=true
+export SGLANG_OPT_USE_ONLINE_COMPRESS=false
+export SGLANG_DSV4_PD_PREFILL_USE_FULL_TOKEN_POOL=true
+export SGLANG_DISAGGREGATION_WAITING_TIMEOUT=1800
+export SGLANG_HEALTH_CHECK_TIMEOUT=1000
+export SGLANG_LIGHTOP_KVALLOC_KERNEL=1
+export ROCSHMEM_GDR_DISABLE_XDP=1
+export TRITON_HIP_CLANG_PATH=/opt/dtk/aillvm/bin/clang-18
+export LD_LIBRARY_PATH=/usr/lib64:$LD_LIBRARY_PATH
+export HIP_VISIBLE_DEVICES=0,1,2,3
+export ROCSHMEM_IPC_MNVL=1
+export DEEP_EP_NORMAL_MNVL=1
+export NCCL_SOCKET_IFNAME=em1
+export GLOO_SOCKET_IFNAME=em1
+export HIP_BUFFER_EXTRA_SIZE=0
+export ROCSHMEM_DISABLE_HDP_FLUSH=1
+export ROCSHMEM_GDA_NUM_QPS_DEFAULT_CTX=288
+export SGLANG_DEEPEP_NUM_MAX_DISPATCH_TOKENS_PER_RANK=64
+export LD_LIBRARY_PATH=/usr/lib64:${LD_LIBRARY_PATH:-}
+export SGLANG_USE_LIGHTOP=1
+export SGLANG_USE_LINEAR_BF16_FP32_USE_BLASLT=1
+export SGLANG_ROCM_USE_AITER_TILELANG_MHC=1
+export SGLANG_USE_DPSKV4_LIGHTOP_RMSNORM=1
+export SGLANG_USE_FP8_W8A8_MOE=1
+export SGLANG_USE_DEEPGEMM_MOE=1
+export SGLANG_OPT_USE_FUSED_STORE_CACHE="${SGLANG_OPT_USE_FUSED_STORE_CACHE:-false}"
+export SGLANG_OPT_USE_FUSED_HASH_TOPK="${SGLANG_OPT_USE_FUSED_HASH_TOPK:-true}"
+export SGLANG_OPT_SWIGLU_CLAMP_FUSION="${SGLANG_OPT_SWIGLU_CLAMP_FUSION:-false}"
+export SGLANG_TOPK_TRANSFORM_512_TORCH="${SGLANG_TOPK_TRANSFORM_512_TORCH:-false}"
+export SGLANG_OPT_USE_JIT_KERNEL_FUSED_TOPK="${SGLANG_OPT_USE_JIT_KERNEL_FUSED_TOPK:-false}"
+export SGLANG_ROCM_USE_AITER_MOE="${SGLANG_ROCM_USE_AITER_MOE:-false}"
+export SGLANG_DSV4_SPLIT_PREFILL_DECODE_MLA="${SGLANG_DSV4_SPLIT_PREFILL_DECODE_MLA:-0}"
+export SGLANG_DSV4_SPLIT_HCA_NONSPARSE_MLA="${SGLANG_DSV4_SPLIT_HCA_NONSPARSE_MLA:-false}"
+export SGLANG_DSV4_SPARSE_PREFILL_SINGLE_CALL="${SGLANG_DSV4_SPARSE_PREFILL_SINGLE_CALL:-false}"
+export SGLANG_DSV4_SPARSE_PREFILL_TRITON_GATHER="${SGLANG_DSV4_SPARSE_PREFILL_TRITON_GATHER:-false}"
+export SGLANG_JIT_DEEPGEMM_PRECOMPILE="${SGLANG_JIT_DEEPGEMM_PRECOMPILE:-0}"
+export SGLANG_DISABLED_MODEL_ARCHS="${SGLANG_DISABLED_MODEL_ARCHS:-midashenglm}"
+export SGLANG_DEBUG_DSV4_LOAD="${SGLANG_DEBUG_DSV4_LOAD:-0}"
+export SGLANG_APPLY_CONFIG_BACKUP="${SGLANG_APPLY_CONFIG_BACKUP:-none}"
+export GPU_MAX_HW_QUEUES=2
+export SGLANG_USE_LIGHTOP_EP_SCATTER=false
+export SGLANG_USE_LIGHTOP_EP_GATHER=false
+export SGLANG_USE_LIGHTOP_EP_MOE_ALIGN=false
+export SGL_CHUNKED_PREFIX_CACHE_THRESHOLD=0
+export SGLANG_DISAGGREGATION_BOOTSTRAP_TIMEOUT=1200
+export GLIBC_TUNABLES=glibc.rtld.optional_static_tls=0x40000
+export SGLANG_KVALLOC_KERNEL=1
+export SGLANG_SET_CPU_AFFINITY=1
+export HIP_KERNEL_BATCH_CEILING=100
+export HSA_KERNARG_POOL_SIZE=8388608
+export ROC_AQL_QUEUE_SIZE=131072
+export ROCSHMEM_MAX_NUM_CONTEXTS=48
+export ROCSHMEM_HEAP_SIZE=3173741824
+export MC_ENABLE_DEST_DEVICE_AFFINITY=1
+export MC_ALLOWED_IBV_DEVICES=shca_0,shca_1,shca_2,shca_4
+
+sglang serve \
+  --model-path hygon/DeepSeek-V4-Pro-Channel-FP8-w8a8 \
+  --tokenizer-path hygon/DeepSeek-V4-Pro-Channel-FP8-w8a8 \
+  --trust-remote-code \
+  --dist-init-addr <P_node0_ip>:<port0> \
+  --nnodes 4 \
+  --node-rank 0 \
+  --host <P_node0_ip> \
+  --port <port1> \
+  --tp-size 8 \
+  --pp-size 2 \
+  --ep-size 8 \
+  --disaggregation-mode prefill \
+  --disaggregation-ib-device shca_0,shca_1,shca_2,shca_4 \
+  --disable-cuda-graph \
+  --skip-server-warmup \
+  --dist-timeout 10000 \
+  --watchdog-timeout 3600 \
+  --mem-fraction-static 0.93 \
+  --chunked-prefill-size 16384 \
+  --disable-flashinfer-autotune \
+  --deepep-config /xxxxx/deepep_config.json \
+  --enable-nsa-prefill-context-parallel \
+  --nsa-prefill-cp-mode round-robin-split \
+  --moe-a2a-backend deepep \
+  --deepep-mode normal \
+  --init-expert-location  /xxxxx/expert_distribution.pt \
+  --ep-dispatch-algorithm static \
+  --ep-num-redundant-experts 8 \
+  --eplb-algorithm deepseek
+```
+
+#### P node 1
+
+```bash
+export SGLANG_DSV4_REQUEST_SCOPED_C128_STATE=true
+export SGLANG_OPT_USE_ONLINE_COMPRESS=false
+export SGLANG_DSV4_PD_PREFILL_USE_FULL_TOKEN_POOL=true
+export SGLANG_DISAGGREGATION_WAITING_TIMEOUT=1800
+export SGLANG_HEALTH_CHECK_TIMEOUT=1000
+export SGLANG_LIGHTOP_KVALLOC_KERNEL=1
+export ROCSHMEM_GDR_DISABLE_XDP=1
+export TRITON_HIP_CLANG_PATH=/opt/dtk/aillvm/bin/clang-18
+export LD_LIBRARY_PATH=/usr/lib64:$LD_LIBRARY_PATH
+export HIP_VISIBLE_DEVICES=0,1,2,3
+export ROCSHMEM_IPC_MNVL=1
+export DEEP_EP_NORMAL_MNVL=1
+export NCCL_SOCKET_IFNAME=em1
+export GLOO_SOCKET_IFNAME=em1
+export HIP_BUFFER_EXTRA_SIZE=0
+export ROCSHMEM_DISABLE_HDP_FLUSH=1
+export ROCSHMEM_GDA_NUM_QPS_DEFAULT_CTX=288
+export SGLANG_DEEPEP_NUM_MAX_DISPATCH_TOKENS_PER_RANK=64
+export LD_LIBRARY_PATH=/usr/lib64:${LD_LIBRARY_PATH:-}
+export SGLANG_USE_LIGHTOP=1
+export SGLANG_USE_LINEAR_BF16_FP32_USE_BLASLT=1
+export SGLANG_ROCM_USE_AITER_TILELANG_MHC=1
+export SGLANG_USE_DPSKV4_LIGHTOP_RMSNORM=1
+export SGLANG_USE_FP8_W8A8_MOE=1
+export SGLANG_USE_DEEPGEMM_MOE=1
+export SGLANG_OPT_USE_FUSED_STORE_CACHE="${SGLANG_OPT_USE_FUSED_STORE_CACHE:-false}"
+export SGLANG_OPT_USE_FUSED_HASH_TOPK="${SGLANG_OPT_USE_FUSED_HASH_TOPK:-true}"
+export SGLANG_OPT_SWIGLU_CLAMP_FUSION="${SGLANG_OPT_SWIGLU_CLAMP_FUSION:-false}"
+export SGLANG_TOPK_TRANSFORM_512_TORCH="${SGLANG_TOPK_TRANSFORM_512_TORCH:-false}"
+export SGLANG_OPT_USE_JIT_KERNEL_FUSED_TOPK="${SGLANG_OPT_USE_JIT_KERNEL_FUSED_TOPK:-false}"
+export SGLANG_ROCM_USE_AITER_MOE="${SGLANG_ROCM_USE_AITER_MOE:-false}"
+export SGLANG_DSV4_SPLIT_PREFILL_DECODE_MLA="${SGLANG_DSV4_SPLIT_PREFILL_DECODE_MLA:-0}"
+export SGLANG_DSV4_SPLIT_HCA_NONSPARSE_MLA="${SGLANG_DSV4_SPLIT_HCA_NONSPARSE_MLA:-false}"
+export SGLANG_DSV4_SPARSE_PREFILL_SINGLE_CALL="${SGLANG_DSV4_SPARSE_PREFILL_SINGLE_CALL:-false}"
+export SGLANG_DSV4_SPARSE_PREFILL_TRITON_GATHER="${SGLANG_DSV4_SPARSE_PREFILL_TRITON_GATHER:-false}"
+export SGLANG_JIT_DEEPGEMM_PRECOMPILE="${SGLANG_JIT_DEEPGEMM_PRECOMPILE:-0}"
+export SGLANG_DISABLED_MODEL_ARCHS="${SGLANG_DISABLED_MODEL_ARCHS:-midashenglm}"
+export SGLANG_DEBUG_DSV4_LOAD="${SGLANG_DEBUG_DSV4_LOAD:-0}"
+export SGLANG_APPLY_CONFIG_BACKUP="${SGLANG_APPLY_CONFIG_BACKUP:-none}"
+export GPU_MAX_HW_QUEUES=2
+export SGLANG_USE_LIGHTOP_EP_SCATTER=false
+export SGLANG_USE_LIGHTOP_EP_GATHER=false
+export SGLANG_USE_LIGHTOP_EP_MOE_ALIGN=false
+export SGL_CHUNKED_PREFIX_CACHE_THRESHOLD=0
+export SGLANG_DISAGGREGATION_BOOTSTRAP_TIMEOUT=1200
+export GLIBC_TUNABLES=glibc.rtld.optional_static_tls=0x40000
+export SGLANG_KVALLOC_KERNEL=1
+export SGLANG_SET_CPU_AFFINITY=1
+export HIP_KERNEL_BATCH_CEILING=100
+export HSA_KERNARG_POOL_SIZE=8388608
+export ROC_AQL_QUEUE_SIZE=131072
+export ROCSHMEM_MAX_NUM_CONTEXTS=48
+export ROCSHMEM_HEAP_SIZE=3173741824
+export MC_ENABLE_DEST_DEVICE_AFFINITY=1
+export MC_ALLOWED_IBV_DEVICES=shca_0,shca_1,shca_2,shca_4
+
+sglang serve \
+  --model-path hygon/DeepSeek-V4-Pro-Channel-FP8-w8a8 \
+  --tokenizer-path hygon/DeepSeek-V4-Pro-Channel-FP8-w8a8 \
+  --trust-remote-code \
+  --dist-init-addr <P_node0_ip>:<port0> \
+  --nnodes 4 \
+  --node-rank 1 \
+  --host <P_node1_ip> \
+  --port <port1> \
+  --tp-size 8 \
+  --pp-size 2 \
+  --ep-size 8 \
+  --disaggregation-mode prefill \
+  --disaggregation-ib-device shca_0,shca_1,shca_2,shca_4 \
+  --disable-cuda-graph \
+  --skip-server-warmup \
+  --dist-timeout 10000 \
+  --watchdog-timeout 3600 \
+  --mem-fraction-static 0.93 \
+  --chunked-prefill-size 16384 \
+  --disable-flashinfer-autotune \
+  --deepep-config /xxxxx/deepep_config.json \
+  --enable-nsa-prefill-context-parallel \
+  --nsa-prefill-cp-mode round-robin-split \
+  --moe-a2a-backend deepep \
+  --deepep-mode normal \
+  --init-expert-location  /xxxxx/expert_distribution.pt \
+  --ep-dispatch-algorithm static \
+  --ep-num-redundant-experts 8 \
+  --eplb-algorithm deepseek
+```
+
+#### P node 2
+
+```bash
+export SGLANG_DSV4_REQUEST_SCOPED_C128_STATE=true
+export SGLANG_OPT_USE_ONLINE_COMPRESS=false
+export SGLANG_DSV4_PD_PREFILL_USE_FULL_TOKEN_POOL=true
+export SGLANG_DISAGGREGATION_WAITING_TIMEOUT=1800
+export SGLANG_HEALTH_CHECK_TIMEOUT=1000
+export SGLANG_LIGHTOP_KVALLOC_KERNEL=1
+export ROCSHMEM_GDR_DISABLE_XDP=1
+export TRITON_HIP_CLANG_PATH=/opt/dtk/aillvm/bin/clang-18
+export LD_LIBRARY_PATH=/usr/lib64:$LD_LIBRARY_PATH
+export HIP_VISIBLE_DEVICES=0,1,2,3
+export ROCSHMEM_IPC_MNVL=1
+export DEEP_EP_NORMAL_MNVL=1
+export NCCL_SOCKET_IFNAME=em1
+export GLOO_SOCKET_IFNAME=em1
+export HIP_BUFFER_EXTRA_SIZE=0
+export ROCSHMEM_DISABLE_HDP_FLUSH=1
+export ROCSHMEM_GDA_NUM_QPS_DEFAULT_CTX=288
+export SGLANG_DEEPEP_NUM_MAX_DISPATCH_TOKENS_PER_RANK=64
+export LD_LIBRARY_PATH=/usr/lib64:${LD_LIBRARY_PATH:-}
+export SGLANG_USE_LIGHTOP=1
+export SGLANG_USE_LINEAR_BF16_FP32_USE_BLASLT=1
+export SGLANG_ROCM_USE_AITER_TILELANG_MHC=1
+export SGLANG_USE_DPSKV4_LIGHTOP_RMSNORM=1
+export SGLANG_USE_FP8_W8A8_MOE=1
+export SGLANG_USE_DEEPGEMM_MOE=1
+export SGLANG_OPT_USE_FUSED_STORE_CACHE="${SGLANG_OPT_USE_FUSED_STORE_CACHE:-false}"
+export SGLANG_OPT_USE_FUSED_HASH_TOPK="${SGLANG_OPT_USE_FUSED_HASH_TOPK:-true}"
+export SGLANG_OPT_SWIGLU_CLAMP_FUSION="${SGLANG_OPT_SWIGLU_CLAMP_FUSION:-false}"
+export SGLANG_TOPK_TRANSFORM_512_TORCH="${SGLANG_TOPK_TRANSFORM_512_TORCH:-false}"
+export SGLANG_OPT_USE_JIT_KERNEL_FUSED_TOPK="${SGLANG_OPT_USE_JIT_KERNEL_FUSED_TOPK:-false}"
+export SGLANG_ROCM_USE_AITER_MOE="${SGLANG_ROCM_USE_AITER_MOE:-false}"
+export SGLANG_DSV4_SPLIT_PREFILL_DECODE_MLA="${SGLANG_DSV4_SPLIT_PREFILL_DECODE_MLA:-0}"
+export SGLANG_DSV4_SPLIT_HCA_NONSPARSE_MLA="${SGLANG_DSV4_SPLIT_HCA_NONSPARSE_MLA:-false}"
+export SGLANG_DSV4_SPARSE_PREFILL_SINGLE_CALL="${SGLANG_DSV4_SPARSE_PREFILL_SINGLE_CALL:-false}"
+export SGLANG_DSV4_SPARSE_PREFILL_TRITON_GATHER="${SGLANG_DSV4_SPARSE_PREFILL_TRITON_GATHER:-false}"
+export SGLANG_JIT_DEEPGEMM_PRECOMPILE="${SGLANG_JIT_DEEPGEMM_PRECOMPILE:-0}"
+export SGLANG_DISABLED_MODEL_ARCHS="${SGLANG_DISABLED_MODEL_ARCHS:-midashenglm}"
+export SGLANG_DEBUG_DSV4_LOAD="${SGLANG_DEBUG_DSV4_LOAD:-0}"
+export SGLANG_APPLY_CONFIG_BACKUP="${SGLANG_APPLY_CONFIG_BACKUP:-none}"
+export GPU_MAX_HW_QUEUES=2
+export SGLANG_USE_LIGHTOP_EP_SCATTER=false
+export SGLANG_USE_LIGHTOP_EP_GATHER=false
+export SGLANG_USE_LIGHTOP_EP_MOE_ALIGN=false
+export SGL_CHUNKED_PREFIX_CACHE_THRESHOLD=0
+export SGLANG_DISAGGREGATION_BOOTSTRAP_TIMEOUT=1200
+export GLIBC_TUNABLES=glibc.rtld.optional_static_tls=0x40000
+export SGLANG_KVALLOC_KERNEL=1
+export SGLANG_SET_CPU_AFFINITY=1
+export HIP_KERNEL_BATCH_CEILING=100
+export HSA_KERNARG_POOL_SIZE=8388608
+export ROC_AQL_QUEUE_SIZE=131072
+export ROCSHMEM_MAX_NUM_CONTEXTS=48
+export ROCSHMEM_HEAP_SIZE=3173741824
+export MC_ENABLE_DEST_DEVICE_AFFINITY=1
+export MC_ALLOWED_IBV_DEVICES=shca_0,shca_1,shca_2,shca_4
+
+sglang serve \
+  --model-path hygon/DeepSeek-V4-Pro-Channel-FP8-w8a8 \
+  --tokenizer-path hygon/DeepSeek-V4-Pro-Channel-FP8-w8a8 \
+  --trust-remote-code \
+  --dist-init-addr <P_node0_ip>:<port0> \
+  --nnodes 4 \
+  --node-rank 2 \
+  --host <P_node2_ip> \
+  --port <port1> \
+  --tp-size 8 \
+  --pp-size 2 \
+  --ep-size 8 \
+  --disaggregation-mode prefill \
+  --disaggregation-ib-device shca_0,shca_1,shca_2,shca_4 \
+  --disable-cuda-graph \
+  --skip-server-warmup \
+  --dist-timeout 10000 \
+  --watchdog-timeout 3600 \
+  --mem-fraction-static 0.93 \
+  --chunked-prefill-size 16384 \
+  --disable-flashinfer-autotune \
+  --deepep-config /xxxxx/deepep_config.json \
+  --enable-nsa-prefill-context-parallel \
+  --nsa-prefill-cp-mode round-robin-split \
+  --moe-a2a-backend deepep \
+  --deepep-mode normal \
+  --init-expert-location  /xxxxx/expert_distribution.pt \
+  --ep-dispatch-algorithm static \
+  --ep-num-redundant-experts 8 \
+  --eplb-algorithm deepseek
+```
+
+#### P node 3
+
+```bash
+export SGLANG_DSV4_REQUEST_SCOPED_C128_STATE=true
+export SGLANG_OPT_USE_ONLINE_COMPRESS=false
+export SGLANG_DSV4_PD_PREFILL_USE_FULL_TOKEN_POOL=true
+export SGLANG_DISAGGREGATION_WAITING_TIMEOUT=1800
+export SGLANG_HEALTH_CHECK_TIMEOUT=1000
+export SGLANG_LIGHTOP_KVALLOC_KERNEL=1
+export ROCSHMEM_GDR_DISABLE_XDP=1
+export TRITON_HIP_CLANG_PATH=/opt/dtk/aillvm/bin/clang-18
+export LD_LIBRARY_PATH=/usr/lib64:$LD_LIBRARY_PATH
+export HIP_VISIBLE_DEVICES=0,1,2,3
+export ROCSHMEM_IPC_MNVL=1
+export DEEP_EP_NORMAL_MNVL=1
+export NCCL_SOCKET_IFNAME=em1
+export GLOO_SOCKET_IFNAME=em1
+export HIP_BUFFER_EXTRA_SIZE=0
+export ROCSHMEM_DISABLE_HDP_FLUSH=1
+export ROCSHMEM_GDA_NUM_QPS_DEFAULT_CTX=288
+export SGLANG_DEEPEP_NUM_MAX_DISPATCH_TOKENS_PER_RANK=64
+export LD_LIBRARY_PATH=/usr/lib64:${LD_LIBRARY_PATH:-}
+export SGLANG_USE_LIGHTOP=1
+export SGLANG_USE_LINEAR_BF16_FP32_USE_BLASLT=1
+export SGLANG_ROCM_USE_AITER_TILELANG_MHC=1
+export SGLANG_USE_DPSKV4_LIGHTOP_RMSNORM=1
+export SGLANG_USE_FP8_W8A8_MOE=1
+export SGLANG_USE_DEEPGEMM_MOE=1
+export SGLANG_OPT_USE_FUSED_STORE_CACHE="${SGLANG_OPT_USE_FUSED_STORE_CACHE:-false}"
+export SGLANG_OPT_USE_FUSED_HASH_TOPK="${SGLANG_OPT_USE_FUSED_HASH_TOPK:-true}"
+export SGLANG_OPT_SWIGLU_CLAMP_FUSION="${SGLANG_OPT_SWIGLU_CLAMP_FUSION:-false}"
+export SGLANG_TOPK_TRANSFORM_512_TORCH="${SGLANG_TOPK_TRANSFORM_512_TORCH:-false}"
+export SGLANG_OPT_USE_JIT_KERNEL_FUSED_TOPK="${SGLANG_OPT_USE_JIT_KERNEL_FUSED_TOPK:-false}"
+export SGLANG_ROCM_USE_AITER_MOE="${SGLANG_ROCM_USE_AITER_MOE:-false}"
+export SGLANG_DSV4_SPLIT_PREFILL_DECODE_MLA="${SGLANG_DSV4_SPLIT_PREFILL_DECODE_MLA:-0}"
+export SGLANG_DSV4_SPLIT_HCA_NONSPARSE_MLA="${SGLANG_DSV4_SPLIT_HCA_NONSPARSE_MLA:-false}"
+export SGLANG_DSV4_SPARSE_PREFILL_SINGLE_CALL="${SGLANG_DSV4_SPARSE_PREFILL_SINGLE_CALL:-false}"
+export SGLANG_DSV4_SPARSE_PREFILL_TRITON_GATHER="${SGLANG_DSV4_SPARSE_PREFILL_TRITON_GATHER:-false}"
+export SGLANG_JIT_DEEPGEMM_PRECOMPILE="${SGLANG_JIT_DEEPGEMM_PRECOMPILE:-0}"
+export SGLANG_DISABLED_MODEL_ARCHS="${SGLANG_DISABLED_MODEL_ARCHS:-midashenglm}"
+export SGLANG_DEBUG_DSV4_LOAD="${SGLANG_DEBUG_DSV4_LOAD:-0}"
+export SGLANG_APPLY_CONFIG_BACKUP="${SGLANG_APPLY_CONFIG_BACKUP:-none}"
+export GPU_MAX_HW_QUEUES=2
+export SGLANG_USE_LIGHTOP_EP_SCATTER=false
+export SGLANG_USE_LIGHTOP_EP_GATHER=false
+export SGLANG_USE_LIGHTOP_EP_MOE_ALIGN=false
+export SGL_CHUNKED_PREFIX_CACHE_THRESHOLD=0
+export SGLANG_DISAGGREGATION_BOOTSTRAP_TIMEOUT=1200
+export GLIBC_TUNABLES=glibc.rtld.optional_static_tls=0x40000
+export SGLANG_KVALLOC_KERNEL=1
+export SGLANG_SET_CPU_AFFINITY=1
+export HIP_KERNEL_BATCH_CEILING=100
+export HSA_KERNARG_POOL_SIZE=8388608
+export ROC_AQL_QUEUE_SIZE=131072
+export ROCSHMEM_MAX_NUM_CONTEXTS=48
+export ROCSHMEM_HEAP_SIZE=3173741824
+export MC_ENABLE_DEST_DEVICE_AFFINITY=1
+export MC_ALLOWED_IBV_DEVICES=shca_0,shca_1,shca_2,shca_4
+
+sglang serve \
+  --model-path hygon/DeepSeek-V4-Pro-Channel-FP8-w8a8 \
+  --tokenizer-path hygon/DeepSeek-V4-Pro-Channel-FP8-w8a8 \
+  --trust-remote-code \
+  --dist-init-addr <P_node0_ip>:<port0> \
+  --nnodes 4 \
+  --node-rank 3 \
+  --host <P_node3_ip> \
+  --port <port1> \
+  --tp-size 8 \
+  --pp-size 2 \
+  --ep-size 8 \
+  --disaggregation-mode prefill \
+  --disaggregation-ib-device shca_0,shca_1,shca_2,shca_4 \
+  --disable-cuda-graph \
+  --skip-server-warmup \
+  --dist-timeout 10000 \
+  --watchdog-timeout 3600 \
+  --mem-fraction-static 0.93 \
+  --chunked-prefill-size 16384 \
+  --disable-flashinfer-autotune \
+  --deepep-config /xxxxx/deepep_config.json \
+  --enable-nsa-prefill-context-parallel \
+  --nsa-prefill-cp-mode round-robin-split \
+  --moe-a2a-backend deepep \
+  --deepep-mode normal \
+  --init-expert-location  /xxxxx/expert_distribution.pt \
+  --ep-dispatch-algorithm static \
+  --ep-num-redundant-experts 8 \
+  --eplb-algorithm deepseek
+```
+
+#### D node 0
+
+```bash
+export SGLANG_DSV4_REQUEST_SCOPED_C128_STATE=true
+export SGLANG_OPT_USE_ONLINE_COMPRESS=false
+export SGLANG_DISAGGREGATION_WAITING_TIMEOUT=1800
+export PYTORCH_ALLOC_CONF=expandable_segments:True
+export SGLANG_DSV4_PD_PREFILL_USE_FULL_TOKEN_POOL=true
+export SGLANG_LIGHTOP_KVALLOC_KERNEL=1
+export ROCSHMEM_GDR_DISABLE_XDP=1
+export TRITON_HIP_CLANG_PATH=/opt/dtk/aillvm/bin/clang-18
+export SGLANG_LIGHTOP_TOPK=true
+export SGLANG_OPT_USE_MULTI_STREAM_OVERLAP=false
+export PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True
+export SGLANG_HEALTH_CHECK_TIMEOUT=10000
+export HIPBLASLT_TUNING_OVERRIDE_FILE=/mnt/rep/hyq/DeepSeek-V4-Pro/ep16.config
+export SGLANG_NCCL_ALL_GATHER_IN_OVERLAP_SCHEDULER_SYNC_BATCH=1
+export HIP_VISIBLE_DEVICES=0,1,2,3
+export HSA_ENABLE_COREDUMP=1
+export ROCSHMEM_MAX_NUM_CONTEXTS=60
+export ROCSHMEM_HEAP_SIZE=3173741824
+export ROCSHMEM_DISABLE_HDP_FLUSH=1
+export ROCSHMEM_GDA_NUM_QPS_DEFAULT_CTX=288
+export NCCL_IB_DISABLE=1
+export MC_IB_GID_INDEX=0
+export MC_ENABLE_DEST_DEVICE_AFFINITY=1
+export NCCL_SOCKET_IFNAME=em1
+export GLOO_SOCKET_IFNAME=em1
+export ROCSHMEM_IB_GID_INDEX=0
+export SGLANG_DEEPEP_NUM_MAX_DISPATCH_TOKENS_PER_RANK=64
+export ROCSHMEM_IPC_MNVL=1
+export HIP_BUFFER_EXTRA_SIZE=0
+export SGLANG_SET_CPU_AFFINITY=1
+export SGLANG_CHUNKED_PREFIX_CACHE_THRESHOLD=0
+export GLIBC_TUNABLES=glibc.rtld.optional_static_tls=0x40000
+export HIP_KERNEL_BATCH_CEILING=100
+export GPU_FORCE_BLIT_COPY_SIZE=16
+export HSA_KERNARG_POOL_SIZE=8388608
+export ROC_AQL_QUEUE_SIZE=131072
+export SGLANG_ENABLE_SPEC_V2=1
+export SGLANG_USE_LIGHTOP=1
+export SGLANG_USE_OPT_CAT=1
+export SGLANG_USE_FUSED_MLA_CAT=1
+export SGLANG_USE_LIGHTOP_GROUP_FP8_QUANT=1
+export SGLANG_USE_LINEAR_BF16_FP32_USE_BLASLT=1
+export SGLANG_ROCM_USE_AITER_TILELANG_MHC=1
+export SGLANG_USE_DPSKV4_LIGHTOP_QUANT_K_CACHE=1
+export SGLANG_USE_DPSKV4_LIGHTOP_RMSNORM=1
+export SGLANG_USE_FP8_W8A8_MOE=1
+export SGLANG_USE_DEEPGEMM_MOE=1
+export SGL_CHUNKED_PREFIX_CACHE_THRESHOLD=0
+export SGLANG_DISAGGREGATION_BOOTSTRAP_TIMEOUT=1200
+export SGLANG_OPT_USE_FUSED_STORE_CACHE="${SGLANG_OPT_USE_FUSED_STORE_CACHE:-false}"
+export SGLANG_OPT_USE_FUSED_HASH_TOPK="${SGLANG_OPT_USE_FUSED_HASH_TOPK:-true}"
+export SGLANG_OPT_SWIGLU_CLAMP_FUSION="${SGLANG_OPT_SWIGLU_CLAMP_FUSION:-false}"
+export SGLANG_TOPK_TRANSFORM_512_TORCH="${SGLANG_TOPK_TRANSFORM_512_TORCH:-false}"
+export SGLANG_OPT_USE_JIT_KERNEL_FUSED_TOPK="${SGLANG_OPT_USE_JIT_KERNEL_FUSED_TOPK:-false}"
+export SGLANG_ROCM_USE_AITER_MOE="${SGLANG_ROCM_USE_AITER_MOE:-false}"
+export SGLANG_DSV4_SPLIT_PREFILL_DECODE_MLA="${SGLANG_DSV4_SPLIT_PREFILL_DECODE_MLA:-0}"
+export SGLANG_DSV4_SPLIT_HCA_NONSPARSE_MLA="${SGLANG_DSV4_SPLIT_HCA_NONSPARSE_MLA:-false}"
+export SGLANG_DSV4_SPARSE_PREFILL_SINGLE_CALL="${SGLANG_DSV4_SPARSE_PREFILL_SINGLE_CALL:-false}"
+export SGLANG_DSV4_SPARSE_PREFILL_TRITON_GATHER="${SGLANG_DSV4_SPARSE_PREFILL_TRITON_GATHER:-false}"
+export SGLANG_JIT_DEEPGEMM_PRECOMPILE="${SGLANG_JIT_DEEPGEMM_PRECOMPILE:-0}"
+export SGLANG_DISABLED_MODEL_ARCHS="${SGLANG_DISABLED_MODEL_ARCHS:-midashenglm}"
+export SGLANG_DEBUG_DSV4_LOAD="${SGLANG_DEBUG_DSV4_LOAD:-0}"
+export SGLANG_APPLY_CONFIG_BACKUP="${SGLANG_APPLY_CONFIG_BACKUP:-none}"
+export SGLANG_USE_LIGHTOP_EP_SCATTER=false
+export SGLANG_USE_LIGHTOP_EP_GATHER=false
+export SGLANG_USE_LIGHTOP_EP_MOE_ALIGN=false
+
+sglang serve \
+  --model-path hygon/DeepSeek-V4-Pro-Channel-FP8-w8a8 \
+  --tokenizer-path hygon/DeepSeek-V4-Pro-Channel-FP8-w8a8 \
+  --trust-remote-code \
+  --dist-init-addr <D_node0_ip>:<port0> \
+  --nnodes 4 \
+  --node-rank 0 \
+  --host <D_node0_ip> \
+  --port <port1> \
+  --tp-size 16 \
+  --ep-size 16 \
+  --dp-size 16 \
+  --moe-dense-tp-size 1 \
+  --enable-dp-attention \
+  --enable-dp-lm-head \
+  --disaggregation-mode decode \
+  --disaggregation-ib-device shca_0,shca_1,shca_2,shca_4 \
+  --cuda-graph-max-bs 16 \
+  --max-running-requests 256 \
+  --skip-server-warmup \
+  --chunked-prefill-size 16384 \
+  --dist-timeout 10000 \
+  --watchdog-timeout 3600 \
+  --mem-fraction-static 0.91 \
+  --speculative-algo EAGLE \
+  --speculative-num-steps 3 \
+  --speculative-eagle-topk 1 \
+  --speculative-num-draft-tokens 4 \
+  --disable-flashinfer-autotune \
+  --context-length 1048576 \
+  --moe-a2a-backend deepep \
+  --deepep-mode low_latency
+```
+
+#### D node 1
+
+```bash
+export SGLANG_DSV4_REQUEST_SCOPED_C128_STATE=true
+export SGLANG_OPT_USE_ONLINE_COMPRESS=false
+export SGLANG_DISAGGREGATION_WAITING_TIMEOUT=1800
+export PYTORCH_ALLOC_CONF=expandable_segments:True
+export SGLANG_DSV4_PD_PREFILL_USE_FULL_TOKEN_POOL=true
+export SGLANG_LIGHTOP_KVALLOC_KERNEL=1
+export ROCSHMEM_GDR_DISABLE_XDP=1
+export TRITON_HIP_CLANG_PATH=/opt/dtk/aillvm/bin/clang-18
+export SGLANG_LIGHTOP_TOPK=true
+export SGLANG_OPT_USE_MULTI_STREAM_OVERLAP=false
+export PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True
+export SGLANG_HEALTH_CHECK_TIMEOUT=10000
+export HIPBLASLT_TUNING_OVERRIDE_FILE=/mnt/rep/hyq/DeepSeek-V4-Pro/ep16.config
+export SGLANG_NCCL_ALL_GATHER_IN_OVERLAP_SCHEDULER_SYNC_BATCH=1
+export HIP_VISIBLE_DEVICES=0,1,2,3
+export HSA_ENABLE_COREDUMP=1
+export ROCSHMEM_MAX_NUM_CONTEXTS=60
+export ROCSHMEM_HEAP_SIZE=3173741824
+export ROCSHMEM_DISABLE_HDP_FLUSH=1
+export ROCSHMEM_GDA_NUM_QPS_DEFAULT_CTX=288
+export NCCL_IB_DISABLE=1
+export MC_IB_GID_INDEX=0
+export MC_ENABLE_DEST_DEVICE_AFFINITY=1
+export NCCL_SOCKET_IFNAME=em1
+export GLOO_SOCKET_IFNAME=em1
+export ROCSHMEM_IB_GID_INDEX=0
+export SGLANG_DEEPEP_NUM_MAX_DISPATCH_TOKENS_PER_RANK=64
+export ROCSHMEM_IPC_MNVL=1
+export HIP_BUFFER_EXTRA_SIZE=0
+export SGLANG_SET_CPU_AFFINITY=1
+export SGLANG_CHUNKED_PREFIX_CACHE_THRESHOLD=0
+export GLIBC_TUNABLES=glibc.rtld.optional_static_tls=0x40000
+export HIP_KERNEL_BATCH_CEILING=100
+export GPU_FORCE_BLIT_COPY_SIZE=16
+export HSA_KERNARG_POOL_SIZE=8388608
+export ROC_AQL_QUEUE_SIZE=131072
+export SGLANG_ENABLE_SPEC_V2=1
+export SGLANG_USE_LIGHTOP=1
+export SGLANG_USE_OPT_CAT=1
+export SGLANG_USE_FUSED_MLA_CAT=1
+export SGLANG_USE_LIGHTOP_GROUP_FP8_QUANT=1
+export SGLANG_USE_LINEAR_BF16_FP32_USE_BLASLT=1
+export SGLANG_ROCM_USE_AITER_TILELANG_MHC=1
+export SGLANG_USE_DPSKV4_LIGHTOP_QUANT_K_CACHE=1
+export SGLANG_USE_DPSKV4_LIGHTOP_RMSNORM=1
+export SGLANG_USE_FP8_W8A8_MOE=1
+export SGLANG_USE_DEEPGEMM_MOE=1
+export SGL_CHUNKED_PREFIX_CACHE_THRESHOLD=0
+export SGLANG_DISAGGREGATION_BOOTSTRAP_TIMEOUT=1200
+export SGLANG_OPT_USE_FUSED_STORE_CACHE="${SGLANG_OPT_USE_FUSED_STORE_CACHE:-false}"
+export SGLANG_OPT_USE_FUSED_HASH_TOPK="${SGLANG_OPT_USE_FUSED_HASH_TOPK:-true}"
+export SGLANG_OPT_SWIGLU_CLAMP_FUSION="${SGLANG_OPT_SWIGLU_CLAMP_FUSION:-false}"
+export SGLANG_TOPK_TRANSFORM_512_TORCH="${SGLANG_TOPK_TRANSFORM_512_TORCH:-false}"
+export SGLANG_OPT_USE_JIT_KERNEL_FUSED_TOPK="${SGLANG_OPT_USE_JIT_KERNEL_FUSED_TOPK:-false}"
+export SGLANG_ROCM_USE_AITER_MOE="${SGLANG_ROCM_USE_AITER_MOE:-false}"
+export SGLANG_DSV4_SPLIT_PREFILL_DECODE_MLA="${SGLANG_DSV4_SPLIT_PREFILL_DECODE_MLA:-0}"
+export SGLANG_DSV4_SPLIT_HCA_NONSPARSE_MLA="${SGLANG_DSV4_SPLIT_HCA_NONSPARSE_MLA:-false}"
+export SGLANG_DSV4_SPARSE_PREFILL_SINGLE_CALL="${SGLANG_DSV4_SPARSE_PREFILL_SINGLE_CALL:-false}"
+export SGLANG_DSV4_SPARSE_PREFILL_TRITON_GATHER="${SGLANG_DSV4_SPARSE_PREFILL_TRITON_GATHER:-false}"
+export SGLANG_JIT_DEEPGEMM_PRECOMPILE="${SGLANG_JIT_DEEPGEMM_PRECOMPILE:-0}"
+export SGLANG_DISABLED_MODEL_ARCHS="${SGLANG_DISABLED_MODEL_ARCHS:-midashenglm}"
+export SGLANG_DEBUG_DSV4_LOAD="${SGLANG_DEBUG_DSV4_LOAD:-0}"
+export SGLANG_APPLY_CONFIG_BACKUP="${SGLANG_APPLY_CONFIG_BACKUP:-none}"
+export SGLANG_USE_LIGHTOP_EP_SCATTER=false
+export SGLANG_USE_LIGHTOP_EP_GATHER=false
+export SGLANG_USE_LIGHTOP_EP_MOE_ALIGN=false
+
+sglang serve \
+  --model-path hygon/DeepSeek-V4-Pro-Channel-FP8-w8a8 \
+  --tokenizer-path hygon/DeepSeek-V4-Pro-Channel-FP8-w8a8 \
+  --trust-remote-code \
+  --dist-init-addr <D_node0_ip>:<port0> \
+  --nnodes 4 \
+  --node-rank 1 \
+  --host <D_node1_ip> \
+  --port <port1> \
+  --tp-size 16 \
+  --ep-size 16 \
+  --dp-size 16 \
+  --moe-dense-tp-size 1 \
+  --enable-dp-attention \
+  --enable-dp-lm-head \
+  --disaggregation-mode decode \
+  --disaggregation-ib-device shca_0,shca_1,shca_2,shca_4 \
+  --cuda-graph-max-bs 16 \
+  --max-running-requests 256 \
+  --skip-server-warmup \
+  --chunked-prefill-size 16384 \
+  --dist-timeout 10000 \
+  --watchdog-timeout 3600 \
+  --mem-fraction-static 0.91 \
+  --speculative-algo EAGLE \
+  --speculative-num-steps 3 \
+  --speculative-eagle-topk 1 \
+  --speculative-num-draft-tokens 4 \
+  --disable-flashinfer-autotune \
+  --context-length 1048576 \
+  --moe-a2a-backend deepep \
+  --deepep-mode low_latency
+```
+
+#### D node 2
+
+```bash
+export SGLANG_DSV4_REQUEST_SCOPED_C128_STATE=true
+export SGLANG_OPT_USE_ONLINE_COMPRESS=false
+export SGLANG_DISAGGREGATION_WAITING_TIMEOUT=1800
+export PYTORCH_ALLOC_CONF=expandable_segments:True
+export SGLANG_DSV4_PD_PREFILL_USE_FULL_TOKEN_POOL=true
+export SGLANG_LIGHTOP_KVALLOC_KERNEL=1
+export ROCSHMEM_GDR_DISABLE_XDP=1
+export TRITON_HIP_CLANG_PATH=/opt/dtk/aillvm/bin/clang-18
+export SGLANG_LIGHTOP_TOPK=true
+export SGLANG_OPT_USE_MULTI_STREAM_OVERLAP=false
+export PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True
+export SGLANG_HEALTH_CHECK_TIMEOUT=10000
+export HIPBLASLT_TUNING_OVERRIDE_FILE=/mnt/rep/hyq/DeepSeek-V4-Pro/ep16.config
+export SGLANG_NCCL_ALL_GATHER_IN_OVERLAP_SCHEDULER_SYNC_BATCH=1
+export HIP_VISIBLE_DEVICES=0,1,2,3
+export HSA_ENABLE_COREDUMP=1
+export ROCSHMEM_MAX_NUM_CONTEXTS=60
+export ROCSHMEM_HEAP_SIZE=3173741824
+export ROCSHMEM_DISABLE_HDP_FLUSH=1
+export ROCSHMEM_GDA_NUM_QPS_DEFAULT_CTX=288
+export NCCL_IB_DISABLE=1
+export MC_IB_GID_INDEX=0
+export MC_ENABLE_DEST_DEVICE_AFFINITY=1
+export NCCL_SOCKET_IFNAME=em1
+export GLOO_SOCKET_IFNAME=em1
+export ROCSHMEM_IB_GID_INDEX=0
+export SGLANG_DEEPEP_NUM_MAX_DISPATCH_TOKENS_PER_RANK=64
+export ROCSHMEM_IPC_MNVL=1
+export HIP_BUFFER_EXTRA_SIZE=0
+export SGLANG_SET_CPU_AFFINITY=1
+export SGLANG_CHUNKED_PREFIX_CACHE_THRESHOLD=0
+export GLIBC_TUNABLES=glibc.rtld.optional_static_tls=0x40000
+export HIP_KERNEL_BATCH_CEILING=100
+export GPU_FORCE_BLIT_COPY_SIZE=16
+export HSA_KERNARG_POOL_SIZE=8388608
+export ROC_AQL_QUEUE_SIZE=131072
+export SGLANG_ENABLE_SPEC_V2=1
+export SGLANG_USE_LIGHTOP=1
+export SGLANG_USE_OPT_CAT=1
+export SGLANG_USE_FUSED_MLA_CAT=1
+export SGLANG_USE_LIGHTOP_GROUP_FP8_QUANT=1
+export SGLANG_USE_LINEAR_BF16_FP32_USE_BLASLT=1
+export SGLANG_ROCM_USE_AITER_TILELANG_MHC=1
+export SGLANG_USE_DPSKV4_LIGHTOP_QUANT_K_CACHE=1
+export SGLANG_USE_DPSKV4_LIGHTOP_RMSNORM=1
+export SGLANG_USE_FP8_W8A8_MOE=1
+export SGLANG_USE_DEEPGEMM_MOE=1
+export SGL_CHUNKED_PREFIX_CACHE_THRESHOLD=0
+export SGLANG_DISAGGREGATION_BOOTSTRAP_TIMEOUT=1200
+export SGLANG_OPT_USE_FUSED_STORE_CACHE="${SGLANG_OPT_USE_FUSED_STORE_CACHE:-false}"
+export SGLANG_OPT_USE_FUSED_HASH_TOPK="${SGLANG_OPT_USE_FUSED_HASH_TOPK:-true}"
+export SGLANG_OPT_SWIGLU_CLAMP_FUSION="${SGLANG_OPT_SWIGLU_CLAMP_FUSION:-false}"
+export SGLANG_TOPK_TRANSFORM_512_TORCH="${SGLANG_TOPK_TRANSFORM_512_TORCH:-false}"
+export SGLANG_OPT_USE_JIT_KERNEL_FUSED_TOPK="${SGLANG_OPT_USE_JIT_KERNEL_FUSED_TOPK:-false}"
+export SGLANG_ROCM_USE_AITER_MOE="${SGLANG_ROCM_USE_AITER_MOE:-false}"
+export SGLANG_DSV4_SPLIT_PREFILL_DECODE_MLA="${SGLANG_DSV4_SPLIT_PREFILL_DECODE_MLA:-0}"
+export SGLANG_DSV4_SPLIT_HCA_NONSPARSE_MLA="${SGLANG_DSV4_SPLIT_HCA_NONSPARSE_MLA:-false}"
+export SGLANG_DSV4_SPARSE_PREFILL_SINGLE_CALL="${SGLANG_DSV4_SPARSE_PREFILL_SINGLE_CALL:-false}"
+export SGLANG_DSV4_SPARSE_PREFILL_TRITON_GATHER="${SGLANG_DSV4_SPARSE_PREFILL_TRITON_GATHER:-false}"
+export SGLANG_JIT_DEEPGEMM_PRECOMPILE="${SGLANG_JIT_DEEPGEMM_PRECOMPILE:-0}"
+export SGLANG_DISABLED_MODEL_ARCHS="${SGLANG_DISABLED_MODEL_ARCHS:-midashenglm}"
+export SGLANG_DEBUG_DSV4_LOAD="${SGLANG_DEBUG_DSV4_LOAD:-0}"
+export SGLANG_APPLY_CONFIG_BACKUP="${SGLANG_APPLY_CONFIG_BACKUP:-none}"
+export SGLANG_USE_LIGHTOP_EP_SCATTER=false
+export SGLANG_USE_LIGHTOP_EP_GATHER=false
+export SGLANG_USE_LIGHTOP_EP_MOE_ALIGN=false
+
+sglang serve \
+  --model-path hygon/DeepSeek-V4-Pro-Channel-FP8-w8a8 \
+  --tokenizer-path hygon/DeepSeek-V4-Pro-Channel-FP8-w8a8 \
+  --trust-remote-code \
+  --dist-init-addr <D_node0_ip>:<port0> \
+  --nnodes 4 \
+  --node-rank 2 \
+  --host <D_node2_ip> \
+  --port <port1> \
+  --tp-size 16 \
+  --ep-size 16 \
+  --dp-size 16 \
+  --moe-dense-tp-size 1 \
+  --enable-dp-attention \
+  --enable-dp-lm-head \
+  --disaggregation-mode decode \
+  --disaggregation-ib-device shca_0,shca_1,shca_2,shca_4 \
+  --cuda-graph-max-bs 16 \
+  --max-running-requests 256 \
+  --skip-server-warmup \
+  --chunked-prefill-size 16384 \
+  --dist-timeout 10000 \
+  --watchdog-timeout 3600 \
+  --mem-fraction-static 0.91 \
+  --speculative-algo EAGLE \
+  --speculative-num-steps 3 \
+  --speculative-eagle-topk 1 \
+  --speculative-num-draft-tokens 4 \
+  --disable-flashinfer-autotune \
+  --context-length 1048576 \
+  --moe-a2a-backend deepep \
+  --deepep-mode low_latency
+```
+
+#### D node 3
+
+```bash
+export SGLANG_DSV4_REQUEST_SCOPED_C128_STATE=true
+export SGLANG_OPT_USE_ONLINE_COMPRESS=false
+export SGLANG_DISAGGREGATION_WAITING_TIMEOUT=1800
+export PYTORCH_ALLOC_CONF=expandable_segments:True
+export SGLANG_DSV4_PD_PREFILL_USE_FULL_TOKEN_POOL=true
+export SGLANG_LIGHTOP_KVALLOC_KERNEL=1
+export ROCSHMEM_GDR_DISABLE_XDP=1
+export TRITON_HIP_CLANG_PATH=/opt/dtk/aillvm/bin/clang-18
+export SGLANG_LIGHTOP_TOPK=true
+export SGLANG_OPT_USE_MULTI_STREAM_OVERLAP=false
+export PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True
+export SGLANG_HEALTH_CHECK_TIMEOUT=10000
+export HIPBLASLT_TUNING_OVERRIDE_FILE=/mnt/rep/hyq/DeepSeek-V4-Pro/ep16.config
+export SGLANG_NCCL_ALL_GATHER_IN_OVERLAP_SCHEDULER_SYNC_BATCH=1
+export HIP_VISIBLE_DEVICES=0,1,2,3
+export HSA_ENABLE_COREDUMP=1
+export ROCSHMEM_MAX_NUM_CONTEXTS=60
+export ROCSHMEM_HEAP_SIZE=3173741824
+export ROCSHMEM_DISABLE_HDP_FLUSH=1
+export ROCSHMEM_GDA_NUM_QPS_DEFAULT_CTX=288
+export NCCL_IB_DISABLE=1
+export MC_IB_GID_INDEX=0
+export MC_ENABLE_DEST_DEVICE_AFFINITY=1
+export NCCL_SOCKET_IFNAME=em1
+export GLOO_SOCKET_IFNAME=em1
+export ROCSHMEM_IB_GID_INDEX=0
+export SGLANG_DEEPEP_NUM_MAX_DISPATCH_TOKENS_PER_RANK=64
+export ROCSHMEM_IPC_MNVL=1
+export HIP_BUFFER_EXTRA_SIZE=0
+export SGLANG_SET_CPU_AFFINITY=1
+export SGLANG_CHUNKED_PREFIX_CACHE_THRESHOLD=0
+export GLIBC_TUNABLES=glibc.rtld.optional_static_tls=0x40000
+export HIP_KERNEL_BATCH_CEILING=100
+export GPU_FORCE_BLIT_COPY_SIZE=16
+export HSA_KERNARG_POOL_SIZE=8388608
+export ROC_AQL_QUEUE_SIZE=131072
+export SGLANG_ENABLE_SPEC_V2=1
+export SGLANG_USE_LIGHTOP=1
+export SGLANG_USE_OPT_CAT=1
+export SGLANG_USE_FUSED_MLA_CAT=1
+export SGLANG_USE_LIGHTOP_GROUP_FP8_QUANT=1
+export SGLANG_USE_LINEAR_BF16_FP32_USE_BLASLT=1
+export SGLANG_ROCM_USE_AITER_TILELANG_MHC=1
+export SGLANG_USE_DPSKV4_LIGHTOP_QUANT_K_CACHE=1
+export SGLANG_USE_DPSKV4_LIGHTOP_RMSNORM=1
+export SGLANG_USE_FP8_W8A8_MOE=1
+export SGLANG_USE_DEEPGEMM_MOE=1
+export SGL_CHUNKED_PREFIX_CACHE_THRESHOLD=0
+export SGLANG_DISAGGREGATION_BOOTSTRAP_TIMEOUT=1200
+export SGLANG_OPT_USE_FUSED_STORE_CACHE="${SGLANG_OPT_USE_FUSED_STORE_CACHE:-false}"
+export SGLANG_OPT_USE_FUSED_HASH_TOPK="${SGLANG_OPT_USE_FUSED_HASH_TOPK:-true}"
+export SGLANG_OPT_SWIGLU_CLAMP_FUSION="${SGLANG_OPT_SWIGLU_CLAMP_FUSION:-false}"
+export SGLANG_TOPK_TRANSFORM_512_TORCH="${SGLANG_TOPK_TRANSFORM_512_TORCH:-false}"
+export SGLANG_OPT_USE_JIT_KERNEL_FUSED_TOPK="${SGLANG_OPT_USE_JIT_KERNEL_FUSED_TOPK:-false}"
+export SGLANG_ROCM_USE_AITER_MOE="${SGLANG_ROCM_USE_AITER_MOE:-false}"
+export SGLANG_DSV4_SPLIT_PREFILL_DECODE_MLA="${SGLANG_DSV4_SPLIT_PREFILL_DECODE_MLA:-0}"
+export SGLANG_DSV4_SPLIT_HCA_NONSPARSE_MLA="${SGLANG_DSV4_SPLIT_HCA_NONSPARSE_MLA:-false}"
+export SGLANG_DSV4_SPARSE_PREFILL_SINGLE_CALL="${SGLANG_DSV4_SPARSE_PREFILL_SINGLE_CALL:-false}"
+export SGLANG_DSV4_SPARSE_PREFILL_TRITON_GATHER="${SGLANG_DSV4_SPARSE_PREFILL_TRITON_GATHER:-false}"
+export SGLANG_JIT_DEEPGEMM_PRECOMPILE="${SGLANG_JIT_DEEPGEMM_PRECOMPILE:-0}"
+export SGLANG_DISABLED_MODEL_ARCHS="${SGLANG_DISABLED_MODEL_ARCHS:-midashenglm}"
+export SGLANG_DEBUG_DSV4_LOAD="${SGLANG_DEBUG_DSV4_LOAD:-0}"
+export SGLANG_APPLY_CONFIG_BACKUP="${SGLANG_APPLY_CONFIG_BACKUP:-none}"
+export SGLANG_USE_LIGHTOP_EP_SCATTER=false
+export SGLANG_USE_LIGHTOP_EP_GATHER=false
+export SGLANG_USE_LIGHTOP_EP_MOE_ALIGN=false
+
+sglang serve \
+  --model-path hygon/DeepSeek-V4-Pro-Channel-FP8-w8a8 \
+  --tokenizer-path hygon/DeepSeek-V4-Pro-Channel-FP8-w8a8 \
+  --trust-remote-code \
+  --dist-init-addr <D_node0_ip>:<port0> \
+  --nnodes 4 \
+  --node-rank 3 \
+  --host <D_node3_ip> \
+  --port <port1> \
+  --tp-size 16 \
+  --ep-size 16 \
+  --dp-size 16 \
+  --moe-dense-tp-size 1 \
+  --enable-dp-attention \
+  --enable-dp-lm-head \
+  --disaggregation-mode decode \
+  --disaggregation-ib-device shca_0,shca_1,shca_2,shca_4 \
+  --cuda-graph-max-bs 16 \
+  --max-running-requests 256 \
+  --skip-server-warmup \
+  --chunked-prefill-size 16384 \
+  --dist-timeout 10000 \
+  --watchdog-timeout 3600 \
+  --mem-fraction-static 0.91 \
+  --speculative-algo EAGLE \
+  --speculative-num-steps 3 \
+  --speculative-eagle-topk 1 \
+  --speculative-num-draft-tokens 4 \
+  --disable-flashinfer-autotune \
+  --context-length 1048576 \
+  --moe-a2a-backend deepep \
+  --deepep-mode low_latency
+```
+
+#### Router
+
+```bash
+python3 -m sglang_router.launch_router \
+  --pd-disaggregation \
+  --prefill "http://<P_node0_ip>:<port1>" \
+  --decode "http://<D_node0_ip>:<port1>" \
+  --request-timeout-secs 600 \
+  --host 0.0.0.0 \
+  --port 30001 \
+  --prometheus-port 29001
 ```
 
 ## API 调用


### PR DESCRIPTION
## Summary
- add the DeepSeek V4 Pro Channel FP8 W8A8 scaleX40-3G deployment entry for SGLang 0.5.12
- document a 4-node Prefill and 4-node Decode PD deployment with complete per-node environment variables and launch commands
- add the SGLang Router and PD API usage examples

## Verification
- git diff --check -- docs/model-deployment/sglang/deepseek-v4.md