### PR TITLE
vllm/Hy4-preview-Channel-FP8-w8a8: update cookbook to 0.25.1

### DIFF
--- a/docs/model-deployment/vllm/hy4.md
+++ b/docs/model-deployment/vllm/hy4.md
@@ -8,11 +8,11 @@ Hy4-preview 是 Hy 系列模型，本文档提供其在 vLLM 上的部署示例�
 
 | 模型权重 | 量化方式 | vLLM 镜像 | 推荐硬件 | 卡数 | 部署方式 | 启动命令 |
 | -------- | -------- | --------- | -------- | ---- | -------- | -------- |
-| [hygon/Hy4-preview-Channel-FP8-w8a8](https://www.modelscope.cn/models/hygon/Hy4-preview-Channel-FP8-w8a8) | FP8 W8A8 | 0.28.1 | BW1100 | 8 | IFB | [**`>_`**](#hy4-preview-channel-fp8-w8a8-ifb-bw1100-8x-vllm-0281) |
+| [hygon/Hy4-preview-Channel-FP8-w8a8](https://www.modelscope.cn/models/hygon/Hy4-preview-Channel-FP8-w8a8) | FP8 W8A8 | 0.25.1 | BW1100 | 8 | IFB | [**`>_`**](#hy4-preview-channel-fp8-w8a8-ifb-bw1100-8x-vllm-0251) |
 
 ## 启动命令
 
-### Hy4-preview-Channel-FP8-w8a8 IFB BW1100 8x vLLM 0.28.1
+### Hy4-preview-Channel-FP8-w8a8 IFB BW1100 8x vLLM 0.25.1
 
 #### TP 方式
 


### PR DESCRIPTION
## Summary
- Update Hy4-preview-Channel-FP8-w8a8 cookbook version from vLLM 0.28.1 to 0.25.1.
- Update the model-list anchor suffix from 0281 to 0251.
- Keep the existing TP/PP command layout and 8192 token settings.

## Verification
- Confirmed 0.25.1 and 0251 anchor are present in docs/model-deployment/vllm/hy4.md
- Confirmed old 0.28.1 and 0281 anchor suffix are absent
- Confirmed max-model-len 8192 and max-num-batched-tokens 8192 remain in both TP/PP commands
- git diff --check