### PR TITLE
vllm/Qwen3.8-Flash-Next-FP8-Channelwise: remove cookbook

### DIFF
--- a/docs/model-deployment/vllm/qwen3.8.md
+++ b/docs/model-deployment/vllm/qwen3.8.md
@@ -18,7 +18,6 @@ Qwen3.8 系列模型面向长上下文推理与工具调用场景，支持 vLLM 
 |  | W8A8 | 0.21 | BW1000 | 2 | IFB | [**`>_`**](#qwen38-27b-channel-int8-w8a8-ifb-bw1000-2x-vllm-021) |
 |  | W8A8 | [0.18-hotfix](../docker_images.md) | BW1000 | 1 | IFB | [**`>_`**](#qwen38-27b-channel-int8-w8a8-ifb-bw1000-1x-vllm-018-hotfix) |
 |  | W8A8 | [0.18-hotfix](../docker_images.md) | BW1000 | 2 | IFB | [**`>_`**](#qwen38-27b-channel-int8-w8a8-ifb-bw1000-2x-vllm-018-hotfix) |
-| Qwen3.8-Flash-Next-FP8-Channelwise | FP8 | 0.28 | BW1100 | 4 | IFB | [**`>_`**](#qwen38-flash-next-fp8-channelwise-ifb-bw1100-4x-vllm-028) |
 
 ## 启动命令
 
@@ -181,19 +180,6 @@ vllm serve hygon/Qwen3.8-27B-Channel-INT8-w8a8 \
   --speculative-config.num_speculative_tokens 3 \
   --speculative-config.quantization "slimquant_marlin" \
   -q slimquant_marlin
-```
-
-### Qwen3.8-Flash-Next-FP8-Channelwise IFB BW1100 4x vLLM 0.28
-
-```bash
-vllm serve hygon/Qwen3.8-Flash-Next-FP8-Channelwise \
-  -tp 4 \
-  --moe-backend aiter \
-  --trust-remote-code \
-  --attention-backend FLASH_ATTN  \
-  --max-num-batched-tokens 10240 \
-  --speculative-config.method mtp \
-  --speculative-config.num_speculative_tokens 3 
 ```
 
 ## API 调用


### PR DESCRIPTION
## Summary
- Remove Qwen3.8-Flash-Next-FP8-Channelwise from qwen3.8 vLLM model list.
- Remove the corresponding vLLM 0.28 BW1100 command section.

## Verification
- Confirmed Qwen3.8-Flash-Next-FP8-Channelwise has no remaining matches in docs/model-deployment/vllm/qwen3.8.md
- Checked README Qwen3.8 support row still points to qwen3.8.md because other Qwen3.8 vLLM cookbooks remain
- git diff --check