### PR TITLE
docs: add Qwen3.5 397B scaleX40-3G PD deployment

### DIFF
--- a/docs/model-deployment/sglang/qwen3.5.md
+++ b/docs/model-deployment/sglang/qwen3.5.md
@@ -33,6 +33,7 @@ Qwen3.5-397B-A17B 采用 MoE 架构（397B 总参数 / 17B 激活参数）。
 | [Qwen/Qwen3.5-397B-A17B](https://www.modelscope.cn/models/Qwen/Qwen3.5-397B-A17B) | BF16 | [0.5.12](../docker_images.md) | BW1100 | 8 | IFB | [**`>_`**](#qwen35-397b-a17b-ifb-bw1100-8x-sglang-0512) |
 |  | BF16 | [0.5.12](../docker_images.md) | BW1000 | 16 | IFB | [**`>_`**](#qwen35-397b-a17b-ifb-bw1000-16x-sglang-0512) |
 | [hygon/Qwen3.5-397B-A17B-Channel-FP8-w8a8](https://www.modelscope.cn/models/hygon/Qwen3.5-397B-A17B-Channel-FP8-w8a8) | FP8 W8A8 | [0.5.12](../docker_images.md) | BW1100 | 4 | IFB | [**`>_`**](#qwen35-397b-a17b-channel-fp8-w8a8-ifb-bw1100-4x-sglang-0512) |
+|  | FP8 W8A8 | [0.5.12](../docker_images.md) | scaleX40-3G | 24 | PD | [**`>_`**](#qwen35-397b-a17b-channel-fp8-w8a8-pd-scalex40-3g-24x-sglang-0512) |
 | [hygon/Qwen3.5-397B-A17B-Channel-FP8](https://www.modelscope.cn/models/hygon/Qwen3.5-397B-A17B-Channel-FP8) | FP8 W8A8 | [0.5.10](../docker_images.md) | BW1100 |  4 | IFB  | [**`>_`**](#qwen35-397b-a17b-channel-fp8-ifb-bw1100-4x-sglang-0510)   |
 |                                                                                                            | FP8 W8A8 | 0.5.10 | BW1100 | 12 | 1P1D | [**`>_`**](#qwen35-397b-a17b-channel-fp8-1p1d-bw1100-12x-sglang-0510) |
 | [hygon/Qwen3.5-397B-A17B-W8A8](https://www.modelscope.cn/models/hygon/Qwen3.5-397B-A17B-W8A8)              | INT8 W8A8 | [0.5.10](../docker_images.md) | BW1000 |  8 | IFB  | [**`>_`**](#qwen35-397b-a17b-w8a8-ifb-bw1000-8x-sglang-0510)          |
@@ -827,6 +828,493 @@ sglang serve \
   --skip-server-warmup \
   --cuda-graph-max-bs 64 \
   --max-running-requests 64
+```
+
+### Qwen3.5-397B-A17B-Channel-FP8-w8a8 PD scaleX40-3G 24x SGLang 0.5.12
+
+#### P node 0
+
+```bash
+export HIP_VISIBLE_DEVICES=0,1,2,3
+export NCCL_MIN_NCHANNELS=32
+export RCCL_COLL_XHCL_CHANNEL_NUM=28
+export RCCL_P2P_XHCL_CHANNEL_NUM=29
+export NCCL_MIN_P2P_NCHANNELS=32
+export SGLANG_ENABLE_SPEC_V2=1
+export SGLANG_TORCH_PROFILER_DIR=/home/proj_qwen3.5-397b/profiling
+export HSA_ENABLE_COREDUMP=1
+export USE_DCU_CUSTOM_ALLREDUCE=1
+export ALLREDUCE_STREAM_WITH_COMPUTE=1
+export HIP_KERNEL_EVENT_SYSTENFENCE=1
+export SGL_CHUNKED_PREFIX_CACHE_THRESHOLD=0
+export GLIBC_TUNABLES=glibc.rtld.optional_static_tls=0x40000
+export HIP_KERNEL_BATCH_CEILING=100
+export GPU_FORCE_BLIT_COPY_SIZE=16
+export SGLANG_USE_LIGHTOP=1
+export SGLANG_USE_FP8_W8A8_MOE=1
+export SGLANG_USE_FUSED_TOPK_SOFTMAX=1
+export SGLANG_USE_CAUSAL_CONV1D=1
+export SGLANG_USE_FUSED_GEMMRMS_QUANT=0
+export SGLANG_USE_LAYER_NORM_FWD=1
+export SGLANG_KV_LAYOUT_DCU_FA=1
+export SGLANG_USE_AITER_LINEAR_ATTN=1
+export HSA_QUEUE_ON_DEVICE=1
+export GPU_MAX_HW_QUEUES=4
+export HSA_KERNARG_POOL_SIZE=8388608
+export ROC_AQL_QUEUE_SIZE=131072
+export GPU_FLUSH_ON_EXECUTION=false
+export SGLANG_USE_FUSED_RMS_ROTARY=0
+export SGLANG_HEALTH_CHECK_TIMEOUT=300
+export NCCL_SOCKET_IFNAME=em1
+export GLOO_SOCKET_IFNAME=em1
+export MC_IB_GID_INDEX=0
+export ROCSHMEM_IB_GID_INDEX=0
+export MC_ENABLE_DEST_DEVICE_AFFINITY=1
+sysctl -w kernel.numa_balancing=0
+export SGLANG_PP_LAYER_PARTITION="15,15,15,15"
+export ROCSHMEM_IPC_MNVL=1
+
+sglang serve \
+  --numa-node 0 5 3 2 \
+  --tp-size 2 \
+  --pp-size 4 \
+  --dp-size 1 \
+  --trust-remote-code \
+  --dtype bfloat16 \
+  --dist-init-addr <P_node0_ip>:<port0> \
+  --host <P_node0_ip> \
+  --port <port1> \
+  --nnodes 2 \
+  --node-rank 0 \
+  --attention-backend fa3 \
+  --page-size 64 \
+  --watchdog-timeout 36000 \
+  --kv-cache-dtype fp8_e4m3 \
+  --model-path hygon/Qwen3.5-397B-A17B-Channel-FP8-w8a8 \
+  --mamba-scheduler-strategy extra_buffer \
+  --mem-fraction-static 0.85 \
+  --chunked-prefill-size 8192 \
+  --skip-server-warmup \
+  --disable-cuda-graph \
+  --enable-cache-report \
+  --disaggregation-mode prefill \
+  --load-balance-method round_robin \
+  --disaggregation-ib-device shca_0,shca_1,shca_2,shca_4 \
+  --model-loader-extra-config '{"enable_multithread_load": "true", "num_threads": 32}'
+```
+
+#### P node 1
+
+```bash
+export HIP_VISIBLE_DEVICES=0,1,2,3
+export NCCL_MIN_NCHANNELS=32
+export RCCL_COLL_XHCL_CHANNEL_NUM=28
+export RCCL_P2P_XHCL_CHANNEL_NUM=29
+export NCCL_MIN_P2P_NCHANNELS=32
+export SGLANG_ENABLE_SPEC_V2=1
+export SGLANG_TORCH_PROFILER_DIR=/home/proj_qwen3.5-397b/profiling
+export HSA_ENABLE_COREDUMP=1
+export USE_DCU_CUSTOM_ALLREDUCE=1
+export ALLREDUCE_STREAM_WITH_COMPUTE=1
+export HIP_KERNEL_EVENT_SYSTENFENCE=1
+export SGL_CHUNKED_PREFIX_CACHE_THRESHOLD=0
+export GLIBC_TUNABLES=glibc.rtld.optional_static_tls=0x40000
+export HIP_KERNEL_BATCH_CEILING=100
+export GPU_FORCE_BLIT_COPY_SIZE=16
+export SGLANG_USE_LIGHTOP=1
+export SGLANG_USE_FP8_W8A8_MOE=1
+export SGLANG_USE_FUSED_TOPK_SOFTMAX=1
+export SGLANG_USE_CAUSAL_CONV1D=1
+export SGLANG_USE_FUSED_GEMMRMS_QUANT=0
+export SGLANG_USE_LAYER_NORM_FWD=1
+export SGLANG_KV_LAYOUT_DCU_FA=1
+export SGLANG_USE_AITER_LINEAR_ATTN=1
+export HSA_QUEUE_ON_DEVICE=1
+export GPU_MAX_HW_QUEUES=4
+export HSA_KERNARG_POOL_SIZE=8388608
+export ROC_AQL_QUEUE_SIZE=131072
+export GPU_FLUSH_ON_EXECUTION=false
+export SGLANG_USE_FUSED_RMS_ROTARY=0
+export SGLANG_HEALTH_CHECK_TIMEOUT=300
+export NCCL_SOCKET_IFNAME=em1
+export GLOO_SOCKET_IFNAME=em1
+export MC_IB_GID_INDEX=0
+export ROCSHMEM_IB_GID_INDEX=0
+export MC_ENABLE_DEST_DEVICE_AFFINITY=1
+sysctl -w kernel.numa_balancing=0
+export SGLANG_PP_LAYER_PARTITION="15,15,15,15"
+export ROCSHMEM_IPC_MNVL=1
+
+sglang serve \
+  --numa-node 0 5 3 2 \
+  --tp-size 2 \
+  --pp-size 4 \
+  --dp-size 1 \
+  --trust-remote-code \
+  --dtype bfloat16 \
+  --dist-init-addr <P_node0_ip>:<port0> \
+  --host <P_node1_ip> \
+  --port <port1> \
+  --nnodes 2 \
+  --node-rank 1 \
+  --attention-backend fa3 \
+  --page-size 64 \
+  --watchdog-timeout 36000 \
+  --kv-cache-dtype fp8_e4m3 \
+  --model-path hygon/Qwen3.5-397B-A17B-Channel-FP8-w8a8 \
+  --mamba-scheduler-strategy extra_buffer \
+  --mem-fraction-static 0.85 \
+  --chunked-prefill-size 8192 \
+  --skip-server-warmup \
+  --disable-cuda-graph \
+  --enable-cache-report \
+  --disaggregation-mode prefill \
+  --load-balance-method round_robin \
+  --disaggregation-ib-device shca_0,shca_1,shca_2,shca_4 \
+  --model-loader-extra-config '{"enable_multithread_load": "true", "num_threads": 32}'
+```
+
+#### D node 0
+
+```bash
+export NCCL_MIN_NCHANNELS=16
+export NCCL_MAX_NCHANNELS=16
+export SGLANG_ENABLE_SPEC_V2=1
+export SGLANG_TORCH_PROFILER_DIR=/home/proj_qwen3.5-397b/profiling
+export HSA_ENABLE_COREDUMP=1
+export USE_DCU_CUSTOM_ALLREDUCE=1
+export ALLREDUCE_STREAM_WITH_COMPUTE=1
+export HIP_KERNEL_EVENT_SYSTENFENCE=1
+export SGL_CHUNKED_PREFIX_CACHE_THRESHOLD=0
+export GLIBC_TUNABLES=glibc.rtld.optional_static_tls=0x40000
+export HIP_KERNEL_BATCH_CEILING=100
+export GPU_FORCE_BLIT_COPY_SIZE=16
+export HSA_KERNARG_POOL_SIZE=8388608
+export ROC_AQL_QUEUE_SIZE=131072
+export SGLANG_USE_LIGHTOP=1
+export SGLANG_USE_FP8_W8A8_MOE=1
+export SGLANG_USE_FUSED_TOPK_SOFTMAX=0
+export SGLANG_USE_CAUSAL_CONV1D=1
+export SGLANG_USE_FUSED_GEMMRMS_QUANT=0
+export SGLANG_USE_FUSED_RMS_ROTARY=0
+export SGLANG_USE_LAYER_NORM_FWD=1
+export SGLANG_KV_LAYOUT_DCU_FA=1
+export SGLANG_USE_AITER_LINEAR_ATTN=1
+export SGLANG_USE_DEEPGEMM_MOE=1
+export SGLANG_ENABLE_DP_ATTENTION_LOCAL_CONTROL_BROADCAST=1
+sysctl -w kernel.numa_balancing=0
+export MC_IB_GID_INDEX=0
+export MC_ENABLE_DEST_DEVICE_AFFINITY=1
+export SGLANG_NCCL_ALL_GATHER_IN_OVERLAP_SCHEDULER_SYNC_BATCH=1
+export HIP_GRAPH_ACCUMULATE_DISPATCH=1
+export HIP_GRAPH_USE_CMD_CACHE=0
+export ROCSHMEM_GDA_NUM_QPS_DEFAULT_CTX=512
+export ROCSHMEM_HEAP_SIZE=3173741824
+export SGLANG_DEEPEP_NUM_MAX_DISPATCH_TOKENS_PER_RANK=64
+export DEEP_EP_DEVICE_TO_HCA_MAPPing=shca_0,shca_1,shca_2,shca_4
+export DEEPEP_ENABLE_LL_LAYERED_OPT=0
+export ROCSHMEM_IB_GID_INDEX=0
+export SGLANG_HEALTH_CHECK_TIMEOUT=300
+export ROCSHMEM_IPC_MNVL=1
+
+sglang serve \
+  --numa-node 0 5 3 2 \
+  --tp-size 16 \
+  --pp-size 1 \
+  --dp-size 16 \
+  --ep-size 16 \
+  --trust-remote-code \
+  --dtype bfloat16 \
+  --dist-init-addr <D_node0_ip>:<port0> \
+  --host <D_node0_ip> \
+  --port <port1> \
+  --nnodes 4 \
+  --node-rank 0 \
+  --attention-backend fa3 \
+  --page-size 64 \
+  --watchdog-timeout 36000 \
+  --kv-cache-dtype fp8_e4m3 \
+  --speculative-algorithm EAGLE \
+  --speculative-num-steps 3 \
+  --speculative-eagle-topk 1 \
+  --speculative-num-draft-tokens 4 \
+  --model-path hygon/Qwen3.5-397B-A17B-Channel-FP8-w8a8 \
+  --mamba-scheduler-strategy extra_buffer \
+  --mem-fraction-static 0.7 \
+  --skip-server-warmup \
+  --enable-cache-report \
+  --chunked-prefill-size 8192 \
+  --moe-dense-tp-size 1 \
+  --enable-dp-lm-head \
+  --enable-dp-attention \
+  --cuda-graph-max-bs 16 \
+  --max-running-requests 256 \
+  --moe-a2a-backend deepep \
+  --deepep-mode low_latency \
+  --disaggregation-mode decode \
+  --prefill-round-robin-balance \
+  --disaggregation-ib-device shca_0,shca_1,shca_2,shca_4 \
+  --model-loader-extra-config '{"enable_multithread_load": "true", "num_threads": 32}'
+```
+
+#### D node 1
+
+```bash
+export NCCL_MIN_NCHANNELS=16
+export NCCL_MAX_NCHANNELS=16
+export SGLANG_ENABLE_SPEC_V2=1
+export SGLANG_TORCH_PROFILER_DIR=/home/proj_qwen3.5-397b/profiling
+export HSA_ENABLE_COREDUMP=1
+export USE_DCU_CUSTOM_ALLREDUCE=1
+export ALLREDUCE_STREAM_WITH_COMPUTE=1
+export HIP_KERNEL_EVENT_SYSTENFENCE=1
+export SGL_CHUNKED_PREFIX_CACHE_THRESHOLD=0
+export GLIBC_TUNABLES=glibc.rtld.optional_static_tls=0x40000
+export HIP_KERNEL_BATCH_CEILING=100
+export GPU_FORCE_BLIT_COPY_SIZE=16
+export HSA_KERNARG_POOL_SIZE=8388608
+export ROC_AQL_QUEUE_SIZE=131072
+export SGLANG_USE_LIGHTOP=1
+export SGLANG_USE_FP8_W8A8_MOE=1
+export SGLANG_USE_FUSED_TOPK_SOFTMAX=0
+export SGLANG_USE_CAUSAL_CONV1D=1
+export SGLANG_USE_FUSED_GEMMRMS_QUANT=0
+export SGLANG_USE_FUSED_RMS_ROTARY=0
+export SGLANG_USE_LAYER_NORM_FWD=1
+export SGLANG_KV_LAYOUT_DCU_FA=1
+export SGLANG_USE_AITER_LINEAR_ATTN=1
+export SGLANG_USE_DEEPGEMM_MOE=1
+export SGLANG_ENABLE_DP_ATTENTION_LOCAL_CONTROL_BROADCAST=1
+sysctl -w kernel.numa_balancing=0
+export MC_IB_GID_INDEX=0
+export MC_ENABLE_DEST_DEVICE_AFFINITY=1
+export SGLANG_NCCL_ALL_GATHER_IN_OVERLAP_SCHEDULER_SYNC_BATCH=1
+export HIP_GRAPH_ACCUMULATE_DISPATCH=1
+export HIP_GRAPH_USE_CMD_CACHE=0
+export ROCSHMEM_GDA_NUM_QPS_DEFAULT_CTX=512
+export ROCSHMEM_HEAP_SIZE=3173741824
+export SGLANG_DEEPEP_NUM_MAX_DISPATCH_TOKENS_PER_RANK=64
+export DEEP_EP_DEVICE_TO_HCA_MAPPing=shca_0,shca_1,shca_2,shca_4
+export DEEPEP_ENABLE_LL_LAYERED_OPT=0
+export ROCSHMEM_IB_GID_INDEX=0
+export SGLANG_HEALTH_CHECK_TIMEOUT=300
+export ROCSHMEM_IPC_MNVL=1
+
+sglang serve \
+  --numa-node 0 5 3 2 \
+  --tp-size 16 \
+  --pp-size 1 \
+  --dp-size 16 \
+  --ep-size 16 \
+  --trust-remote-code \
+  --dtype bfloat16 \
+  --dist-init-addr <D_node0_ip>:<port0> \
+  --host <D_node1_ip> \
+  --port <port1> \
+  --nnodes 4 \
+  --node-rank 1 \
+  --attention-backend fa3 \
+  --page-size 64 \
+  --watchdog-timeout 36000 \
+  --kv-cache-dtype fp8_e4m3 \
+  --speculative-algorithm EAGLE \
+  --speculative-num-steps 3 \
+  --speculative-eagle-topk 1 \
+  --speculative-num-draft-tokens 4 \
+  --model-path hygon/Qwen3.5-397B-A17B-Channel-FP8-w8a8 \
+  --mamba-scheduler-strategy extra_buffer \
+  --mem-fraction-static 0.7 \
+  --skip-server-warmup \
+  --enable-cache-report \
+  --chunked-prefill-size 8192 \
+  --moe-dense-tp-size 1 \
+  --enable-dp-lm-head \
+  --enable-dp-attention \
+  --cuda-graph-max-bs 16 \
+  --max-running-requests 256 \
+  --moe-a2a-backend deepep \
+  --deepep-mode low_latency \
+  --disaggregation-mode decode \
+  --prefill-round-robin-balance \
+  --disaggregation-ib-device shca_0,shca_1,shca_2,shca_4 \
+  --model-loader-extra-config '{"enable_multithread_load": "true", "num_threads": 32}'
+```
+
+#### D node 2
+
+```bash
+export NCCL_MIN_NCHANNELS=16
+export NCCL_MAX_NCHANNELS=16
+export SGLANG_ENABLE_SPEC_V2=1
+export SGLANG_TORCH_PROFILER_DIR=/home/proj_qwen3.5-397b/profiling
+export HSA_ENABLE_COREDUMP=1
+export USE_DCU_CUSTOM_ALLREDUCE=1
+export ALLREDUCE_STREAM_WITH_COMPUTE=1
+export HIP_KERNEL_EVENT_SYSTENFENCE=1
+export SGL_CHUNKED_PREFIX_CACHE_THRESHOLD=0
+export GLIBC_TUNABLES=glibc.rtld.optional_static_tls=0x40000
+export HIP_KERNEL_BATCH_CEILING=100
+export GPU_FORCE_BLIT_COPY_SIZE=16
+export HSA_KERNARG_POOL_SIZE=8388608
+export ROC_AQL_QUEUE_SIZE=131072
+export SGLANG_USE_LIGHTOP=1
+export SGLANG_USE_FP8_W8A8_MOE=1
+export SGLANG_USE_FUSED_TOPK_SOFTMAX=0
+export SGLANG_USE_CAUSAL_CONV1D=1
+export SGLANG_USE_FUSED_GEMMRMS_QUANT=0
+export SGLANG_USE_FUSED_RMS_ROTARY=0
+export SGLANG_USE_LAYER_NORM_FWD=1
+export SGLANG_KV_LAYOUT_DCU_FA=1
+export SGLANG_USE_AITER_LINEAR_ATTN=1
+export SGLANG_USE_DEEPGEMM_MOE=1
+export SGLANG_ENABLE_DP_ATTENTION_LOCAL_CONTROL_BROADCAST=1
+sysctl -w kernel.numa_balancing=0
+export MC_IB_GID_INDEX=0
+export MC_ENABLE_DEST_DEVICE_AFFINITY=1
+export SGLANG_NCCL_ALL_GATHER_IN_OVERLAP_SCHEDULER_SYNC_BATCH=1
+export HIP_GRAPH_ACCUMULATE_DISPATCH=1
+export HIP_GRAPH_USE_CMD_CACHE=0
+export ROCSHMEM_GDA_NUM_QPS_DEFAULT_CTX=512
+export ROCSHMEM_HEAP_SIZE=3173741824
+export SGLANG_DEEPEP_NUM_MAX_DISPATCH_TOKENS_PER_RANK=64
+export DEEP_EP_DEVICE_TO_HCA_MAPPing=shca_0,shca_1,shca_2,shca_4
+export DEEPEP_ENABLE_LL_LAYERED_OPT=0
+export ROCSHMEM_IB_GID_INDEX=0
+export SGLANG_HEALTH_CHECK_TIMEOUT=300
+export ROCSHMEM_IPC_MNVL=1
+
+sglang serve \
+  --numa-node 0 5 3 2 \
+  --tp-size 16 \
+  --pp-size 1 \
+  --dp-size 16 \
+  --ep-size 16 \
+  --trust-remote-code \
+  --dtype bfloat16 \
+  --dist-init-addr <D_node0_ip>:<port0> \
+  --host <D_node2_ip> \
+  --port <port1> \
+  --nnodes 4 \
+  --node-rank 2 \
+  --attention-backend fa3 \
+  --page-size 64 \
+  --watchdog-timeout 36000 \
+  --kv-cache-dtype fp8_e4m3 \
+  --speculative-algorithm EAGLE \
+  --speculative-num-steps 3 \
+  --speculative-eagle-topk 1 \
+  --speculative-num-draft-tokens 4 \
+  --model-path hygon/Qwen3.5-397B-A17B-Channel-FP8-w8a8 \
+  --mamba-scheduler-strategy extra_buffer \
+  --mem-fraction-static 0.7 \
+  --skip-server-warmup \
+  --enable-cache-report \
+  --chunked-prefill-size 8192 \
+  --moe-dense-tp-size 1 \
+  --enable-dp-lm-head \
+  --enable-dp-attention \
+  --cuda-graph-max-bs 16 \
+  --max-running-requests 256 \
+  --moe-a2a-backend deepep \
+  --deepep-mode low_latency \
+  --disaggregation-mode decode \
+  --prefill-round-robin-balance \
+  --disaggregation-ib-device shca_0,shca_1,shca_2,shca_4 \
+  --model-loader-extra-config '{"enable_multithread_load": "true", "num_threads": 32}'
+```
+
+#### D node 3
+
+```bash
+export NCCL_MIN_NCHANNELS=16
+export NCCL_MAX_NCHANNELS=16
+export SGLANG_ENABLE_SPEC_V2=1
+export SGLANG_TORCH_PROFILER_DIR=/home/proj_qwen3.5-397b/profiling
+export HSA_ENABLE_COREDUMP=1
+export USE_DCU_CUSTOM_ALLREDUCE=1
+export ALLREDUCE_STREAM_WITH_COMPUTE=1
+export HIP_KERNEL_EVENT_SYSTENFENCE=1
+export SGL_CHUNKED_PREFIX_CACHE_THRESHOLD=0
+export GLIBC_TUNABLES=glibc.rtld.optional_static_tls=0x40000
+export HIP_KERNEL_BATCH_CEILING=100
+export GPU_FORCE_BLIT_COPY_SIZE=16
+export HSA_KERNARG_POOL_SIZE=8388608
+export ROC_AQL_QUEUE_SIZE=131072
+export SGLANG_USE_LIGHTOP=1
+export SGLANG_USE_FP8_W8A8_MOE=1
+export SGLANG_USE_FUSED_TOPK_SOFTMAX=0
+export SGLANG_USE_CAUSAL_CONV1D=1
+export SGLANG_USE_FUSED_GEMMRMS_QUANT=0
+export SGLANG_USE_FUSED_RMS_ROTARY=0
+export SGLANG_USE_LAYER_NORM_FWD=1
+export SGLANG_KV_LAYOUT_DCU_FA=1
+export SGLANG_USE_AITER_LINEAR_ATTN=1
+export SGLANG_USE_DEEPGEMM_MOE=1
+export SGLANG_ENABLE_DP_ATTENTION_LOCAL_CONTROL_BROADCAST=1
+sysctl -w kernel.numa_balancing=0
+export MC_IB_GID_INDEX=0
+export MC_ENABLE_DEST_DEVICE_AFFINITY=1
+export SGLANG_NCCL_ALL_GATHER_IN_OVERLAP_SCHEDULER_SYNC_BATCH=1
+export HIP_GRAPH_ACCUMULATE_DISPATCH=1
+export HIP_GRAPH_USE_CMD_CACHE=0
+export ROCSHMEM_GDA_NUM_QPS_DEFAULT_CTX=512
+export ROCSHMEM_HEAP_SIZE=3173741824
+export SGLANG_DEEPEP_NUM_MAX_DISPATCH_TOKENS_PER_RANK=64
+export DEEP_EP_DEVICE_TO_HCA_MAPPing=shca_0,shca_1,shca_2,shca_4
+export DEEPEP_ENABLE_LL_LAYERED_OPT=0
+export ROCSHMEM_IB_GID_INDEX=0
+export SGLANG_HEALTH_CHECK_TIMEOUT=300
+export ROCSHMEM_IPC_MNVL=1
+
+sglang serve \
+  --numa-node 0 5 3 2 \
+  --tp-size 16 \
+  --pp-size 1 \
+  --dp-size 16 \
+  --ep-size 16 \
+  --trust-remote-code \
+  --dtype bfloat16 \
+  --dist-init-addr <D_node0_ip>:<port0> \
+  --host <D_node3_ip> \
+  --port <port1> \
+  --nnodes 4 \
+  --node-rank 3 \
+  --attention-backend fa3 \
+  --page-size 64 \
+  --watchdog-timeout 36000 \
+  --kv-cache-dtype fp8_e4m3 \
+  --speculative-algorithm EAGLE \
+  --speculative-num-steps 3 \
+  --speculative-eagle-topk 1 \
+  --speculative-num-draft-tokens 4 \
+  --model-path hygon/Qwen3.5-397B-A17B-Channel-FP8-w8a8 \
+  --mamba-scheduler-strategy extra_buffer \
+  --mem-fraction-static 0.7 \
+  --skip-server-warmup \
+  --enable-cache-report \
+  --chunked-prefill-size 8192 \
+  --moe-dense-tp-size 1 \
+  --enable-dp-lm-head \
+  --enable-dp-attention \
+  --cuda-graph-max-bs 16 \
+  --max-running-requests 256 \
+  --moe-a2a-backend deepep \
+  --deepep-mode low_latency \
+  --disaggregation-mode decode \
+  --prefill-round-robin-balance \
+  --disaggregation-ib-device shca_0,shca_1,shca_2,shca_4 \
+  --model-loader-extra-config '{"enable_multithread_load": "true", "num_threads": 32}'
+```
+
+#### Router
+
+```bash
+python3 -m sglang_router.launch_router \
+  --pd-disaggregation \
+  --prefill http://172.20.2.156:30005 \
+  --decode http://172.20.2.152:30005 \
+  --policy cache_aware \
+  --port 40001
 ```
 
 ### Qwen3.5-397B-A17B-Channel-FP8 IFB BW1100 4x SGLang 0.5.10


### PR DESCRIPTION
## Summary
- add the Qwen3.5-397B-A17B Channel FP8 W8A8 scaleX40-3G deployment entry for SGLang 0.5.12
- document complete per-node commands for 2 Prefill nodes and 4 Decode nodes
- add the SGLang PD Router command

## Verification
- git diff --check -- docs/model-deployment/sglang/qwen3.5.md
- verified 2 Prefill and 4 Decode node blocks with matching node ranks