### PR TITLE
vllm/Qwen3.8-27B-Channel-INT8-w8a8: add mamba prefix cache params

### DIFF
--- a/docs/model-deployment/vllm/qwen3.8.md
+++ b/docs/model-deployment/vllm/qwen3.8.md
@@ -112,6 +112,9 @@ vllm serve hygon/Qwen3.8-27B-Channel-INT8-w8a8 \
   --attention-backend FLASH_ATTN \
   --speculative-config '{"method":"mtp","num_speculative_tokens":3}' \
   --enable-prefix-caching \
+  --mamba-cache-mode align \
+  --prefix-match-unit 64 \
+  --enable-mamba-fine-grained-prefix-cache \
   --max-model-len 32768 \
   --max-num-batched-tokens 16384 \
   --max-num-seqs 32


### PR DESCRIPTION
## Summary
- Add mamba prefix cache parameters to the Qwen3.8-27B-Channel-INT8-w8a8 vLLM 0.28.1 command.
- Keep the existing BW1100/BW1000 shared command and append the new options after prefix caching.

## Verification
- Confirmed --mamba-cache-mode align is present in docs/model-deployment/vllm/qwen3.8.md
- Confirmed --prefix-match-unit 64 is present
- Confirmed --enable-mamba-fine-grained-prefix-cache is present
- Confirmed the target vLLM 0.28.1 command section remains present
- git diff --check