### PR TITLE
vllm/Hy4-preview-Channel-FP8-w8a8: add 0.28.1 cookbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,7 +230,12 @@
       <td align="center">🚧</td><td align="center">🚧</td><td align="center">🚧</td>
     </tr>
     <tr>
-      <td rowspan="2" align="center"><img src="https://cdn-avatars.huggingface.co/v1/production/uploads/5dd96eb166059660ed1ee413/Lp3m-XLpjQGwBItlvn69q.png" height="40"/><br/>Tencent</td>
+      <td rowspan="3" align="center"><img src="https://cdn-avatars.huggingface.co/v1/production/uploads/5dd96eb166059660ed1ee413/Lp3m-XLpjQGwBItlvn69q.png" height="40"/><br/>Tencent</td>
+      <td>Hy4</td>
+      <td>vLLM</td>
+      <td align="center">-</td><td align="center">-</td><td align="center"><a href="docs/model-deployment/vllm/hy4.md">✅</a></td>
+    </tr>
+    <tr>
       <td rowspan="2">Hy3</td>
       <td>vLLM</td>
       <td align="center">-</td><td align="center">-</td><td align="center"><a href="docs/model-deployment/vllm/hy3.md">✅</a></td>

--- a/docs/model-deployment/vllm/hy4.md
+++ b/docs/model-deployment/vllm/hy4.md
@@ -8,12 +8,13 @@ Hy4-preview 是 Hy 系列模型，本文档提供其在 vLLM 上的部署示例�
 
 | 模型权重 | 量化方式 | vLLM 镜像 | 推荐硬件 | 卡数 | 部署方式 | 启动命令 |
 | -------- | -------- | --------- | -------- | ---- | -------- | -------- |
-| [hygon/Hy4-preview-Channel-FP8-w8a8](https://www.modelscope.cn/models/hygon/Hy4-preview-Channel-FP8-w8a8) | FP8 W8A8 | 0.28.1 | BW1100 | 8 | IFB(TP) | [**`>_`**](#hy4-preview-channel-fp8-w8a8-ifb-bw1100-8x-vllm-0281-tp) |
-|  | FP8 W8A8 | 0.28.1 | BW1100 | 8 | IFB(PP) | [**`>_`**](#hy4-preview-channel-fp8-w8a8-ifb-bw1100-8x-vllm-0281-pp) |
+| [hygon/Hy4-preview-Channel-FP8-w8a8](https://www.modelscope.cn/models/hygon/Hy4-preview-Channel-FP8-w8a8) | FP8 W8A8 | 0.28.1 | BW1100 | 8 | IFB | [**`>_`**](#hy4-preview-channel-fp8-w8a8-ifb-bw1100-8x-vllm-0281) |
 
 ## 启动命令
 
-### Hy4-preview-Channel-FP8-w8a8 IFB BW1100 8x vLLM 0.28.1 TP
+### Hy4-preview-Channel-FP8-w8a8 IFB BW1100 8x vLLM 0.28.1
+
+#### TP 方式
 
 ```bash
 export VLLM_USE_V2_MODEL_RUNNER=1
@@ -36,7 +37,7 @@ vllm serve hygon/Hy4-preview-Channel-FP8-w8a8 \
   --speculative-config '{"method":"mtp","num_speculative_tokens":3}'
 ```
 
-### Hy4-preview-Channel-FP8-w8a8 IFB BW1100 8x vLLM 0.28.1 PP
+#### PP 方式
 
 ```bash
 export VLLM_USE_V2_MODEL_RUNNER=1

--- a/docs/model-deployment/vllm/hy4.md
+++ b/docs/model-deployment/vllm/hy4.md
@@ -26,9 +26,9 @@ vllm serve hygon/Hy4-preview-Channel-FP8-w8a8 \
   --moe-backend aiter \
   --kv-cache-dtype fp8_e4m3 \
   --gpu-memory-utilization 0.95 \
-  --max-model-len 4096 \
+  --max-model-len 8192 \
   --max-num-seqs 16 \
-  --max-num-batched-tokens 4096 \
+  --max-num-batched-tokens 8192 \
   --default-chat-template-kwargs '{"reasoning_effort":"no_think"}' \
   --reasoning-parser hy_v4 \
   --enable-auto-tool-choice \
@@ -50,9 +50,9 @@ vllm serve hygon/Hy4-preview-Channel-FP8-w8a8 \
   --moe-backend aiter \
   --kv-cache-dtype fp8_e4m3 \
   --gpu-memory-utilization 0.95 \
-  --max-model-len 4096 \
+  --max-model-len 8192 \
   --max-num-seqs 16 \
-  --max-num-batched-tokens 4096 \
+  --max-num-batched-tokens 8192 \
   --default-chat-template-kwargs '{"reasoning_effort":"no_think"}' \
   --reasoning-parser hy_v4 \
   --enable-auto-tool-choice \

--- a/docs/model-deployment/vllm/hy4.md
+++ b/docs/model-deployment/vllm/hy4.md
@@ -1,0 +1,61 @@
+# Hy4 on vLLM
+
+## 模型简介
+
+Hy4-preview 是 Hy 系列模型，本文档提供其在 vLLM 上的部署示例。
+
+## 模型列表
+
+| 模型权重 | 量化方式 | vLLM 镜像 | 推荐硬件 | 卡数 | 部署方式 | 启动命令 |
+| -------- | -------- | --------- | -------- | ---- | -------- | -------- |
+| [hygon/Hy4-preview-Channel-FP8-w8a8](https://www.modelscope.cn/models/hygon/Hy4-preview-Channel-FP8-w8a8) | FP8 W8A8 | 0.28.1 | BW1100 | 8 | IFB(TP) | [**`>_`**](#hy4-preview-channel-fp8-w8a8-ifb-bw1100-8x-vllm-0281-tp) |
+|  | FP8 W8A8 | 0.28.1 | BW1100 | 8 | IFB(PP) | [**`>_`**](#hy4-preview-channel-fp8-w8a8-ifb-bw1100-8x-vllm-0281-pp) |
+
+## 启动命令
+
+### Hy4-preview-Channel-FP8-w8a8 IFB BW1100 8x vLLM 0.28.1 TP
+
+```bash
+export VLLM_USE_V2_MODEL_RUNNER=1
+
+vllm serve hygon/Hy4-preview-Channel-FP8-w8a8 \
+  --tensor-parallel-size 8 \
+  --pipeline-parallel-size 1 \
+  --no-enable-expert-parallel \
+  --moe-backend aiter \
+  --kv-cache-dtype fp8_e4m3 \
+  --gpu-memory-utilization 0.95 \
+  --max-model-len 4096 \
+  --max-num-seqs 16 \
+  --max-num-batched-tokens 4096 \
+  --default-chat-template-kwargs '{"reasoning_effort":"no_think"}' \
+  --reasoning-parser hy_v4 \
+  --enable-auto-tool-choice \
+  --tool-call-parser hy_v4 \
+  --compilation-config '{"cudagraph_capture_sizes":[1,16]}' \
+  --speculative-config '{"method":"mtp","num_speculative_tokens":3}'
+```
+
+### Hy4-preview-Channel-FP8-w8a8 IFB BW1100 8x vLLM 0.28.1 PP
+
+```bash
+export VLLM_USE_V2_MODEL_RUNNER=1
+export VLLM_PP_LAYER_PARTITION=9,8,12,8,12,8,12,9
+
+vllm serve hygon/Hy4-preview-Channel-FP8-w8a8 \
+  --tensor-parallel-size 1 \
+  --pipeline-parallel-size 8 \
+  --no-enable-expert-parallel \
+  --moe-backend aiter \
+  --kv-cache-dtype fp8_e4m3 \
+  --gpu-memory-utilization 0.95 \
+  --max-model-len 4096 \
+  --max-num-seqs 16 \
+  --max-num-batched-tokens 4096 \
+  --default-chat-template-kwargs '{"reasoning_effort":"no_think"}' \
+  --reasoning-parser hy_v4 \
+  --enable-auto-tool-choice \
+  --tool-call-parser hy_v4 \
+  --compilation-config '{"cudagraph_capture_sizes":[1,16]}' \
+  --speculative-config '{"method":"mtp","num_speculative_tokens":3}'
+```


### PR DESCRIPTION
## Summary
- Add Hy4-preview-Channel-FP8-w8a8 BW1100 8x vLLM 0.28.1 cookbook.
- Keep a single model-list entry and distinguish TP/PP within the same command section.
- Set max-model-len and max-num-batched-tokens to 8192 for both TP and PP commands.
- Add Hy4 vLLM support entry to the README model list.

## Verification
- Confirmed max-model-len 8192 appears in both commands
- Confirmed max-num-batched-tokens 8192 appears in both commands
- Confirmed old 4096 values are absent from the target parameters
- git diff --check