### PR TITLE
vllm/DeepSeek-V4-Flash-0731: add 0.25.1 cookbook

### DIFF
--- a/docs/model-deployment/vllm/deepseek-v4.md
+++ b/docs/model-deployment/vllm/deepseek-v4.md
@@ -9,7 +9,9 @@ DeepSeek-V4 是 DeepSeek 系列大语言模型，本文档提供其在 vLLM 上�
 | 模型权重 | 量化方式 | vLLM 镜像 | 推荐硬件 | 卡数 | 部署方式 | 启动命令 |
 | -------- | -------- | --------- | -------- | ---- | -------- | -------- |
 | [hygon/DeepSeek-V4-Flash-0731-Channel-INT8-w8a8](https://www.modelscope.cn/models/hygon/DeepSeek-V4-Flash-0731-Channel-INT8-w8a8) | INT8 W8A8 | 0.28.1 | BW1000 | 8 | IFB | [**`>_`**](#deepseek-v4-flash-0731-channel-int8-w8a8-ifb-bw1000-8x-vllm-0281) |
+|  | INT8 W8A8 | 0.25.1 | BW1000 | 8 | IFB | [**`>_`**](#deepseek-v4-flash-0731-channel-int8-w8a8-ifb-bw1000-8x-vllm-0251) |
 | [hygon/DeepSeek-V4-Flash-0731-Channel-FP8-w8a8](https://www.modelscope.cn/models/hygon/DeepSeek-V4-Flash-0731-Channel-FP8-w8a8) | FP8 W8A8 | 0.28.1 | BW1100 | 8 | IFB | [**`>_`**](#deepseek-v4-flash-0731-channel-fp8-w8a8-ifb-bw1100-8x-vllm-0281) |
+|  | FP8 W8A8 | 0.25.1 | BW1100 | 8 | IFB | [**`>_`**](#deepseek-v4-flash-0731-channel-fp8-w8a8-ifb-bw1100-8x-vllm-0251) |
 
 ## 启动命令
 
@@ -32,6 +34,42 @@ vllm serve hygon/DeepSeek-V4-Flash-0731-Channel-INT8-w8a8 \
 ```
 
 ### DeepSeek-V4-Flash-0731-Channel-FP8-w8a8 IFB BW1100 8x vLLM 0.28.1
+
+```bash
+vllm serve hygon/DeepSeek-V4-Flash-0731-Channel-FP8-w8a8 \
+  --dtype bfloat16 \
+  --kv-cache-dtype fp8 \
+  --tensor-parallel-size 8 \
+  --max-model-len 32768 \
+  --max-num-batched-tokens 16384 \
+  --max-num-seqs 64 \
+  --block-size 256 \
+  --trust-remote-code \
+  --tokenizer-mode deepseek_v4 \
+  --distributed-executor-backend mp \
+  --moe-backend aiter \
+  --speculative-config '{"method":"dspark","num_speculative_tokens":5,"draft_sample_method":"probabilistic"}'
+```
+
+### DeepSeek-V4-Flash-0731-Channel-INT8-w8a8 IFB BW1000 8x vLLM 0.25.1
+
+```bash
+vllm serve hygon/DeepSeek-V4-Flash-0731-Channel-INT8-w8a8 \
+  --dtype bfloat16 \
+  --kv-cache-dtype fp8 \
+  --tensor-parallel-size 8 \
+  --max-model-len 32768 \
+  --max-num-batched-tokens 16384 \
+  --max-num-seqs 64 \
+  --block-size 256 \
+  --trust-remote-code \
+  --tokenizer-mode deepseek_v4 \
+  --distributed-executor-backend mp \
+  --moe-backend aiter \
+  --speculative-config '{"method":"dspark","num_speculative_tokens":5,"draft_sample_method":"probabilistic"}'
+```
+
+### DeepSeek-V4-Flash-0731-Channel-FP8-w8a8 IFB BW1100 8x vLLM 0.25.1
 
 ```bash
 vllm serve hygon/DeepSeek-V4-Flash-0731-Channel-FP8-w8a8 \


### PR DESCRIPTION
## Summary
- Add vLLM 0.25.1 cookbook entries for DeepSeek-V4-Flash-0731 Channel INT8 and FP8 models.
- Mirror the existing 0.28.1 BW1000/BW1100 launch command structure from PR #446.

## Verification
- Confirmed 0.25.1 BW1000 and BW1100 model-list entries in docs/model-deployment/vllm/deepseek-v4.md
- Confirmed 0.25.1 INT8 and FP8 command sections are present
- Confirmed tokenizer-mode and dspark speculative config are present in all DeepSeek-V4 commands
- Checked deepseek-v4.md has no question-mark/replacement characters
- git diff --check