### PR TITLE
vllm/Qwen3.8-27B-Channel-INT8-w8a8: add 0.28.1 cookbook

### DIFF
--- a/docs/model-deployment/vllm/qwen3.8.md
+++ b/docs/model-deployment/vllm/qwen3.8.md
@@ -13,7 +13,8 @@ Qwen3.8 系列模型面向长上下文推理与工具调用场景，支持 vLLM 
 |  | BF16 | 0.21 | BW1100 | 1 | IFB | [**`>_`**](#qwen38-27b-ifb-bw1100-1x-vllm-021) |
 |  | BF16 | 0.21 | BW1000 | 2 | IFB | [**`>_`**](#qwen38-27b-ifb-bw1000-2x-vllm-021) |
 |  | BF16 | [0.18-hotfix](../docker_images.md) | BW1000 | 2 | IFB | [**`>_`**](#qwen38-27b-ifb-bw1000-2x-vllm-018-hotfix) |
-| [hygon/Qwen3.8-27B-Channel-INT8-w8a8](https://www.modelscope.cn/models/hygon/Qwen3.8-27B-Channel-INT8-w8a8) | W8A8 | 0.21 | BW1100 | 1 | IFB | [**`>_`**](#qwen38-27b-channel-int8-w8a8-ifb-bw1100-1x-vllm-021) |
+| [hygon/Qwen3.8-27B-Channel-INT8-w8a8](https://www.modelscope.cn/models/hygon/Qwen3.8-27B-Channel-INT8-w8a8) | W8A8 | 0.28.1 | BW1100/BW1000 | 1 | IFB | [**`>_`**](#qwen38-27b-channel-int8-w8a8-ifb-bw1100-bw1000-1x-vllm-0281) |
+|  | W8A8 | 0.21 | BW1100 | 1 | IFB | [**`>_`**](#qwen38-27b-channel-int8-w8a8-ifb-bw1100-1x-vllm-021) |
 |  | W8A8 | 0.21 | BW1000 | 1 | IFB | [**`>_`**](#qwen38-27b-channel-int8-w8a8-ifb-bw1000-1x-vllm-021) |
 |  | W8A8 | 0.21 | BW1000 | 2 | IFB | [**`>_`**](#qwen38-27b-channel-int8-w8a8-ifb-bw1000-2x-vllm-021) |
 |  | W8A8 | [0.18-hotfix](../docker_images.md) | BW1000 | 1 | IFB | [**`>_`**](#qwen38-27b-channel-int8-w8a8-ifb-bw1000-1x-vllm-018-hotfix) |
@@ -99,6 +100,21 @@ vllm serve Qwen/Qwen3.8-27B \
   --compilation-config '{"cudagraph_mode":"FULL","max_cudagraph_capture_size":2048}' \
   --speculative-config.method mtp \
   --speculative-config.num_speculative_tokens 3
+```
+
+### Qwen3.8-27B-Channel-INT8-w8a8 IFB BW1100 BW1000 1x vLLM 0.28.1
+
+```bash
+export VLLM_USE_V2_MODEL_RUNNER=1
+
+vllm serve hygon/Qwen3.8-27B-Channel-INT8-w8a8 \
+  --trust-remote-code \
+  --attention-backend FLASH_ATTN \
+  --speculative-config '{"method":"mtp","num_speculative_tokens":3}' \
+  --enable-prefix-caching \
+  --max-model-len 32768 \
+  --max-num-batched-tokens 16384 \
+  --max-num-seqs 32
 ```
 
 ### Qwen3.8-27B-Channel-INT8-w8a8 IFB BW1100 1x vLLM 0.21


### PR DESCRIPTION
## Summary
- Add hygon/Qwen3.8-27B-Channel-INT8-w8a8 IFB BW1100/BW1000 1x vLLM 0.28.1 entry.
- Add the vLLM 0.28.1 launch command with V2 model runner, FLASH_ATTN, prefix caching, and MTP speculative config.

## Verification
- Confirmed 0.28.1 model-list entry in docs/model-deployment/vllm/qwen3.8.md
- Confirmed command includes VLLM_USE_V2_MODEL_RUNNER=1, FLASH_ATTN, max-model-len 32768, max-num-batched-tokens 16384, and max-num-seqs 32
- git diff --check