### PR TITLE
vLLM/Kimi-K2.5: 删除 BW1100 0.21 部署配置

### DIFF
--- a/docs/model-deployment/vllm/kimi-k2.5.md
+++ b/docs/model-deployment/vllm/kimi-k2.5.md
@@ -8,26 +8,10 @@ Kimi-K2.5 是月之暗面（Moonshot AI）推出的新一代大语言模型，�
 
 | 模型权重 | 量化方式 | vLLM 镜像 | 推荐硬件 | 卡数 | 部署方式 | 启动命令 |
 | -------- | -------- | --------- | -------- | ---- | -------- | -------- |
-| [moonshotai/Kimi-K2.5](https://www.modelscope.cn/models/moonshotai/Kimi-K2.5) | INT4 W4A16 | 0.21 | BW1100 | 8 | IFB | [**`>_`**](#kimi-k25-ifb-bw1100-8x-vllm-021) |
 | [moonshotai/Kimi-K2.5](https://www.modelscope.cn/models/moonshotai/Kimi-K2.5) | INT4 W4A16 | 0.18 | BW1100 | 8 | IFB | [**`>_`**](#kimi-k25-ifb-bw1100-8x-vllm-015) |
 | [moonshotai/Kimi-K2.5](https://www.modelscope.cn/models/moonshotai/Kimi-K2.5) | INT4 W4A16 | 0.15 | BW1100 | 8 | IFB | [**`>_`**](#kimi-k25-ifb-bw1100-8x-vllm-015) |
 
 ## 启动命令
-
-### Kimi-K2.5 IFB BW1100 8x vLLM 0.21
-
-```bash
-vllm serve moonshotai/Kimi-K2.5 \
-    -tp 8 \
-    --trust-remote-code   \
-    --dtype bfloat16  \
-    --max-model-len 65536  \
-    --enable-prefix-caching \
-    --gpu-memory-utilization 0.90 \
-    --max-num-batched-tokens 16384 \
-    --kv-cache-dtype fp8_e4m3 \
-    --moe-backend aiter
-```
 
 ### Kimi-K2.5 IFB BW1100 8x vLLM 0.18
 


### PR DESCRIPTION
## Summary
- 删除 Kimi-K2.5 BW1100 8x vLLM 0.21 模型列表记录。
- 删除对应的 vLLM 0.21 启动命令章节。
- 保留 vLLM 0.18 和 0.15 部署配置。

## Verification
- 已确认仅修改 docs/model-deployment/vllm/kimi-k2.5.md。
- 已检查差异无换行噪声。