### PR TITLE
vllm/DeepSeek-V4-Flash-0731: add 0.28.1 cookbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@
       <td rowspan="10" align="center"><img src="https://cdn-avatars.huggingface.co/v1/production/uploads/6538815d1bdb3c40db94fbfa/xMBly9PUMphrFVMxLX4kq.png" height="40"/><br/>DeepSeek</td>
       <td rowspan="2">DeepSeek-V4</td>
       <td>vLLM</td>
-      <td align="center">🚧</td><td align="center"><a href="docs/model-deployment/vllm/deepseek-v4.md">✅</a></td><td align="center">🚧</td>
+      <td align="center">🚧</td><td align="center"><a href="docs/model-deployment/vllm/deepseek-v4.md">✅</a></td><td align="center"><a href="docs/model-deployment/vllm/deepseek-v4.md">✅</a></td>
     </tr>
     <tr>
       <td>SGLang</td>

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@
       <td rowspan="10" align="center"><img src="https://cdn-avatars.huggingface.co/v1/production/uploads/6538815d1bdb3c40db94fbfa/xMBly9PUMphrFVMxLX4kq.png" height="40"/><br/>DeepSeek</td>
       <td rowspan="2">DeepSeek-V4</td>
       <td>vLLM</td>
-      <td align="center">🚧</td><td align="center">🚧</td><td align="center">🚧</td>
+      <td align="center">🚧</td><td align="center"><a href="docs/model-deployment/vllm/deepseek-v4.md">✅</a></td><td align="center">🚧</td>
     </tr>
     <tr>
       <td>SGLang</td>

--- a/docs/model-deployment/vllm/deepseek-v4.md
+++ b/docs/model-deployment/vllm/deepseek-v4.md
@@ -9,7 +9,7 @@ DeepSeek-V4 是 DeepSeek 系列大语言模型，本文档提供其在 vLLM 上�
 | 模型权重 | 量化方式 | vLLM 镜像 | 推荐硬件 | 卡数 | 部署方式 | 启动命令 |
 | -------- | -------- | --------- | -------- | ---- | -------- | -------- |
 | [hygon/DeepSeek-V4-Flash-0731-Channel-INT8-w8a8](https://www.modelscope.cn/models/hygon/DeepSeek-V4-Flash-0731-Channel-INT8-w8a8) | INT8 W8A8 | 0.28.1 | BW1000 | 8 | IFB | [**`>_`**](#deepseek-v4-flash-0731-channel-int8-w8a8-ifb-bw1000-8x-vllm-0281) |
-| [hygon/DeepSeek-V4-Flash-0731-Channel-FP8-w8a8](https://www.modelscope.cn/models/hygon/DeepSeek-V4-Flash-0731-Channel-FP8-w8a8) | FP8 W8A8 | 0.28.1 | BW1000 | 8 | IFB | [**`>_`**](#deepseek-v4-flash-0731-channel-fp8-w8a8-ifb-bw1000-8x-vllm-0281) |
+| [hygon/DeepSeek-V4-Flash-0731-Channel-FP8-w8a8](https://www.modelscope.cn/models/hygon/DeepSeek-V4-Flash-0731-Channel-FP8-w8a8) | FP8 W8A8 | 0.28.1 | BW1100 | 8 | IFB | [**`>_`**](#deepseek-v4-flash-0731-channel-fp8-w8a8-ifb-bw1100-8x-vllm-0281) |
 
 ## 启动命令
 
@@ -31,7 +31,7 @@ vllm serve hygon/DeepSeek-V4-Flash-0731-Channel-INT8-w8a8 \
   --speculative-config '{"method":"dspark","num_speculative_tokens":5,"draft_sample_method":"probabilistic"}'
 ```
 
-### DeepSeek-V4-Flash-0731-Channel-FP8-w8a8 IFB BW1000 8x vLLM 0.28.1
+### DeepSeek-V4-Flash-0731-Channel-FP8-w8a8 IFB BW1100 8x vLLM 0.28.1
 
 ```bash
 vllm serve hygon/DeepSeek-V4-Flash-0731-Channel-FP8-w8a8 \

--- a/docs/model-deployment/vllm/deepseek-v4.md
+++ b/docs/model-deployment/vllm/deepseek-v4.md
@@ -1,0 +1,31 @@
+# DeepSeek-V4 on vLLM
+
+## 模型简介
+
+DeepSeek-V4 是 DeepSeek 系列大语言模型，本文档提供其在 vLLM 上的部署示例。
+
+## 模型列表
+
+| 模型权重 | 量化方式 | vLLM 镜像 | 推荐硬件 | 卡数 | 部署方式 | 启动命令 |
+| -------- | -------- | --------- | -------- | ---- | -------- | -------- |
+| [hygon/DeepSeek-V4-Flash-0731-Channel-INT8-w8a8](https://www.modelscope.cn/models/hygon/DeepSeek-V4-Flash-0731-Channel-INT8-w8a8) | INT8 W8A8 | 0.28.1 | BW1000 | 8 | IFB | [**`>_`**](#deepseek-v4-flash-0731-channel-int8-w8a8-ifb-bw1000-8x-vllm-0281) |
+
+## 启动命令
+
+### DeepSeek-V4-Flash-0731-Channel-INT8-w8a8 IFB BW1000 8x vLLM 0.28.1
+
+```bash
+vllm serve hygon/DeepSeek-V4-Flash-0731-Channel-INT8-w8a8 \
+  --dtype bfloat16 \
+  --kv-cache-dtype fp8 \
+  --tensor-parallel-size 8 \
+  --max-model-len 32768 \
+  --max-num-batched-tokens 16384 \
+  --max-num-seqs 64 \
+  --block-size 256 \
+  --trust-remote-code \
+  --tokenizer-mode deepseek_v4 \
+  --distributed-executor-backend mp \
+  --moe-backend aiter \
+  --speculative-config '{"method":"dspark","num_speculative_tokens":5,"draft_sample_method":"probabilistic"}'
+```

--- a/docs/model-deployment/vllm/deepseek-v4.md
+++ b/docs/model-deployment/vllm/deepseek-v4.md
@@ -9,6 +9,7 @@ DeepSeek-V4 是 DeepSeek 系列大语言模型，本文档提供其在 vLLM 上�
 | 模型权重 | 量化方式 | vLLM 镜像 | 推荐硬件 | 卡数 | 部署方式 | 启动命令 |
 | -------- | -------- | --------- | -------- | ---- | -------- | -------- |
 | [hygon/DeepSeek-V4-Flash-0731-Channel-INT8-w8a8](https://www.modelscope.cn/models/hygon/DeepSeek-V4-Flash-0731-Channel-INT8-w8a8) | INT8 W8A8 | 0.28.1 | BW1000 | 8 | IFB | [**`>_`**](#deepseek-v4-flash-0731-channel-int8-w8a8-ifb-bw1000-8x-vllm-0281) |
+| [hygon/DeepSeek-V4-Flash-0731-Channel-FP8-w8a8](https://www.modelscope.cn/models/hygon/DeepSeek-V4-Flash-0731-Channel-FP8-w8a8) | FP8 W8A8 | 0.28.1 | BW1000 | 8 | IFB | [**`>_`**](#deepseek-v4-flash-0731-channel-fp8-w8a8-ifb-bw1000-8x-vllm-0281) |
 
 ## 启动命令
 
@@ -16,6 +17,24 @@ DeepSeek-V4 是 DeepSeek 系列大语言模型，本文档提供其在 vLLM 上�
 
 ```bash
 vllm serve hygon/DeepSeek-V4-Flash-0731-Channel-INT8-w8a8 \
+  --dtype bfloat16 \
+  --kv-cache-dtype fp8 \
+  --tensor-parallel-size 8 \
+  --max-model-len 32768 \
+  --max-num-batched-tokens 16384 \
+  --max-num-seqs 64 \
+  --block-size 256 \
+  --trust-remote-code \
+  --tokenizer-mode deepseek_v4 \
+  --distributed-executor-backend mp \
+  --moe-backend aiter \
+  --speculative-config '{"method":"dspark","num_speculative_tokens":5,"draft_sample_method":"probabilistic"}'
+```
+
+### DeepSeek-V4-Flash-0731-Channel-FP8-w8a8 IFB BW1000 8x vLLM 0.28.1
+
+```bash
+vllm serve hygon/DeepSeek-V4-Flash-0731-Channel-FP8-w8a8 \
   --dtype bfloat16 \
   --kv-cache-dtype fp8 \
   --tensor-parallel-size 8 \


### PR DESCRIPTION
## Summary
- Add DeepSeek-V4-Flash-0731-Channel-INT8-w8a8 BW1000 8x vLLM 0.28.1 cookbook command.
- Add DeepSeek-V4-Flash-0731-Channel-FP8-w8a8 BW1100 8x vLLM 0.28.1 cookbook command.
- Update README support model matrix with DeepSeek-V4 vLLM BW1000 and BW1100 support links.

## Verification
- Checked INT8 and FP8 cookbook commands in docs/model-deployment/vllm/deepseek-v4.md
- Checked README links to docs/model-deployment/vllm/deepseek-v4.md
- Confirmed FP8 entry uses BW1100 and has no BW1000 FP8 anchor/title
- Confirmed the older gpu-memory-utilization 0.80 parameter is absent
- git diff --check