### PR TITLE
vllm/GLM-5.3-Flash-Channel-FP8-w8a8: add 0.28.1 cookbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,12 @@
       <td align="center"><a href="docs/model-deployment/sglang/deepseek-r1.md">✅</a></td><td align="center"><a href="docs/model-deployment/sglang/deepseek-r1.md">✅</a></td><td align="center"><a href="docs/model-deployment/sglang/deepseek-r1.md">✅</a></td>
     </tr>
     <tr>
-      <td rowspan="8" align="center"><img src="https://cdn-avatars.huggingface.co/v1/production/uploads/62dc173789b4cf157d36ebee/i_pxzM2ZDo3Ub-BEgIkE9.png" height="40"/><br/>Z.ai</td>
+      <td rowspan="9" align="center"><img src="https://cdn-avatars.huggingface.co/v1/production/uploads/62dc173789b4cf157d36ebee/i_pxzM2ZDo3Ub-BEgIkE9.png" height="40"/><br/>Z.ai</td>
+      <td>GLM-5.3</td>
+      <td>vLLM</td>
+      <td align="center">-</td><td align="center">-</td><td align="center"><a href="docs/model-deployment/vllm/glm-5.3.md">✅</a></td>
+    </tr>
+    <tr>
       <td rowspan="2">GLM-5.2</td>
       <td>vLLM</td>
       <td align="center">🚧</td><td align="center"><a href="docs/model-deployment/vllm/glm-5.2.md">✅</a></td><td align="center"><a href="docs/model-deployment/vllm/glm-5.2.md">✅</a></td>

--- a/docs/model-deployment/vllm/glm-5.3.md
+++ b/docs/model-deployment/vllm/glm-5.3.md
@@ -1,0 +1,28 @@
+# GLM-5.3 on vLLM
+
+## 模型简介
+
+GLM-5.3 是 Z.ai 推出的 GLM 系列大语言模型，本文档提供其在 vLLM 上的部署示例。
+
+## 模型列表
+
+| 模型权重 | 量化方式 | vLLM 镜像 | 推荐硬件 | 卡数 | 部署方式 | 启动命令 |
+| -------- | -------- | --------- | -------- | ---- | -------- | -------- |
+| [hygon/GLM-5.3-Flash-Channel-FP8-w8a8](https://www.modelscope.cn/models/hygon/GLM-5.3-Flash-Channel-FP8-w8a8) | FP8 W8A8 | 0.28.1 | BW1100 | 4 | IFB | [**`>_`**](#glm-53-flash-channel-fp8-w8a8-ifb-bw1100-4x-vllm-0281) |
+
+## 启动命令
+
+### GLM-5.3-Flash-Channel-FP8-w8a8 IFB BW1100 4x vLLM 0.28.1
+
+```bash
+vllm serve hygon/GLM-5.3-Flash-Channel-FP8-w8a8 \
+  --tensor-parallel-size 4 \
+  --attention-backend FLASHMLA_SPARSE \
+  --moe-backend aiter \
+  --speculative-config '{"method":"mtp","num_speculative_tokens":3,"use_local_argmax_reduction":true}' \
+  --enable-prefix-caching \
+  --max-model-len 32768 \
+  --max-num-batched-tokens 16384 \
+  --max-num-seqs 64 \
+  --default-chat-template-kwargs '{"reasoning_effort":"low"}'
+```


### PR DESCRIPTION
## Summary
- Add GLM-5.3-Flash-Channel-FP8-w8a8 BW1100 4x vLLM 0.28.1 cookbook command.
- Update README support model matrix with GLM-5.3 vLLM BW1100 support link.

## Verification
- Checked the new cookbook command in docs/model-deployment/vllm/glm-5.3.md
- Checked README links to docs/model-deployment/vllm/glm-5.3.md
- git diff --cached --check