### PR TITLE
docs(sglang): update ScaleX40 deployment guides

### DIFF
--- a/docs/model-deployment/sglang/deepseek-v4.md
+++ b/docs/model-deployment/sglang/deepseek-v4.md
@@ -13,7 +13,7 @@ DeepSeek-V4 是 DeepSeek 系列的混合专家模型。本页汇总 DeepSeek-V4 
 | [hygon/DeepSeek-V4-Flash-Channel-FP8-w8a8](https://www.modelscope.cn/models/hygon/DeepSeek-V4-Flash-Channel-FP8-w8a8) | FP8 W8A8 | 0.5.12 | BW1100 | 8 | IFB(CP8EP8) | [**`>_`**](#deepseek-v4-flash-channel-fp8-w8a8-ifb-bw1100-8x-sglang-0512) |
 |  | FP8 W8A8 | 0.5.12 | BW1100 | 8 | IFB(DP8EP8) | [**`>_`**](#deepseek-v4-flash-channel-fp8-w8a8-ifb-bw1100-8x-sglang-0512) |
 |  | FP8 W8A8 | 0.5.12 | BW1100 | 16 | 1P1D | [**`>_`**](#deepseek-v4-flash-channel-fp8-w8a8-1p1d-bw1100-16x-sglang-0512) |
-|  | FP8 W8A8 | 0.5.12 | ScaleX40 | 16 | PD | [**`>_`**](#deepseek-v4-flash-channel-fp8-w8a8-pd-scalex40-16x-sglang-0512) |
+|  | FP8 W8A8 | 0.5.12 | scaleX40-3G | 16 | PD | [**`>_`**](#deepseek-v4-flash-channel-fp8-w8a8-pd-scalex40-3g-16x-sglang-0512) |
 | [hygon/DeepSeek-V4-Pro-Channel-FP8-w8a8](https://www.modelscope.cn/models/hygon/DeepSeek-V4-Pro-Channel-FP8-w8a8) | FP8 W8A8 | 0.5.12 | BW1100 | 16 | IFB(CP8EP8PP2) | [**`>_`**](#deepseek-v4-pro-channel-fp8-w8a8-ifb-p-bw1100-16x-sglang-0512) |
 |  | FP8 W8A8 | 0.5.12 | BW1100 | 16 | IFB(EP16DP16) | [**`>_`**](#deepseek-v4-pro-channel-fp8-w8a8-ifb-d-bw1100-16x-sglang-0512) |
 |  | FP8 W8A8 | 0.5.12 | BW1100 | 32 | PD | [**`>_`**](#deepseek-v4-pro-channel-fp8-w8a8-pd-bw1100-32x-sglang-0512) |
@@ -523,7 +523,7 @@ python3 -m sglang_router.launch_router \
   --port <router_port>
 ```
 
-### DeepSeek-V4-Flash-Channel-FP8-w8a8 PD ScaleX40 16x SGLang 0.5.12
+### DeepSeek-V4-Flash-Channel-FP8-w8a8 PD scaleX40-3G 16x SGLang 0.5.12
 
 #### P node 0
 

--- a/docs/model-deployment/sglang/glm-5.2.md
+++ b/docs/model-deployment/sglang/glm-5.2.md
@@ -7,8 +7,8 @@
 | [hygon/GLM-5.2-Channel-INT8-w8a8](https://www.modelscope.cn/models/hygon/GLM-5.2-Channel-INT8-w8a8) | INT8 W8A8 | [0.5.12](../docker_images.md) | BW1100 | 8 | IFB | [**`>_`**](#glm-52-channel-int8-w8a8-ifb-bw1100-8x-sglang-0512) |
 |                                                                                                 | INT8 W8A8 | [0.5.12](../docker_images.md) | BW1000 | 16 | IFB | [**`>_`**](#glm-52-channel-int8-w8a8-ifb-bw1000-16x-sglang-0512) |
 | [hygon/GLM-5.2-Channel-FP8-w8a8](https://www.modelscope.cn/models/hygon/GLM-5.2-Channel-FP8-w8a8) | FP8 W8A8 | [0.5.12](../docker_images.md) | BW1100 | 8 | IFB(tp8) | [**`>_`**](#glm-52-channel-fp8-w8a8-ifb-bw1100-8x-sglang-0512-tp8) |
-|                                                                                                 | FP8 W8A8 | [0.5.12](../docker_images.md) | BW1100 | 8 | IFB(tp8ep8) | [**`>_`**](#glm-52-channel-fp8-w8a8-ifb-bw1100-8x-sglang-0512-tp8ep8) |
-|                                                                                                 | FP8 W8A8 | [0.5.12](../docker_images.md) | ScaleX40 | 24 | PD | [**`>_`**](#glm-52-channel-fp8-w8a8-pd-scalex40-24x-sglang-0512) |
+|  | FP8 W8A8 | [0.5.12](../docker_images.md) | BW1100 | 8 | IFB(tp8ep8) | [**`>_`**](#glm-52-channel-fp8-w8a8-ifb-bw1100-8x-sglang-0512-tp8ep8) |
+|  | FP8 W8A8 | [0.5.12](../docker_images.md) | scaleX40-3G | 24 | PD | [**`>_`**](#glm-52-channel-fp8-w8a8-pd-scalex40-3g-24x-sglang-0512) |
 | [hygon/GLM-5.2-Channel-INT4-w4a8](https://www.modelscope.cn/models/hygon/GLM-5.2-Channel-INT4-w4a8) | INT4 W4A8 | [0.5.12](../docker_images.md) | BW1100 | 4 | IFB | [**`>_`**](#glm-52-channel-int4-w4a8-ifb-bw1100-4x-sglang-0512) |
 |                                                                                                 | INT4 W4A8 | [0.5.12](../docker_images.md) | BW1000 | 8 | IFB | [**`>_`**](#glm-52-channel-int4-w4a8-ifb-bw1000-8x-sglang-0512) |
 
@@ -303,7 +303,7 @@ sglang serve \
   --deepep-mode auto
 ~~~
 
-### GLM-5.2-Channel-FP8-w8a8 PD ScaleX40 24x SGLang 0.5.12
+### GLM-5.2-Channel-FP8-w8a8 PD scaleX40-3G 24x SGLang 0.5.12
 #### DeepEP 配置
 
 以下 `ep_config.json` 仅作为参考配置。使用时请将其保存为 `ep_config.json`

--- a/docs/model-deployment/sglang/kimi-k2.6.md
+++ b/docs/model-deployment/sglang/kimi-k2.6.md
@@ -417,10 +417,10 @@ python3 -m sglang.launch_server \
 ```
 python3 -m sglang_router.launch_router \
   --pd-disaggregation \
-  --prefill http://<P_node_ip>:30000 \
-  --decode http://<D_node_ip>:30000 \
+  --prefill http://<P_node_ip>:<port1> \
+  --decode http://<D_node_ip>:<port1>\
   --policy round_robin \
-  --port 30020
+  --port 30001
 ```
 
 ### Kimi-K2.6 IFB BW1100 8x SGLang 0.5.12

--- a/docs/model-deployment/sglang/kimi-k2.6.md
+++ b/docs/model-deployment/sglang/kimi-k2.6.md
@@ -8,13 +8,420 @@ Kimi K2.6 是一个开源的原生多模态智能体模型，在长周期编码�
 
 | 模型权重 | 量化方式 | SGLang 镜像 | 推荐硬件 | 卡数 | 部署方式 | 启动命令 |
 | -------- | -------- | ----------- | -------- | ---- | -------- | -------- |
-| [moonshotai/Kimi-K2.6](https://www.modelscope.cn/models/moonshotai/Kimi-K2.6) | INT4 W4A16 | [0.5.12](../docker_images.md) | BW1100 | 8 | IFB | [**`>_`**](#kimi-k26-ifb-bw1100-8x-sglang-0512) |
+| [moonshotai/Kimi-K2.6](https://www.modelscope.cn/models/moonshotai/Kimi-K2.6) | INT4 W4A16 | [0.5.12](../docker_images.md) | scaleX40-3G | 24 | 1P1D | [**`>_`**](#kimi-k26-1p1d-scalex40-3g-24x-sglang-0512) |
+|  | INT4 W4A16 | [0.5.12](../docker_images.md) | BW1100 | 8 | IFB | [**`>_`**](#kimi-k26-ifb-bw1100-8x-sglang-0512) |
 |  | INT4 W4A16 | [0.5.12](../docker_images.md) | BW1000 | 16 | IFB | [**`>_`**](#kimi-k26-ifb-bw1000-16x-sglang-0512) |
 |  | INT4 W4A16 | 0.5.10 | BW1100 | 8 | IFB | [**`>_`**](#kimi-k26-ifb-bw1100-8x-sglang-0510) |
 |  | INT4 W4A16 | 0.5.10 | BW1100 | 16 | 1P1D | [**`>_`**](#kimi-k26-1p1d-bw1100-16x-sglang-0510) |
-|  | INT4 W4A16 | 0.5.12 | ScaleX40 | 24 | 1P1D | [**`>_`**](#kimi-k26-1p1d-bw1100-超节点ep16-24x-sglang-0512) |
 
 ## 启动命令
+
+### Kimi-K2.6 1P1D scaleX40-3G 24x SGLang 0.5.12
+
+#### EPLB 配置参考：[EPLB](../../optimization/static-eplb-sglang.md)。
+
+#### P node0
+
+```
+export SGLANG_USE_LIGHTOP=1
+export SGLANG_USE_OPT_CAT=1
+export USE_DCU_CUSTOM_ALLREDUCE=1
+export SGL_CHUNKED_PREFIX_CACHE_THRESHOLD=0
+export SGLANG_DISAGGREGATION_BOOTSTRAP_TIMEOUT=1200
+export GLIBC_TUNABLES=glibc.rtld.optional_static_tls=0x40000
+export HIP_GRAPH_ACCUMULATE_DISPATCH=0
+export SGLANG_KVALLOC_KERNEL=1
+export SGLANG_CREATE_EXTEND_AFTER_DECODE_SPEC_INFO=1
+export SGLANG_ASSIGN_EXTEND_CACHE_LOCS=1
+export SGLANG_ASSIGN_REQ_TO_TOKEN_POOL=1
+export SGLANG_GET_LAST_LOC=1
+export SGLANG_CREATE_FLASHMLA_KV_INDICES_TRITON=1
+export SGLANG_CREATE_CHUNKED_PREFIX_CACHE_KV_INDICES=1
+export SGLANG_USE_MARLIN_W4A16_MOE=1
+export ALLREDUCE_STREAM_WITH_COMPUTE=1
+export MC_IB_GID_INDEX=0
+export SGLANG_HEALTH_CHECK_TIMEOUT=60
+export SGLANG_ROCM_USE_AITER_MOE=1
+export DEEP_EP_NORMAL_MNVL=1
+export HIP_BUFFER_EXTRA_SIZE=0
+export ROCSHMEM_GDR_DISABLE_XDP=1
+export PYTHONUNBUFFERED=1
+export AITER_ENABLE_SUPERNODE_AR=1 AITER_REBUILD=1
+export AITER_AR_TRANSPORT=fabric AITER_AR_ENABLE_REG_CAPTURE=0
+export SGLANG_OPT_USE_CUSTOM_ALL_REDUCE_V2=0
+
+sglang serve \
+  --model-path moonshotai/Kimi-K2.6 \
+  --kv-cache-dtype fp8_e4m3 \
+  --host <P_node0_ip> \
+  --port <port1> \
+  --trust-remote-code \
+  --page-size 64 \
+  --dist-init-addr <P_node0_ip>:<port0> \
+  --nnodes 2 \
+  --node-rank 0 \
+  --dtype bfloat16 \
+  --tp-size 4 \
+  --pp-size 2 \
+  --mem-fraction-static 0.9 \
+  --attention-backend hcu_mla \
+  --numa-node 0 5 3 2 \
+  --chunked-prefill-size -1 \
+  --max-running-requests 512 \
+  --context-length 81920 \
+  --disaggregation-ib-device shca_0,shca_1,shca_2,shca_4 \
+  --disaggregation-mode prefill \
+  --custom-all-reduce-backend aiter
+```
+
+#### P node1
+
+```
+export SGLANG_USE_LIGHTOP=1
+export SGLANG_USE_OPT_CAT=1
+export USE_DCU_CUSTOM_ALLREDUCE=1
+export SGL_CHUNKED_PREFIX_CACHE_THRESHOLD=0
+export SGLANG_DISAGGREGATION_BOOTSTRAP_TIMEOUT=1200
+export GLIBC_TUNABLES=glibc.rtld.optional_static_tls=0x40000
+export HIP_GRAPH_ACCUMULATE_DISPATCH=0
+export SGLANG_KVALLOC_KERNEL=1
+export SGLANG_CREATE_EXTEND_AFTER_DECODE_SPEC_INFO=1
+export SGLANG_ASSIGN_EXTEND_CACHE_LOCS=1
+export SGLANG_ASSIGN_REQ_TO_TOKEN_POOL=1
+export SGLANG_GET_LAST_LOC=1
+export SGLANG_CREATE_FLASHMLA_KV_INDICES_TRITON=1
+export SGLANG_CREATE_CHUNKED_PREFIX_CACHE_KV_INDICES=1
+export SGLANG_USE_MARLIN_W4A16_MOE=1
+export ALLREDUCE_STREAM_WITH_COMPUTE=1
+export MC_IB_GID_INDEX=0
+export SGLANG_HEALTH_CHECK_TIMEOUT=60
+export SGLANG_ROCM_USE_AITER_MOE=1
+export DEEP_EP_NORMAL_MNVL=1
+export HIP_BUFFER_EXTRA_SIZE=0
+export ROCSHMEM_GDR_DISABLE_XDP=1
+export PYTHONUNBUFFERED=1
+export AITER_ENABLE_SUPERNODE_AR=1 AITER_REBUILD=1
+export AITER_AR_TRANSPORT=fabric AITER_AR_ENABLE_REG_CAPTURE=0
+export SGLANG_OPT_USE_CUSTOM_ALL_REDUCE_V2=0
+
+sglang serve \
+  --model-path moonshotai/Kimi-K2.6 \
+  --kv-cache-dtype fp8_e4m3 \
+  --host <P_node1_ip> \
+  --port <port1> \
+  --trust-remote-code \
+  --page-size 64 \
+  --dist-init-addr <P_node0_ip>:<port0> \
+  --nnodes 2 \
+  --node-rank 1 \
+  --dtype bfloat16 \
+  --tp-size 4 \
+  --pp-size 2 \
+  --mem-fraction-static 0.9 \
+  --attention-backend hcu_mla \
+  --numa-node 0 5 3 2 \
+  --chunked-prefill-size -1 \
+  --max-running-requests 512 \
+  --context-length 81920 \
+  --disaggregation-ib-device shca_0,shca_1,shca_2,shca_4 \
+  --disaggregation-mode prefill \
+  --custom-all-reduce-backend aiter
+```
+
+
+#### D node0
+
+```
+export SGLANG_USE_LIGHTOP=1
+export SGLANG_USE_OPT_CAT=1
+export USE_DCU_CUSTOM_ALLREDUCE=1
+export SGL_CHUNKED_PREFIX_CACHE_THRESHOLD=0
+export SGLANG_DISAGGREGATION_BOOTSTRAP_TIMEOUT=1200
+export GLIBC_TUNABLES=glibc.rtld.optional_static_tls=0x40000
+export HIP_GRAPH_ACCUMULATE_DISPATCH=0
+export SGLANG_KVALLOC_KERNEL=1
+export SGLANG_CREATE_EXTEND_AFTER_DECODE_SPEC_INFO=1
+export SGLANG_ASSIGN_EXTEND_CACHE_LOCS=1
+export SGLANG_ASSIGN_REQ_TO_TOKEN_POOL=1
+export SGLANG_GET_LAST_LOC=1
+export SGLANG_CREATE_FLASHMLA_KV_INDICES_TRITON=1
+export SGLANG_CREATE_CHUNKED_PREFIX_CACHE_KV_INDICES=1
+export SGLANG_USE_MARLIN_W4A16_MOE=1
+export ALLREDUCE_STREAM_WITH_COMPUTE=1
+export MC_IB_GID_INDEX=0
+export SGLANG_HEALTH_CHECK_TIMEOUT=60
+export SGLANG_ROCM_USE_AITER_MOE=1
+export SGLANG_USE_MARLIN_W4A16_MOE_OPT=1
+export ROCSHMEM_IB_GID_INDEX=0
+export ROCSHMEM_DISABLE_HDP_FLUSH=1
+export ROCSHMEM_GDA_NUM_QPS_DEFAULT_CTX=288
+export ROCSHMEM_HEAP_SIZE=6442450944
+export SGLANG_DEEPEP_NUM_MAX_DISPATCH_TOKENS_PER_RANK=256
+export ROCSHMEM_IPC_MNVL=1
+export DEEP_EP_NORMAL_MNVL=1
+export HIP_BUFFER_EXTRA_SIZE=0
+export ROCSHMEM_GDR_DISABLE_XDP=1
+export PYTHONUNBUFFERED=1
+
+python3 -m sglang.launch_server \
+  --model-path moonshotai/Kimi-K2.6 \
+  --kv-cache-dtype fp8_e4m3 \
+  --host <D_node0_ip> \
+  --port <port1> \
+  --trust-remote-code \
+  --page-size 64 \
+  --dist-init-addr <D_node0_ip>:<port0> \
+  --nnodes 4 \
+  --node-rank 0 \
+  --dtype bfloat16 \
+  --tp-size 16 \
+  --pp-size 1 \
+  --mem-fraction-static 0.85 \
+  --attention-backend hcu_mla \
+  --numa-node 0 5 3 2 \
+  --chunked-prefill-size -1 \
+  --max-running-requests 512 \
+  --context-length 81920 \
+  --disaggregation-ib-device shca_0,shca_1,shca_2,shca_4 \
+  --disaggregation-mode decode \
+  --ep-size 16 \
+  --dp-size 16 \
+  --enable-dp-attention \
+  --moe-dense-tp-size 1 \
+  --enable-dp-lm-head \
+  --moe-a2a-backend deepep \
+  --deepep-mode low_latency \
+  --speculative-algorithm EAGLE3 \
+  --speculative-draft-model-path lightseekorg/kimi-k2.6-eagle3-mla \
+  --speculative-num-steps 3 \
+  --speculative-eagle-topk 1 \
+  --speculative-num-draft-tokens 4 \
+  --init-expert-location <path_to_eplb_trace_pt> \
+  --ep-num-redundant-experts 16
+```
+
+#### D node1
+
+```
+export SGLANG_USE_LIGHTOP=1
+export SGLANG_USE_OPT_CAT=1
+export USE_DCU_CUSTOM_ALLREDUCE=1
+export SGL_CHUNKED_PREFIX_CACHE_THRESHOLD=0
+export SGLANG_DISAGGREGATION_BOOTSTRAP_TIMEOUT=1200
+export GLIBC_TUNABLES=glibc.rtld.optional_static_tls=0x40000
+export HIP_GRAPH_ACCUMULATE_DISPATCH=0
+export SGLANG_KVALLOC_KERNEL=1
+export SGLANG_CREATE_EXTEND_AFTER_DECODE_SPEC_INFO=1
+export SGLANG_ASSIGN_EXTEND_CACHE_LOCS=1
+export SGLANG_ASSIGN_REQ_TO_TOKEN_POOL=1
+export SGLANG_GET_LAST_LOC=1
+export SGLANG_CREATE_FLASHMLA_KV_INDICES_TRITON=1
+export SGLANG_CREATE_CHUNKED_PREFIX_CACHE_KV_INDICES=1
+export SGLANG_USE_MARLIN_W4A16_MOE=1
+export ALLREDUCE_STREAM_WITH_COMPUTE=1
+export MC_IB_GID_INDEX=0
+export SGLANG_HEALTH_CHECK_TIMEOUT=60
+export SGLANG_ROCM_USE_AITER_MOE=1
+export SGLANG_USE_MARLIN_W4A16_MOE_OPT=1
+export ROCSHMEM_IB_GID_INDEX=0
+export ROCSHMEM_DISABLE_HDP_FLUSH=1
+export ROCSHMEM_GDA_NUM_QPS_DEFAULT_CTX=288
+export ROCSHMEM_HEAP_SIZE=6442450944
+export SGLANG_DEEPEP_NUM_MAX_DISPATCH_TOKENS_PER_RANK=256
+export ROCSHMEM_IPC_MNVL=1
+export DEEP_EP_NORMAL_MNVL=1
+export HIP_BUFFER_EXTRA_SIZE=0
+export ROCSHMEM_GDR_DISABLE_XDP=1
+export PYTHONUNBUFFERED=1
+
+python3 -m sglang.launch_server \
+  --model-path moonshotai/Kimi-K2.6 \
+  --kv-cache-dtype fp8_e4m3 \
+  --host <D_node1_ip> \
+  --port <port1> \
+  --trust-remote-code \
+  --page-size 64 \
+  --dist-init-addr <D_node0_ip>:<port0> \
+  --nnodes 4 \
+  --node-rank 1 \
+  --dtype bfloat16 \
+  --tp-size 16 \
+  --pp-size 1 \
+  --mem-fraction-static 0.85 \
+  --attention-backend hcu_mla \
+  --numa-node 0 5 3 2 \
+  --chunked-prefill-size -1 \
+  --max-running-requests 512 \
+  --context-length 81920 \
+  --disaggregation-ib-device shca_0,shca_1,shca_2,shca_4 \
+  --disaggregation-mode decode \
+  --ep-size 16 \
+  --dp-size 16 \
+  --enable-dp-attention \
+  --moe-dense-tp-size 1 \
+  --enable-dp-lm-head \
+  --moe-a2a-backend deepep \
+  --deepep-mode low_latency \
+  --speculative-algorithm EAGLE3 \
+  --speculative-draft-model-path lightseekorg/kimi-k2.6-eagle3-mla \
+  --speculative-num-steps 3 \
+  --speculative-eagle-topk 1 \
+  --speculative-num-draft-tokens 4 \
+  --init-expert-location <path_to_eplb_trace_pt> \
+  --ep-num-redundant-experts 16
+```
+#### D node2
+
+```
+export SGLANG_USE_LIGHTOP=1
+export SGLANG_USE_OPT_CAT=1
+export USE_DCU_CUSTOM_ALLREDUCE=1
+export SGL_CHUNKED_PREFIX_CACHE_THRESHOLD=0
+export SGLANG_DISAGGREGATION_BOOTSTRAP_TIMEOUT=1200
+export GLIBC_TUNABLES=glibc.rtld.optional_static_tls=0x40000
+export HIP_GRAPH_ACCUMULATE_DISPATCH=0
+export SGLANG_KVALLOC_KERNEL=1
+export SGLANG_CREATE_EXTEND_AFTER_DECODE_SPEC_INFO=1
+export SGLANG_ASSIGN_EXTEND_CACHE_LOCS=1
+export SGLANG_ASSIGN_REQ_TO_TOKEN_POOL=1
+export SGLANG_GET_LAST_LOC=1
+export SGLANG_CREATE_FLASHMLA_KV_INDICES_TRITON=1
+export SGLANG_CREATE_CHUNKED_PREFIX_CACHE_KV_INDICES=1
+export SGLANG_USE_MARLIN_W4A16_MOE=1
+export ALLREDUCE_STREAM_WITH_COMPUTE=1
+export MC_IB_GID_INDEX=0
+export SGLANG_HEALTH_CHECK_TIMEOUT=60
+export SGLANG_ROCM_USE_AITER_MOE=1
+export SGLANG_USE_MARLIN_W4A16_MOE_OPT=1
+export ROCSHMEM_IB_GID_INDEX=0
+export ROCSHMEM_DISABLE_HDP_FLUSH=1
+export ROCSHMEM_GDA_NUM_QPS_DEFAULT_CTX=288
+export ROCSHMEM_HEAP_SIZE=6442450944
+export SGLANG_DEEPEP_NUM_MAX_DISPATCH_TOKENS_PER_RANK=256
+export ROCSHMEM_IPC_MNVL=1
+export DEEP_EP_NORMAL_MNVL=1
+export HIP_BUFFER_EXTRA_SIZE=0
+export ROCSHMEM_GDR_DISABLE_XDP=1
+export PYTHONUNBUFFERED=1
+
+python3 -m sglang.launch_server \
+  --model-path moonshotai/Kimi-K2.6 \
+  --kv-cache-dtype fp8_e4m3 \
+  --host <D_node2_ip> \
+  --port <port1> \
+  --trust-remote-code \
+  --page-size 64 \
+  --dist-init-addr <D_node0_ip>:<port0> \
+  --nnodes 4 \
+  --node-rank 2 \
+  --dtype bfloat16 \
+  --tp-size 16 \
+  --pp-size 1 \
+  --mem-fraction-static 0.85 \
+  --attention-backend hcu_mla \
+  --numa-node 0 5 3 2 \
+  --chunked-prefill-size -1 \
+  --max-running-requests 512 \
+  --context-length 81920 \
+  --disaggregation-ib-device shca_0,shca_1,shca_2,shca_4 \
+  --disaggregation-mode decode \
+  --ep-size 16 \
+  --dp-size 16 \
+  --enable-dp-attention \
+  --moe-dense-tp-size 1 \
+  --enable-dp-lm-head \
+  --moe-a2a-backend deepep \
+  --deepep-mode low_latency \
+  --speculative-algorithm EAGLE3 \
+  --speculative-draft-model-path lightseekorg/kimi-k2.6-eagle3-mla \
+  --speculative-num-steps 3 \
+  --speculative-eagle-topk 1 \
+  --speculative-num-draft-tokens 4 \
+  --init-expert-location <path_to_eplb_trace_pt> \
+  --ep-num-redundant-experts 16
+```
+
+#### D node3
+
+```
+export SGLANG_USE_LIGHTOP=1
+export SGLANG_USE_OPT_CAT=1
+export USE_DCU_CUSTOM_ALLREDUCE=1
+export SGL_CHUNKED_PREFIX_CACHE_THRESHOLD=0
+export SGLANG_DISAGGREGATION_BOOTSTRAP_TIMEOUT=1200
+export GLIBC_TUNABLES=glibc.rtld.optional_static_tls=0x40000
+export HIP_GRAPH_ACCUMULATE_DISPATCH=0
+export SGLANG_KVALLOC_KERNEL=1
+export SGLANG_CREATE_EXTEND_AFTER_DECODE_SPEC_INFO=1
+export SGLANG_ASSIGN_EXTEND_CACHE_LOCS=1
+export SGLANG_ASSIGN_REQ_TO_TOKEN_POOL=1
+export SGLANG_GET_LAST_LOC=1
+export SGLANG_CREATE_FLASHMLA_KV_INDICES_TRITON=1
+export SGLANG_CREATE_CHUNKED_PREFIX_CACHE_KV_INDICES=1
+export SGLANG_USE_MARLIN_W4A16_MOE=1
+export ALLREDUCE_STREAM_WITH_COMPUTE=1
+export MC_IB_GID_INDEX=0
+export SGLANG_HEALTH_CHECK_TIMEOUT=60
+export SGLANG_ROCM_USE_AITER_MOE=1
+export SGLANG_USE_MARLIN_W4A16_MOE_OPT=1
+export ROCSHMEM_IB_GID_INDEX=0
+export ROCSHMEM_DISABLE_HDP_FLUSH=1
+export ROCSHMEM_GDA_NUM_QPS_DEFAULT_CTX=288
+export ROCSHMEM_HEAP_SIZE=6442450944
+export SGLANG_DEEPEP_NUM_MAX_DISPATCH_TOKENS_PER_RANK=256
+export ROCSHMEM_IPC_MNVL=1
+export DEEP_EP_NORMAL_MNVL=1
+export HIP_BUFFER_EXTRA_SIZE=0
+export ROCSHMEM_GDR_DISABLE_XDP=1
+export PYTHONUNBUFFERED=1
+
+python3 -m sglang.launch_server \
+  --model-path moonshotai/Kimi-K2.6 \
+  --kv-cache-dtype fp8_e4m3 \
+  --host <D_node3_ip> \
+  --port <port1> \
+  --trust-remote-code \
+  --page-size 64 \
+  --dist-init-addr <D_node0_ip>:<port0> \
+  --nnodes 4 \
+  --node-rank 3 \
+  --dtype bfloat16 \
+  --tp-size 16 \
+  --pp-size 1 \
+  --mem-fraction-static 0.85 \
+  --attention-backend hcu_mla \
+  --numa-node 0 5 3 2 \
+  --chunked-prefill-size -1 \
+  --max-running-requests 512 \
+  --context-length 81920 \
+  --disaggregation-ib-device shca_0,shca_1,shca_2,shca_4 \
+  --disaggregation-mode decode \
+  --ep-size 16 \
+  --dp-size 16 \
+  --enable-dp-attention \
+  --moe-dense-tp-size 1 \
+  --enable-dp-lm-head \
+  --moe-a2a-backend deepep \
+  --deepep-mode low_latency \
+  --speculative-algorithm EAGLE3 \
+  --speculative-draft-model-path lightseekorg/kimi-k2.6-eagle3-mla \
+  --speculative-num-steps 3 \
+  --speculative-eagle-topk 1 \
+  --speculative-num-draft-tokens 4 \
+  --init-expert-location <path_to_eplb_trace_pt> \
+  --ep-num-redundant-experts 16
+```
+
+## Router
+
+```
+python3 -m sglang_router.launch_router \
+  --pd-disaggregation \
+  --prefill http://<P_node_ip>:30000 \
+  --decode http://<D_node_ip>:30000 \
+  --policy round_robin \
+  --port 30020
+```
 
 ### Kimi-K2.6 IFB BW1100 8x SGLang 0.5.12
 
@@ -287,146 +694,6 @@ python3 -m sglang.launch_server \
   --context-length 81920 \
   --disaggregation-ib-device mlx5_2,mlx5_3,mlx5_4,mlx5_5,mlx5_8,mlx5_9 \
   --disaggregation-mode decode
-```
-
-### Kimi-K2.6 1P1D BW1100 超节点ep16 24x SGLang 0.5.12
-
-网卡配置参考：[IB 网卡](../../troubleshooting/common-issues.md#ib网卡)。
-
-离线EPLB参考：[EPLB](../../optimization/static-eplb-sglang.md)。
-
-#### P node
-
-```
-NODE_RANK=${1:-0}
-export SGLANG_USE_LIGHTOP=1
-export SGLANG_USE_OPT_CAT=1
-export USE_DCU_CUSTOM_ALLREDUCE=1
-export SGL_CHUNKED_PREFIX_CACHE_THRESHOLD=0
-export SGLANG_DISAGGREGATION_BOOTSTRAP_TIMEOUT=1200
-export GLIBC_TUNABLES=glibc.rtld.optional_static_tls=0x40000
-export HIP_GRAPH_ACCUMULATE_DISPATCH=0
-export SGLANG_KVALLOC_KERNEL=1
-export SGLANG_CREATE_EXTEND_AFTER_DECODE_SPEC_INFO=1
-export SGLANG_ASSIGN_EXTEND_CACHE_LOCS=1
-export SGLANG_ASSIGN_REQ_TO_TOKEN_POOL=1
-export SGLANG_GET_LAST_LOC=1
-export SGLANG_CREATE_FLASHMLA_KV_INDICES_TRITON=1
-export SGLANG_CREATE_CHUNKED_PREFIX_CACHE_KV_INDICES=1
-export SGLANG_USE_MARLIN_W4A16_MOE=1
-export ALLREDUCE_STREAM_WITH_COMPUTE=1
-export MC_IB_GID_INDEX=0
-export SGLANG_HEALTH_CHECK_TIMEOUT=60
-export SGLANG_ROCM_USE_AITER_MOE=1
-export DEEP_EP_NORMAL_MNVL=1
-export HIP_BUFFER_EXTRA_SIZE=0
-export ROCSHMEM_GDR_DISABLE_XDP=1
-export PYTHONUNBUFFERED=1
-export AITER_ENABLE_SUPERNODE_AR=1 AITER_REBUILD=1  # 构建 aiter
-export AITER_AR_TRANSPORT=fabric AITER_AR_ENABLE_REG_CAPTURE=0
-export SGLANG_OPT_USE_CUSTOM_ALL_REDUCE_V2=0
-
-python3 -m sglang.launch_server \
-  --model-path moonshotai/Kimi-K2.6 \
-  --kv-cache-dtype fp8_e4m3 \
-  --host $(hostname -I | awk '{print $1}') \
-  --port 30000 \
-  --trust-remote-code \
-  --page-size 64 \
-  --dist-init-addr <P_node0_ip>:5001 \
-  --nnodes 2 \
-  --node-rank ${NODE_RANK} \
-  --dtype bfloat16 \
-  --tp-size 4 \
-  --pp-size 2 \
-  --mem-fraction-static 0.9 \
-  --attention-backend hcu_mla \
-  --numa-node 0 5 3 2 \
-  --chunked-prefill-size -1 \
-  --max-running-requests 512 \
-  --context-length 81920 \
-  --disaggregation-ib-device shca_0,shca_1,shca_2,shca_4 \
-  --disaggregation-mode prefill \
-  --custom-all-reduce-backend aiter \
-```
-
-#### D node
-
-```
-NODE_RANK=${1:-0}
-export SGLANG_USE_LIGHTOP=1
-export SGLANG_USE_OPT_CAT=1
-export USE_DCU_CUSTOM_ALLREDUCE=1
-export SGL_CHUNKED_PREFIX_CACHE_THRESHOLD=0
-export SGLANG_DISAGGREGATION_BOOTSTRAP_TIMEOUT=1200
-export GLIBC_TUNABLES=glibc.rtld.optional_static_tls=0x40000
-export HIP_GRAPH_ACCUMULATE_DISPATCH=0
-export SGLANG_KVALLOC_KERNEL=1
-export SGLANG_CREATE_EXTEND_AFTER_DECODE_SPEC_INFO=1
-export SGLANG_ASSIGN_EXTEND_CACHE_LOCS=1
-export SGLANG_ASSIGN_REQ_TO_TOKEN_POOL=1
-export SGLANG_GET_LAST_LOC=1
-export SGLANG_CREATE_FLASHMLA_KV_INDICES_TRITON=1
-export SGLANG_CREATE_CHUNKED_PREFIX_CACHE_KV_INDICES=1
-export SGLANG_USE_MARLIN_W4A16_MOE=1
-export ALLREDUCE_STREAM_WITH_COMPUTE=1
-export MC_IB_GID_INDEX=0
-export SGLANG_HEALTH_CHECK_TIMEOUT=60
-export SGLANG_ROCM_USE_AITER_MOE=1
-export SGLANG_USE_MARLIN_W4A16_MOE_OPT=1
-export ROCSHMEM_IB_GID_INDEX=0
-export ROCSHMEM_DISABLE_HDP_FLUSH=1
-export ROCSHMEM_GDA_NUM_QPS_DEFAULT_CTX=288
-export ROCSHMEM_HEAP_SIZE=6442450944
-export SGLANG_DEEPEP_NUM_MAX_DISPATCH_TOKENS_PER_RANK=256
-
-export ROCSHMEM_IPC_MNVL=1
-export DEEP_EP_NORMAL_MNVL=1
-export HIP_BUFFER_EXTRA_SIZE=0
-export ROCSHMEM_GDR_DISABLE_XDP=1
-export PYTHONUNBUFFERED=1
-
-python3 -m sglang.launch_server \
-  --model-path moonshotai/Kimi-K2.6 \
-  --kv-cache-dtype fp8_e4m3 \
-  --host $(hostname -I | awk '{print $1}') \
-  --port 30000 \
-  --trust-remote-code \
-  --page-size 64 \
-  --dist-init-addr <P_node0_ip>:5003 \
-  --nnodes 4 \
-  --node-rank ${NODE_RANK} \
-  --dtype bfloat16 \
-  --tp-size 16 \
-  --pp-size 1 \
-  --mem-fraction-static 0.85 \
-  --attention-backend hcu_mla \
-  --numa-node 0 5 3 2 \
-  --chunked-prefill-size -1 \
-  --max-running-requests 512 \
-  --context-length 81920 \
-  --disaggregation-ib-device shca_0,shca_1,shca_2,shca_4 \
-  --disaggregation-mode decode \
-  --ep-size 16 \
-  --dp-size 16 \
-  --enable-dp-attention \
-  --moe-dense-tp-size 1 \
-  --enable-dp-lm-head \
-  --moe-a2a-backend deepep \
-  --deepep-mode low_latency \
-  --speculative-algorithm EAGLE3 \
-  --speculative-draft-model-path lightseekorg/kimi-k2.6-eagle3-mla \
-  --speculative-num-steps 3 \
-  --speculative-eagle-topk 1 \
-  --speculative-num-draft-tokens 4 \
-  --init-expert-location <path_to_eplb_trace_pt> \
-  --ep-num-redundant-experts 16
-```
-
-## Router
-
-```
-python3 -m sglang_router.launch_router --pd-disaggregation --prefill http://<P_node_ip>:30000 --decode http://<D_node_ip>:30000 --policy round_robin --port 30020
 ```
 
 ## API 调用

--- a/docs/model-deployment/sglang/kimi-k2.6.md
+++ b/docs/model-deployment/sglang/kimi-k2.6.md
@@ -8,7 +8,7 @@ Kimi K2.6 是一个开源的原生多模态智能体模型，在长周期编码�
 
 | 模型权重 | 量化方式 | SGLang 镜像 | 推荐硬件 | 卡数 | 部署方式 | 启动命令 |
 | -------- | -------- | ----------- | -------- | ---- | -------- | -------- |
-| [moonshotai/Kimi-K2.6](https://www.modelscope.cn/models/moonshotai/Kimi-K2.6) | INT4 W4A16 | [0.5.12](../docker_images.md) | scaleX40-3G | 24 | 1P1D | [**`>_`**](#kimi-k26-1p1d-scalex40-3g-24x-sglang-0512) |
+| [moonshotai/Kimi-K2.6](https://www.modelscope.cn/models/moonshotai/Kimi-K2.6) | INT4 W4A16 | [0.5.12](../docker_images.md) | scaleX40-3G | 24 | 1P1D | [**`>_`**](#kimi-k26-pd-scalex40-3g-24x-sglang-0512) |
 |  | INT4 W4A16 | [0.5.12](../docker_images.md) | BW1100 | 8 | IFB | [**`>_`**](#kimi-k26-ifb-bw1100-8x-sglang-0512) |
 |  | INT4 W4A16 | [0.5.12](../docker_images.md) | BW1000 | 16 | IFB | [**`>_`**](#kimi-k26-ifb-bw1000-16x-sglang-0512) |
 |  | INT4 W4A16 | 0.5.10 | BW1100 | 8 | IFB | [**`>_`**](#kimi-k26-ifb-bw1100-8x-sglang-0510) |
@@ -16,7 +16,7 @@ Kimi K2.6 是一个开源的原生多模态智能体模型，在长周期编码�
 
 ## 启动命令
 
-### Kimi-K2.6 1P1D scaleX40-3G 24x SGLang 0.5.12
+### Kimi-K2.6 PD scaleX40-3G 24x SGLang 0.5.12
 
 #### EPLB 配置参考：[EPLB](../../optimization/static-eplb-sglang.md)。
 

--- a/docs/model-deployment/sglang/qwen3.5.md
+++ b/docs/model-deployment/sglang/qwen3.5.md
@@ -836,7 +836,6 @@ sglang serve \
 
 ```bash
 export HIP_VISIBLE_DEVICES=0,1,2,3
-export NCCL_MIN_NCHANNELS=32
 export RCCL_COLL_XHCL_CHANNEL_NUM=28
 export RCCL_P2P_XHCL_CHANNEL_NUM=29
 export NCCL_MIN_P2P_NCHANNELS=32
@@ -907,7 +906,6 @@ sglang serve \
 
 ```bash
 export HIP_VISIBLE_DEVICES=0,1,2,3
-export NCCL_MIN_NCHANNELS=32
 export RCCL_COLL_XHCL_CHANNEL_NUM=28
 export RCCL_P2P_XHCL_CHANNEL_NUM=29
 export NCCL_MIN_P2P_NCHANNELS=32
@@ -977,8 +975,6 @@ sglang serve \
 #### D node 0
 
 ```bash
-export NCCL_MIN_NCHANNELS=16
-export NCCL_MAX_NCHANNELS=16
 export SGLANG_ENABLE_SPEC_V2=1
 export SGLANG_TORCH_PROFILER_DIR=/home/proj_qwen3.5-397b/profiling
 export HSA_ENABLE_COREDUMP=1
@@ -1060,8 +1056,6 @@ sglang serve \
 #### D node 1
 
 ```bash
-export NCCL_MIN_NCHANNELS=16
-export NCCL_MAX_NCHANNELS=16
 export SGLANG_ENABLE_SPEC_V2=1
 export SGLANG_TORCH_PROFILER_DIR=/home/proj_qwen3.5-397b/profiling
 export HSA_ENABLE_COREDUMP=1
@@ -1143,8 +1137,6 @@ sglang serve \
 #### D node 2
 
 ```bash
-export NCCL_MIN_NCHANNELS=16
-export NCCL_MAX_NCHANNELS=16
 export SGLANG_ENABLE_SPEC_V2=1
 export SGLANG_TORCH_PROFILER_DIR=/home/proj_qwen3.5-397b/profiling
 export HSA_ENABLE_COREDUMP=1
@@ -1226,8 +1218,6 @@ sglang serve \
 #### D node 3
 
 ```bash
-export NCCL_MIN_NCHANNELS=16
-export NCCL_MAX_NCHANNELS=16
 export SGLANG_ENABLE_SPEC_V2=1
 export SGLANG_TORCH_PROFILER_DIR=/home/proj_qwen3.5-397b/profiling
 export HSA_ENABLE_COREDUMP=1


### PR DESCRIPTION
## Summary
- standardize `scaleX40-3G` naming and anchors in the DeepSeek-V4 and GLM-5.2 SGLang guides
- add and prioritize the Kimi-K2.6 `scaleX40-3G` deployment, with per-node P/D commands and router configuration
- remove redundant NCCL channel overrides from the Qwen3.5 deployment commands

## Verification
- `git diff --check`
